### PR TITLE
refactor(agent-connection): widen seam for InteractiveModeLocalSessionHost removal (PR1)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,37 @@
+# Prime Agent
+
+A self-improving RLM (Recursive Language Model) agent. Terminal clients, the headless daemon, and the web adapter all drive the same core session runtime through a single typed connection seam.
+
+## Language
+
+### Connection & boundary
+
+**AgentConnection**:
+The single client-side seam between any front end (terminal, RPC, web) and the agent runtime. All session state, event streams, and commands flow through this interface — never directly to `AgentSession` or its internal managers.
+_Avoid_: host, bridge (except historical), direct session access
+
+**extensions** (sub-interface on AgentConnection):
+The narrow projection of extension-runtime surface (argument completions, diagnostics, shortcuts, message renderers, `bindExtensions`) exposed to clients. Process-local by nature; kept behind its own group on `AgentConnection` so the top-level seam stays small.
+_Avoid_: ExtensionRunner (the runtime-internal implementation name), "host" API
+
+**SessionView**:
+Read-only, serializable projection of `AgentSession` — cwd, session dir, header, context-tree walks, and session-file materialization. Deliberately excludes mutation and anything that needs the live `SessionManager` or `ExtensionRunner`.
+_Avoid_: SessionManager (implementation), Session, Host
+
+**ReplacedClientContext**:
+The narrow surface given to `afterReplace` hooks after `newSession`/`fork`/`switchSession` swaps the underlying session. Exposes: `sendUserMessage`, `notify`, `setEditorText`. Nothing else is permitted to cross the seam.
+_Avoid_: withSession, setup hook, session replacement
+
+**afterReplace**:
+The single supported shape for client-side work that must run immediately after a session swap. An explicit, typed hook on the connection methods — not a raw `AgentSession` reference — so daemon-backed clients can queue it over the wire.
+_Avoid_: withSession (legacy), setup, seed hook
+
+**seedMessages**:
+The supported way to populate a freshly-created session with initial user/assistant messages without a raw session handle. Passed to `newSession` as part of the client-visible options bag.
+_Avoid_: setup, bootstrap, new-session script
+
+### Anti-terms (removed from the language)
+
+**InteractiveModeLocalSessionHost** (retired):
+Former backdoor exposing raw `AgentSession`, `SessionManager`, and `ExtensionRunner` to terminal UI code under the guise of "in-process convenience". Deleted because every method on it bypassed the seam and produced daemon-incompatible features.
+_Avoid_: local host, host services, legacy bridge

--- a/docs/adr/0001-kill-interactivemode-localsessionhost.md
+++ b/docs/adr/0001-kill-interactivemode-localsessionhost.md
@@ -1,0 +1,18 @@
+# Kill the InteractiveModeLocalSessionHost bypass
+
+`InteractiveModeLocalSessionHost` was a documented "legacy" backdoor (`interactive-mode-services.ts:43-110`) exposing raw `AgentSession`, `SessionManager`, and `ExtensionRunner` plus `runtimeHost.session.agent.signal` to terminal UI code whenever the connection was in-process. Every feature built through the host silently became daemon-incompatible, and the 75-method `AgentConnection` contract was being undercut from the inside.
+
+We decided to remove the host entirely. The gap is closed by widening `AgentConnection` with: an `extensions` sub-interface (completions, diagnostics, shortcuts, message renderers, `bindExtensions`), a read-only `SessionView`, and an `afterReplace` hook with a narrow `ReplacedClientContext` (sendUserMessage/notify/setEditorText) replacing the old `withSession`/`setup` hooks. This requires a `DAEMON_PROTOCOL_VERSION` 7→8 bump — new wire commands for the extension surface and `seedMessages` on `new_session` — and dual-compat tests per `AGENTS.md`.
+
+## Considered options
+
+- **Keep the host, document it as "in-process only"** — rejected: it had already produced 13 call sites in one file and `session.agent.transport =` direct writes from the daemon; "document-only" had not worked.
+- **Extend existing AgentConnection methods with optional params** — rejected: would have hidden process-local operations (extension introspection) inside uniformly wire-capable calls, making caller intent opaque.
+- **Delete without replacement** — rejected: `getArgumentCompletions`, diagnostics, shortcuts, message renderers have no existing wire equivalent.
+
+## Consequences
+
+- New ClientConnection methods are only implemented by the daemon; in-process and daemon clients now share one path.
+- The wire protocol is at version 8; clients speaking v7 must not use the extension surface.
+- `createFakeAgentConnection(overrides)` (throws on unstubbed methods) becomes the supported way to test InteractiveMode against the seam.
+- `interactive-mode-boundary.test.ts` now asserts behavior (boundary-awareness) in addition to imports.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -128,6 +128,7 @@ import { exportSessionToHtml, type ToolHtmlRenderer } from "./export-html/index.
 import { createToolHtmlRenderer } from "./export-html/tool-renderer.js";
 import {
 	type ContextUsage,
+	type ExtensionBindings,
 	type ExtensionCommandContextActions,
 	type ExtensionErrorListener,
 	ExtensionRunner,
@@ -496,12 +497,13 @@ export interface AgentSessionConfig {
 	initialGoal?: { objective: string; tokenBudget?: number };
 }
 
-export interface ExtensionBindings {
-	uiContext?: ExtensionUIContext;
-	commandContextActions?: ExtensionCommandContextActions;
-	shutdownHandler?: ShutdownHandler;
-	onError?: ExtensionErrorListener;
-}
+/**
+ * Kept as a re-export from core/extensions so existing local/daemon import
+ * sites keep compiling; the canonical definition lives in
+ * core/extensions/types.ts so connection contracts can reference it without
+ * importing the session runtime.
+ */
+export type { ExtensionBindings } from "./extensions/index.js";
 
 export interface AutoRefineReviewRequest {
 	reason: AutoRefineReason;

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -35,6 +35,8 @@ export type {
 	AppendEntryHandler,
 	// App keybindings (for custom editors)
 	AppKeybinding,
+	// Re-exported from pi-tui for render surfaces consumed by connection contracts.
+	AutocompleteItem,
 	AutocompleteProviderFactory,
 	// Events - Tool (ToolCallEvent types)
 	BashToolCallEvent,
@@ -62,6 +64,7 @@ export type {
 	ExtensionActions,
 	// API
 	ExtensionAPI,
+	ExtensionBindings,
 	ExtensionCommandContext,
 	ExtensionCommandContextActions,
 	ExtensionContext,

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -72,6 +72,7 @@ import type {
 export type { ExecOptions, ExecResult } from "../exec.js";
 export type { BuildSystemPromptOptions } from "../system-prompt.js";
 export type { AgentToolResult, AgentToolUpdateCallback, ToolExecutionMode };
+export type { AutocompleteItem } from "@earendil-works/pi-tui";
 export type { AppKeybinding, KeybindingsManager } from "../keybindings.js";
 
 // ============================================================================
@@ -1489,6 +1490,14 @@ export interface ExtensionCommandContextActions {
  * Created by loader with throwing action stubs, completed by runner.initialize().
  */
 export interface ExtensionRuntime extends ExtensionRuntimeState, ExtensionActions {}
+
+/** Bindings a mode provides to host the extension system in-process. */
+export interface ExtensionBindings {
+	uiContext?: ExtensionUIContext;
+	commandContextActions?: ExtensionCommandContextActions;
+	shutdownHandler?: () => void;
+	onError?: (error: ExtensionError) => void;
+}
 
 /** Loaded extension with all registered items. */
 export interface Extension {

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -49,6 +49,7 @@ import type {
 	AgentConnectionEvent,
 	AgentConnectionEventListener,
 	AgentConnectionExecuteBashOptions,
+	AgentConnectionExtensions,
 	AgentConnectionExtensionUiResponse,
 	AgentConnectionForkOptions,
 	AgentConnectionHeartbeat,
@@ -61,15 +62,18 @@ import type {
 	AgentConnectionPromptOptions,
 	AgentConnectionQueueMode,
 	AgentConnectionQueueState,
+	AgentConnectionReplacedClientContext,
 	AgentConnectionResourceSnapshot,
 	AgentConnectionSavedSessionInfo,
 	AgentConnectionSavedSessionScope,
 	AgentConnectionScopedModel,
+	AgentConnectionSeedMessage,
 	AgentConnectionSessionContext,
 	AgentConnectionSessionHeader,
 	AgentConnectionSessionListCallbacks,
 	AgentConnectionSessionTreeFlatNode,
 	AgentConnectionSessionTreeNode,
+	AgentConnectionSessionView,
 	AgentConnectionSessionWatcher,
 	AgentConnectionSideQuestionEvent,
 	AgentConnectionSideQuestionTurn,
@@ -80,7 +84,7 @@ import type {
 	AgentConnectionToolDefinition,
 	AgentConnectionUserMessage,
 } from "./types.js";
-import { AgentConnectionPromptAdmissionError } from "./types.js";
+import { AgentConnectionPromptAdmissionError, AgentConnectionUnsupportedError } from "./types.js";
 
 type DistributiveOmit<T, K extends keyof T> = T extends unknown ? Omit<T, K> : never;
 type DaemonCommandBody = DistributiveOmit<DaemonCommand, "id">;
@@ -116,6 +120,24 @@ function formatErrorSentence(error: unknown): string {
 		return "Unknown daemon error.";
 	}
 	return /[.!?]$/.test(message) ? message : `${message}.`;
+}
+
+/**
+ * Process-local extension surface on daemon transports: every member throws
+ * until the wire protocol grows the matching commands.
+ */
+function createUnsupportedExtensionsSurface(): AgentConnectionExtensions {
+	const unsupported = (feature: string): never => {
+		throw new AgentConnectionUnsupportedError(`${feature} requires DAEMON_PROTOCOL_VERSION >= 8`, feature);
+	};
+	return {
+		getArgumentCompletions: (_commandName, _argumentPrefix) => unsupported("extensions.getArgumentCompletions"),
+		getCommandDiagnostics: () => unsupported("extensions.getCommandDiagnostics"),
+		getShortcutDiagnostics: () => unsupported("extensions.getShortcutDiagnostics"),
+		getShortcuts: () => unsupported("extensions.getShortcuts"),
+		getToolRendererDefinition: (_name) => unsupported("extensions.getToolRendererDefinition"),
+		bindExtensions: (_bindings) => unsupported("extensions.bindExtensions"),
+	};
 }
 
 function reconnectDaemonTransportAfterUpdate(client: DaemonClient): Promise<void> {
@@ -207,6 +229,8 @@ export class DaemonAgentConnection implements AgentConnection {
 	private readonly unsubscribeDaemonMessages: () => void;
 	private readonly unsubscribeDaemonClose: () => void;
 	private readonly clientId = `daemon-agent-connection:${randomUUID()}`;
+	readonly extensions: AgentConnectionExtensions = createUnsupportedExtensionsSurface();
+	private sessionView: AgentConnectionSessionView | undefined;
 	private ownedSessionPromotionTail = Promise.resolve();
 	private lastEventCursor: DaemonEventCursor | undefined;
 	private readonly retiredEventGenerations = new Set<string>();
@@ -436,6 +460,25 @@ export class DaemonAgentConnection implements AgentConnection {
 			activeSessionId: this.activeSessionId,
 		});
 		return data.header ?? undefined;
+	}
+
+	getAbortSignal(): AbortSignal | undefined {
+		// AbortSignals cannot cross the daemon socket; abort via abort() instead.
+		throw new AgentConnectionUnsupportedError(
+			"getAbortSignal requires DAEMON_PROTOCOL_VERSION >= 8",
+			"getAbortSignal",
+		);
+	}
+
+	getSessionView(): AgentConnectionSessionView {
+		this.sessionView ??= this.createDaemonSessionView();
+		return this.sessionView;
+	}
+
+	async setAgentTransport(transport: Transport): Promise<void> {
+		// set_transport already persists through the daemon's settings manager and
+		// updates the live agent, so it carries the full setAgentTransport semantic.
+		await this.requestOk({ type: "set_transport", activeSessionId: this.activeSessionId, transport });
 	}
 
 	async getCommands(): Promise<AgentConnectionSlashCommand[]> {
@@ -1072,11 +1115,17 @@ export class DaemonAgentConnection implements AgentConnection {
 	}
 
 	async newSession(options?: AgentConnectionNewSessionOptions): Promise<{ cancelled: boolean }> {
-		return this.requestData<{ cancelled: boolean }>({
+		this.assertSeedMessagesSupported(options?.seedMessages, "newSession");
+		const runAfterReplace = this.createAfterReplaceHook(options?.afterReplace);
+		const result = await this.requestData<{ cancelled: boolean }>({
 			type: "new_session",
 			activeSessionId: this.activeSessionId,
 			parentSession: options?.parentSession,
 		});
+		if (!result.cancelled) {
+			await runAfterReplace?.();
+		}
+		return result;
 	}
 
 	async switchSession(
@@ -1084,13 +1133,18 @@ export class DaemonAgentConnection implements AgentConnection {
 		options?: AgentConnectionSwitchSessionOptions,
 	): Promise<{ cancelled: boolean }> {
 		const sourceActiveSessionId = this.activeSessionId;
+		const runAfterReplace = this.createAfterReplaceHook(options?.afterReplace);
 		try {
-			return await this.requestData<{ cancelled: boolean }>({
+			const result = await this.requestData<{ cancelled: boolean }>({
 				type: "switch_session",
 				activeSessionId: sourceActiveSessionId,
 				sessionPath,
 				cwdOverride: options?.cwdOverride,
 			});
+			if (!result.cancelled) {
+				await runAfterReplace?.();
+			}
+			return result;
 		} catch (error) {
 			if (!(error instanceof SessionAlreadyActiveError) || !error.activeSessionId) {
 				throw error;
@@ -1101,7 +1155,9 @@ export class DaemonAgentConnection implements AgentConnection {
 			if (error.activeSessionId === sourceActiveSessionId) {
 				return { cancelled: false };
 			}
-			return this.reattachSession(sourceActiveSessionId, error.activeSessionId);
+			const reattachResult = await this.reattachSession(sourceActiveSessionId, error.activeSessionId);
+			await runAfterReplace?.();
+			return reattachResult;
 		}
 	}
 
@@ -1187,12 +1243,17 @@ export class DaemonAgentConnection implements AgentConnection {
 		entryId: string,
 		options?: AgentConnectionForkOptions,
 	): Promise<{ cancelled: boolean; selectedText?: string }> {
-		return this.requestData<{ cancelled: boolean; selectedText?: string }>({
+		const runAfterReplace = this.createAfterReplaceHook(options?.afterReplace);
+		const result = await this.requestData<{ cancelled: boolean; selectedText?: string }>({
 			type: "fork",
 			activeSessionId: this.activeSessionId,
 			entryId,
 			position: options?.position,
 		});
+		if (!result.cancelled) {
+			await runAfterReplace?.();
+		}
+		return result;
 	}
 
 	async navigateTree(
@@ -1957,6 +2018,106 @@ export class DaemonAgentConnection implements AgentConnection {
 		if (!current || current.generation !== cursor.generation || cursor.sequence > current.sequence) {
 			this.lastEventCursor = cursor;
 		}
+	}
+
+	/**
+	 * Most accessors ride existing wire commands. `materializeSessionFile`
+	 * stays desktop-only for PR1 — the daemon writes the session file eagerly,
+	 * so clients never need to materialize one remotely.
+	 */
+	private createDaemonSessionView(): AgentConnectionSessionView {
+		return {
+			getCwd: async () => {
+				const state = await this.getState();
+				return state.cwd;
+			},
+			getSessionDir: async () => {
+				const state = await this.getState();
+				if (!state.sessionDir) {
+					throw new AgentConnectionUnsupportedError(
+						"sessionView.getSessionDir requires DAEMON_PROTOCOL_VERSION >= 8",
+						"sessionView.getSessionDir",
+					);
+				}
+				return state.sessionDir;
+			},
+			getSessionName: async () => {
+				const state = await this.getState();
+				return state.sessionName;
+			},
+			getHeader: async () => {
+				const data = await this.requestData<{ header?: AgentConnectionSessionHeader | null }>({
+					type: "get_session_header",
+					activeSessionId: this.activeSessionId,
+				});
+				if (!data.header) {
+					throw new Error("Session has no header yet.");
+				}
+				return data.header;
+			},
+			getFlatTree: async () => {
+				const data = await this.requestData<{
+					flatNodes: AgentConnectionSessionTreeFlatNode[];
+					leafId: string | null;
+				}>({
+					type: "get_session_tree",
+					activeSessionId: this.activeSessionId,
+				});
+				return data.flatNodes;
+			},
+			getLeafId: async () => {
+				const state = await this.getState();
+				return state.leafId;
+			},
+			buildSessionContext: async () => this.getSessionContext(),
+			materializeSessionFile: async () => {
+				throw new AgentConnectionUnsupportedError(
+					"sessionView.materializeSessionFile is desktop-only; daemon sessions are materialized server-side",
+					"sessionView.materializeSessionFile",
+				);
+			},
+		};
+	}
+
+	/**
+	 * seedMessages mutate the fresh SessionManager before the swap resolves;
+	 * that write has no wire command yet, so fail fast rather than silently
+	 * starting an unseeded session.
+	 */
+	private assertSeedMessagesSupported(seedMessages: AgentConnectionSeedMessage[] | undefined, feature: string): void {
+		if (seedMessages && seedMessages.length > 0) {
+			throw new AgentConnectionUnsupportedError(
+				`${feature} seedMessages requires DAEMON_PROTOCOL_VERSION >= 8`,
+				`${feature}.seedMessages`,
+			);
+		}
+	}
+
+	/**
+	 * afterReplace runs client-side after the daemon completes the swap and
+	 * this adapter has applied the replacement snapshot, so subscribers see
+	 * client_notice/client_set_editor_text in event order after session_replaced.
+	 */
+	private createAfterReplaceHook(
+		afterReplace?: (ctx: AgentConnectionReplacedClientContext) => void | Promise<void>,
+	): (() => Promise<void>) | undefined {
+		if (!afterReplace) {
+			return undefined;
+		}
+		return async () => {
+			const ctx: AgentConnectionReplacedClientContext = {
+				sendUserMessage: async (text) => {
+					await this.prompt(text);
+				},
+				notify: async (message, level) => {
+					await this.emit({ type: "client_notice", message, level });
+				},
+				setEditorText: async (text) => {
+					await this.emit({ type: "client_set_editor_text", text });
+				},
+			};
+			await afterReplace(ctx);
+		};
 	}
 
 	private async emit(event: AgentConnectionEvent): Promise<void> {

--- a/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
@@ -1,6 +1,6 @@
 import { resolve } from "node:path";
 import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
-import type { ImageContent, ServiceTier, Transport } from "@earendil-works/pi-ai";
+import type { ImageContent, Message as PiAiMessage, ServiceTier, Transport, UserMessage } from "@earendil-works/pi-ai";
 import type { AgentSessionMessageReceipt, AgentSessionMessageSafetyStatus } from "../../core/agent-messages.js";
 import type { AgentSessionRuntime } from "../../core/agent-session-runtime.js";
 import type { AgentAutonomousStatus } from "../../core/autonomous.js";
@@ -33,6 +33,7 @@ import type {
 	AgentConnectionEvent,
 	AgentConnectionEventListener,
 	AgentConnectionExecuteBashOptions,
+	AgentConnectionExtensions,
 	AgentConnectionExtensionUiResponse,
 	AgentConnectionForkOptions,
 	AgentConnectionHeartbeat,
@@ -45,14 +46,17 @@ import type {
 	AgentConnectionPromptOptions,
 	AgentConnectionQueueMode,
 	AgentConnectionQueueState,
+	AgentConnectionReplacedClientContext,
 	AgentConnectionResourceSnapshot,
 	AgentConnectionSavedSessionInfo,
 	AgentConnectionSavedSessionScope,
 	AgentConnectionScopedModel,
+	AgentConnectionSeedMessage,
 	AgentConnectionSessionContext,
 	AgentConnectionSessionHeader,
 	AgentConnectionSessionListCallbacks,
 	AgentConnectionSessionTreeNode,
+	AgentConnectionSessionView,
 	AgentConnectionSessionWatcher,
 	AgentConnectionSideQuestionTurn,
 	AgentConnectionSlashCommand,
@@ -60,6 +64,7 @@ import type {
 	AgentConnectionState,
 	AgentConnectionSwitchSessionOptions,
 	AgentConnectionToolDefinition,
+	AgentConnectionToolRendererDefinition,
 	AgentConnectionUserMessage,
 } from "./types.js";
 
@@ -68,14 +73,29 @@ export interface InProcessHeadlessExtensionOptions {
 	shutdownHandler?: () => void;
 }
 
+function seedMessageToSessionMessage(seed: AgentConnectionSeedMessage): PiAiMessage {
+	if (seed.role === "user") {
+		return { role: "user", content: seed.text, timestamp: Date.now() } satisfies UserMessage;
+	}
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: seed.text }],
+		stopReason: "stop",
+		timestamp: Date.now(),
+	} as PiAiMessage;
+}
+
 export class InProcessAgentConnection implements AgentConnection {
 	private readonly listeners = new Set<AgentConnectionEventListener>();
 	private readonly beforeSessionInvalidateListeners = new Set<AgentConnectionBeforeSessionInvalidateListener>();
 	private readonly sideQuestionRuns = new Map<string, SideQuestionRun>();
 	private headlessExtensionOptions: InProcessHeadlessExtensionOptions | undefined;
 	private unsubscribeSessionEvents: (() => void) | undefined;
+	readonly extensions: AgentConnectionExtensions;
+	private sessionView: AgentConnectionSessionView | undefined;
 
 	constructor(private readonly runtimeHost: AgentSessionRuntime) {
+		this.extensions = this.createExtensionsSurface();
 		this.bindCurrentSessionEvents();
 		if (typeof this.runtimeHost.setBeforeSessionInvalidate === "function") {
 			this.runtimeHost.setBeforeSessionInvalidate(() => {
@@ -131,6 +151,20 @@ export class InProcessAgentConnection implements AgentConnection {
 
 	async getSessionHeader(): Promise<AgentConnectionSessionHeader | undefined> {
 		return this.session.sessionManager.getHeader() ?? undefined;
+	}
+
+	getAbortSignal(): AbortSignal | undefined {
+		return this.session.agent.signal;
+	}
+
+	getSessionView(): AgentConnectionSessionView {
+		this.sessionView ??= this.createSessionView();
+		return this.sessionView;
+	}
+
+	async setAgentTransport(transport: Transport): Promise<void> {
+		this.session.settingsManager.setTransport(transport);
+		this.session.agent.transport = transport;
 	}
 
 	async getCommands(): Promise<AgentConnectionSlashCommand[]> {
@@ -477,21 +511,39 @@ export class InProcessAgentConnection implements AgentConnection {
 	}
 
 	async newSession(options?: AgentConnectionNewSessionOptions): Promise<{ cancelled: boolean }> {
-		return this.runtimeHost.newSession(options);
+		const seedMessages = options?.seedMessages;
+		return this.runtimeHost.newSession({
+			parentSession: options?.parentSession,
+			setup:
+				seedMessages && seedMessages.length > 0
+					? async (sessionManager) => {
+							for (const message of seedMessages) {
+								sessionManager.appendMessage(seedMessageToSessionMessage(message));
+							}
+						}
+					: undefined,
+			withSession: this.createAfterReplaceHook(options?.afterReplace),
+		});
 	}
 
 	async switchSession(
 		sessionPath: string,
 		options?: AgentConnectionSwitchSessionOptions,
 	): Promise<{ cancelled: boolean }> {
-		return this.runtimeHost.switchSession(sessionPath, options);
+		return this.runtimeHost.switchSession(sessionPath, {
+			cwdOverride: options?.cwdOverride,
+			withSession: this.createAfterReplaceHook(options?.afterReplace),
+		});
 	}
 
 	async fork(
 		entryId: string,
 		options?: AgentConnectionForkOptions,
 	): Promise<{ cancelled: boolean; selectedText?: string }> {
-		return this.runtimeHost.fork(entryId, options);
+		return this.runtimeHost.fork(entryId, {
+			position: options?.position,
+			withSession: this.createAfterReplaceHook(options?.afterReplace),
+		});
 	}
 
 	async navigateTree(
@@ -586,6 +638,98 @@ export class InProcessAgentConnection implements AgentConnection {
 
 	private get session() {
 		return this.runtimeHost.session;
+	}
+
+	/**
+	 * The withSession hook runs after the replacement session is live (runtime
+	 * already rebound events). The ReplacedClientContext is intentionally built
+	 * over the connection's own prompt/subscribe plumbing rather than the
+	 * extension ReplacedSessionContext it receives, so daemon adapters can
+	 * honor the same semantic once the wire protocol grows client callbacks:
+	 * sendUserMessage admits a prompt through this connection; notify/setEditorText
+	 * are delivered to subscribers as client_notice/client_set_editor_text events.
+	 */
+	private createAfterReplaceHook(
+		afterReplace?: (ctx: AgentConnectionReplacedClientContext) => void | Promise<void>,
+	): (() => Promise<void>) | undefined {
+		if (!afterReplace) {
+			return undefined;
+		}
+		return async () => {
+			const ctx: AgentConnectionReplacedClientContext = {
+				sendUserMessage: async (text) => {
+					await this.prompt(text);
+				},
+				notify: async (message, level) => {
+					await this.emit({ type: "client_notice", message, level });
+				},
+				setEditorText: async (text) => {
+					await this.emit({ type: "client_set_editor_text", text });
+				},
+			};
+			await afterReplace(ctx);
+		};
+	}
+
+	private createSessionView(): AgentConnectionSessionView {
+		return {
+			getCwd: async () => this.session.sessionManager.getCwd(),
+			getSessionDir: async () => this.session.sessionManager.getSessionDir(),
+			getSessionName: async () => this.session.sessionManager.getSessionName(),
+			getHeader: async () => {
+				const header = this.session.sessionManager.getHeader();
+				if (!header) {
+					throw new Error("Session has no header yet.");
+				}
+				return header;
+			},
+			getFlatTree: async () => this.session.sessionManager.getFlatTree(),
+			getLeafId: async () => this.session.sessionManager.getLeafId(),
+			buildSessionContext: async () => this.session.sessionManager.buildSessionContext(),
+			materializeSessionFile: async () => this.session.sessionManager.materializeSessionFile(),
+		};
+	}
+
+	private createExtensionsSurface(): AgentConnectionExtensions {
+		return {
+			getArgumentCompletions: async (commandName, argumentPrefix) => {
+				const command = this.session.extensionRunner.getCommand(commandName);
+				if (!command?.getArgumentCompletions) {
+					return null;
+				}
+				return command.getArgumentCompletions(argumentPrefix);
+			},
+			getCommandDiagnostics: async () => this.session.extensionRunner.getCommandDiagnostics(),
+			getShortcutDiagnostics: async () => this.session.extensionRunner.getShortcutDiagnostics(),
+			getShortcuts: async () =>
+				this.session.extensionRunner.getRegisteredCommands().map((entry) => ({
+					name: entry.invocationName,
+					registeredName: entry.name,
+					description: entry.description,
+					source: "extension" as const,
+					sourceInfo: entry.sourceInfo,
+				})),
+			getToolRendererDefinition: async (name) => {
+				const definition = this.session.getToolDefinition(name);
+				if (!definition) {
+					return undefined;
+				}
+				const rendererDefinition: AgentConnectionToolRendererDefinition = {};
+				if (definition.renderCall) {
+					rendererDefinition.renderCall = definition.renderCall;
+				}
+				if (definition.renderResult) {
+					rendererDefinition.renderResult = definition.renderResult;
+				}
+				if (definition.renderShell) {
+					rendererDefinition.renderShell = definition.renderShell;
+				}
+				return Object.keys(rendererDefinition).length > 0 ? rendererDefinition : undefined;
+			},
+			bindExtensions: async (bindings) => {
+				await this.session.bindExtensions(bindings);
+			},
+		};
 	}
 
 	private bindCurrentSessionEvents(): void {

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -12,8 +12,13 @@ import type {
 	AgentHeartbeatManagementAction,
 	AgentHeartbeatUpdateAction,
 } from "../../core/cron-jobs.js";
-import type { ReplayBuiltInToolName } from "../../core/extensions/index.js";
-import type { InputSource } from "../../core/extensions/types.js";
+import type {
+	AutocompleteItem,
+	ExtensionBindings,
+	InputSource,
+	ReplayBuiltInToolName,
+	ToolDefinition,
+} from "../../core/extensions/index.js";
 import type { GoalState } from "../../core/goals.js";
 import type { KernelSentAgentMessage } from "../../core/kernel/index.js";
 import type { RefinementResult } from "../../core/refinement/index.js";
@@ -444,6 +449,22 @@ export class AgentConnectionPromptAdmissionError extends Error {
 	}
 }
 
+/**
+ * A connection member exists only on process-local transports: the daemon
+ * wire protocol has no command for it yet. Thrown by daemon-backed adapters
+ * in place of silently returning stale or partial data.
+ */
+export class AgentConnectionUnsupportedError extends Error {
+	constructor(
+		message: string,
+		readonly feature?: string,
+		options?: ErrorOptions,
+	) {
+		super(message, options);
+		this.name = "AgentConnectionUnsupportedError";
+	}
+}
+
 export interface AgentConnectionPromptOptions {
 	images?: ImageContent[];
 	streamingBehavior?: "steer" | "followUp";
@@ -478,16 +499,45 @@ export interface AgentConnectionExecuteBashOptions {
 	runId?: string;
 }
 
+export interface AgentConnectionSeedMessage {
+	role: "user" | "assistant";
+	text: string;
+}
+
+/**
+ * Narrow client-facing surface handed to `afterReplace` hooks once a
+ * newSession/fork/switchSession replacement has landed.
+ *
+ * This is deliberately not the extension ReplacedSessionContext: it carries
+ * only the bits a connected client can drive through AgentConnection itself
+ * (admit a user message, surface a notification as a connection event, and
+ * restore editor text), so daemon/gateway-backed adapters can honor it over
+ * the wire once the protocol supports it.
+ */
+export interface AgentConnectionReplacedClientContext {
+	sendUserMessage(text: string): Promise<void>;
+	notify(message: string, level?: "info" | "warning" | "error"): Promise<void>;
+	setEditorText(text: string): Promise<void>;
+}
+
 export interface AgentConnectionNewSessionOptions {
 	parentSession?: string;
+	/** Transcript messages to append to the fresh SessionManager before the swap resolves. */
+	seedMessages?: AgentConnectionSeedMessage[];
+	/** Called once after the replacement session is live, with the client-bound context above. */
+	afterReplace?: (ctx: AgentConnectionReplacedClientContext) => void | Promise<void>;
 }
 
 export interface AgentConnectionForkOptions {
 	position?: "before" | "at";
+	/** Called once after the replacement session is live, with the client-bound context above. */
+	afterReplace?: (ctx: AgentConnectionReplacedClientContext) => void | Promise<void>;
 }
 
 export interface AgentConnectionSwitchSessionOptions {
 	cwdOverride?: string;
+	/** Called once after the replacement session is live, with the client-bound context above. */
+	afterReplace?: (ctx: AgentConnectionReplacedClientContext) => void | Promise<void>;
 }
 
 export interface AgentConnectionNavigateTreeOptions {
@@ -617,19 +667,83 @@ export type AgentConnectionEvent =
 	| { type: "extension_error"; extensionPath: string; event: string; error: string }
 	| { type: "connection_status"; status: "reconnecting" | "connected"; error?: string }
 	| { type: "heartbeats_changed" }
+	/**
+	 * Client-bound notice emitted by afterReplace hooks (and future wire-level
+	 * client callbacks). InteractiveMode maps it onto its notification surface;
+	 * `setEditorText` restores editor content after a session swap.
+	 */
+	| { type: "client_notice"; message: string; level?: "info" | "warning" | "error" }
+	| { type: "client_set_editor_text"; text: string }
 	| { type: "closed"; error?: string };
 
 export type AgentConnectionEventListener = (event: AgentConnectionEvent) => void | Promise<void>;
 export type AgentConnectionBeforeSessionInvalidateListener = () => void;
 
+/**
+ * Read-only, serializable projection of the live AgentSession.
+ *
+ * Every accessor returns a snapshot value safe to send across a wire-typed
+ * boundary; the view object itself is obtained synchronously so callers can
+ * hold it without a round trip, while each method performs its own fresh
+ * read. Daemon-backed accessors throw AgentConnectionUnsupportedError until
+ * the matching wire commands exist.
+ */
+export interface AgentConnectionSessionView {
+	getCwd(): Promise<string>;
+	getSessionDir(): Promise<string>;
+	getSessionName(): Promise<string | undefined>;
+	getHeader(): Promise<AgentConnectionSessionHeader>;
+	getFlatTree(): Promise<AgentConnectionSessionTreeFlatNode[]>;
+	getLeafId(): Promise<string | null>;
+	buildSessionContext(): Promise<AgentConnectionSessionContext>;
+	materializeSessionFile(): Promise<string>;
+}
+
+/** Renderer callbacks for a tool, patched onto a serializable tool definition by client code. */
+export type AgentConnectionToolRendererDefinition = Pick<ToolDefinition, "renderCall" | "renderResult" | "renderShell">;
+
+/**
+ * Process-local extension surface, grouped under one sub-interface so the
+ * host-replacement work can delete InteractiveModeLocalSessionHost without
+ * growing the top-level AgentConnection method count.
+ *
+ * These members are only meaningful in-process: they expose executable
+ * callbacks (argument completions, tool renderers) and process state
+ * (extension bindings, shortcuts) that cannot cross a network boundary.
+ * Daemon-backed adapters throw AgentConnectionUnsupportedError until a
+ * wire protocol version covers them.
+ */
+export interface AgentConnectionExtensions {
+	getArgumentCompletions(commandName: string, argumentPrefix: string): Promise<AutocompleteItem[] | null>;
+	getCommandDiagnostics(): Promise<AgentConnectionResourceDiagnostic[]>;
+	getShortcutDiagnostics(): Promise<AgentConnectionResourceDiagnostic[]>;
+	/** Resolved extension commands; same shape as getCommands() entries sourced from extensions. */
+	getShortcuts(): Promise<AgentConnectionSlashCommand[]>;
+	getToolRendererDefinition(name: string): Promise<AgentConnectionToolRendererDefinition | undefined>;
+	bindExtensions(bindings: ExtensionBindings): Promise<void>;
+}
+
 export interface AgentConnection {
 	subscribe(listener: AgentConnectionEventListener): () => void;
 	onBeforeSessionInvalidate(listener: AgentConnectionBeforeSessionInvalidateListener): () => void;
 
+	/** Process-local extension surface; daemon adapters report unsupported until the wire catches up. */
+	readonly extensions: AgentConnectionExtensions;
 	getState(): Promise<AgentConnectionState>;
 	getInitialSnapshot(): Promise<AgentConnectionSnapshot>;
 	getMessages(): Promise<AgentMessage[]>;
 	getSessionHeader(): Promise<AgentConnectionSessionHeader | undefined>;
+	/**
+	 * Synchronous handle to the session's abort signal (undefined when no turn is
+	 * in flight). Process-local: daemon adapters throw because an AbortSignal
+	 * cannot cross the wire.
+	 */
+	getAbortSignal(): AbortSignal | undefined;
+	/**
+	 * Synchronous handle to a read-only session projection. The view object is
+	 * free; each accessor performs a fresh async read.
+	 */
+	getSessionView(): AgentConnectionSessionView;
 	getCommands(): Promise<AgentConnectionSlashCommand[]>;
 	getResourceSnapshot(): Promise<AgentConnectionResourceSnapshot>;
 	getModelCatalog(): Promise<AgentConnectionModelCatalog>;
@@ -702,6 +816,12 @@ export interface AgentConnection {
 	setServiceTier(serviceTier: ServiceTier): Promise<void>;
 	cycleThinkingLevel(): Promise<ThinkingLevel | undefined>;
 	setTransport(transport: Transport): Promise<void>;
+	/**
+	 * First-class transport swap: persists via the settings manager and updates
+	 * the live agent, so daemon-mode host code no longer reaches through the
+	 * session for transport writes.
+	 */
+	setAgentTransport(transport: Transport): Promise<void>;
 	setSteeringMode(mode: AgentConnectionQueueMode): Promise<void>;
 	setFollowUpMode(mode: AgentConnectionQueueMode): Promise<void>;
 	setAutoCompactionEnabled(enabled: boolean): Promise<void>;


### PR DESCRIPTION
## Summary

Widen the `AgentConnection` seam so `InteractiveModeLocalSessionHost` can be deleted in a follow-up — no call-site changes here.

PR1 of 3 tracked in ADR-0001 / CONTEXT.md (additions in this PR).

## Changes

- **`AgentConnection` gains**: `extensions` sub-interface (completions, diagnostics, shortcuts, renderer definitions, `bindExtensions`), `getSessionView()` (read-only projection), `getAbortSignal()`, `setAgentTransport()`
- **Session-swap options gain**: `seedMessages` + `afterReplace` with a narrow `ReplacedClientContext` (`sendUserMessage` / `notify` / `setEditorText`)
- **New event variants** `client_notice` and `client_set_editor_text` so afterReplace notifications cross daemon/InProcess adapters uniformly
- **`ExtensionBindings` relocated** from `core/agent-session.ts` to `core/extensions/types.ts` (fixes a would-be circular import: connection types cannot import agent-session per `interactive-mode-boundary.test.ts`)
- **Docs**: `CONTEXT.md` (glossary for the new seam terms), `docs/adr/0001-kill-interactivemode-localsessionhost.md` (decision record)

Daemon adapter stubs throw `AgentConnectionUnsupportedError` for process-local extension surface — wire commands land in PR3 (`feat/c1-protocol-v8`, protocol 7→8 bump with dual-compat tests per AGENTS.md).

## Test plan

- [x] `test/agent-connection-in-process.test.ts` — 12 tests
- [x] `test/interactive-mode-boundary.test.ts` — import boundary still enforced
- [x] `test/agent-connection-daemon.test.ts` — 65 tests (regression)
- [x] `test/agent-connection-snapshot.test.ts` — 1 test
- [x] `npm run check` — biome + tsgo + installer + browser-smoke (pre-commit hook)
- [ ] PR2 (`feat/c1-im-migration`) migrates 13 `interactive-mode.ts` call sites onto these new members

Refs ADR-0001, CONTEXT.md.
