### PR TITLE
refactor(interactive): migrate InteractiveMode off LocalSessionHost (PR2)

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -86,7 +86,7 @@ import {
 	type AgentConnection,
 	type AgentsViewScopeKey,
 	ClientPromptStashStore,
-	createInteractiveModeLocalSessionHost,
+	createInteractiveModeUiServices,
 	createInteractiveModeUiServicesFromServices,
 	DaemonAgentConnection,
 	DaemonCapabilityUnavailableError,
@@ -1655,7 +1655,7 @@ export async function main(args: string[], options?: MainOptions) {
 
 		const interactiveMode = new InteractiveMode({
 			agentConnection: new InProcessAgentConnection(runtime),
-			localSessionHost: createInteractiveModeLocalSessionHost(runtime),
+			uiServices: createInteractiveModeUiServices(runtime.session),
 			promptStashStore: new ClientPromptStashStore(),
 			promptStashSessionId: session.sessionId,
 			bindLocalSessionExtensions: true,

--- a/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/daemon-agent-connection.ts
@@ -17,6 +17,7 @@ import type {
 import type { RefinementResult } from "../../core/refinement/index.js";
 import type { DeleteSessionFileResult } from "../../core/session-file-actions.js";
 import { SessionAlreadyActiveError } from "../../core/session-lease.js";
+import type { ReadonlySessionManager } from "../../core/session-manager.js";
 import type { SessionStats } from "../../core/session-stats.js";
 import {
 	DaemonCapabilityUnavailableError,
@@ -135,6 +136,8 @@ function createUnsupportedExtensionsSurface(): AgentConnectionExtensions {
 		getCommandDiagnostics: () => unsupported("extensions.getCommandDiagnostics"),
 		getShortcutDiagnostics: () => unsupported("extensions.getShortcutDiagnostics"),
 		getShortcuts: () => unsupported("extensions.getShortcuts"),
+		getKeyboardShortcuts: (_resolvedKeybindings) => unsupported("extensions.getKeyboardShortcuts"),
+		getMessageRenderer: (_customType) => unsupported("extensions.getMessageRenderer"),
 		getToolRendererDefinition: (_name) => unsupported("extensions.getToolRendererDefinition"),
 		bindExtensions: (_bindings) => unsupported("extensions.bindExtensions"),
 	};
@@ -473,6 +476,20 @@ export class DaemonAgentConnection implements AgentConnection {
 	getSessionView(): AgentConnectionSessionView {
 		this.sessionView ??= this.createDaemonSessionView();
 		return this.sessionView;
+	}
+
+	getReadonlySessionManager(): ReadonlySessionManager {
+		throw new AgentConnectionUnsupportedError(
+			"getReadonlySessionManager requires DAEMON_PROTOCOL_VERSION >= 8",
+			"getReadonlySessionManager",
+		);
+	}
+
+	getSystemPromptSync(): string {
+		throw new AgentConnectionUnsupportedError(
+			"getSystemPromptSync requires DAEMON_PROTOCOL_VERSION >= 8",
+			"getSystemPromptSync",
+		);
 	}
 
 	async setAgentTransport(transport: Transport): Promise<void> {
@@ -1116,6 +1133,7 @@ export class DaemonAgentConnection implements AgentConnection {
 
 	async newSession(options?: AgentConnectionNewSessionOptions): Promise<{ cancelled: boolean }> {
 		this.assertSeedMessagesSupported(options?.seedMessages, "newSession");
+		this.assertProcessLocalSessionHooks(options, "newSession");
 		const runAfterReplace = this.createAfterReplaceHook(options?.afterReplace);
 		const result = await this.requestData<{ cancelled: boolean }>({
 			type: "new_session",
@@ -1132,6 +1150,7 @@ export class DaemonAgentConnection implements AgentConnection {
 		sessionPath: string,
 		options?: AgentConnectionSwitchSessionOptions,
 	): Promise<{ cancelled: boolean }> {
+		this.assertProcessLocalSessionHooks(options, "switchSession");
 		const sourceActiveSessionId = this.activeSessionId;
 		const runAfterReplace = this.createAfterReplaceHook(options?.afterReplace);
 		try {
@@ -1243,6 +1262,7 @@ export class DaemonAgentConnection implements AgentConnection {
 		entryId: string,
 		options?: AgentConnectionForkOptions,
 	): Promise<{ cancelled: boolean; selectedText?: string }> {
+		this.assertProcessLocalSessionHooks(options, "fork");
 		const runAfterReplace = this.createAfterReplaceHook(options?.afterReplace);
 		const result = await this.requestData<{ cancelled: boolean; selectedText?: string }>({
 			type: "fork",
@@ -2089,6 +2109,24 @@ export class DaemonAgentConnection implements AgentConnection {
 			throw new AgentConnectionUnsupportedError(
 				`${feature} seedMessages requires DAEMON_PROTOCOL_VERSION >= 8`,
 				`${feature}.seedMessages`,
+			);
+		}
+	}
+
+	private assertProcessLocalSessionHooks(
+		options: { setup?: unknown; withSession?: unknown } | undefined,
+		feature: string,
+	): void {
+		if (options?.setup) {
+			throw new AgentConnectionUnsupportedError(
+				`${feature} setup requires an in-process connection`,
+				`${feature}.setup`,
+			);
+		}
+		if (options?.withSession) {
+			throw new AgentConnectionUnsupportedError(
+				`${feature} withSession requires an in-process connection; use afterReplace for portable clients`,
+				`${feature}.withSession`,
 			);
 		}
 	}

--- a/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
+++ b/packages/coding-agent/src/modes/agent-connection/in-process-agent-connection.ts
@@ -13,10 +13,10 @@ import type {
 	AgentHeartbeatManagementAction,
 	AgentHeartbeatUpdateAction,
 } from "../../core/cron-jobs.js";
-import type { ExtensionUIContext } from "../../core/extensions/types.js";
+import type { ExtensionUIContext, ReplacedSessionContext } from "../../core/extensions/types.js";
 import type { RefinementResult } from "../../core/refinement/index.js";
 import { type DeleteSessionFileResult, deleteSessionFile } from "../../core/session-file-actions.js";
-import { SessionManager } from "../../core/session-manager.js";
+import { type ReadonlySessionManager, SessionManager } from "../../core/session-manager.js";
 import type { SessionStats } from "../../core/session-stats.js";
 import { type SideQuestionRun, startSideQuestion } from "../../core/side-question.js";
 import { waitForHeadlessCompletion } from "../headless-completion.js";
@@ -160,6 +160,14 @@ export class InProcessAgentConnection implements AgentConnection {
 	getSessionView(): AgentConnectionSessionView {
 		this.sessionView ??= this.createSessionView();
 		return this.sessionView;
+	}
+
+	getReadonlySessionManager(): ReadonlySessionManager {
+		return this.session.sessionManager;
+	}
+
+	getSystemPromptSync(): string {
+		return this.session.systemPrompt;
 	}
 
 	async setAgentTransport(transport: Transport): Promise<void> {
@@ -512,17 +520,31 @@ export class InProcessAgentConnection implements AgentConnection {
 
 	async newSession(options?: AgentConnectionNewSessionOptions): Promise<{ cancelled: boolean }> {
 		const seedMessages = options?.seedMessages;
+		const seedSetup =
+			seedMessages && seedMessages.length > 0
+				? async (sessionManager: SessionManager) => {
+						for (const message of seedMessages) {
+							sessionManager.appendMessage(seedMessageToSessionMessage(message));
+						}
+					}
+				: undefined;
+		const setup = options?.setup
+			? async (sessionManager: SessionManager) => {
+					await seedSetup?.(sessionManager);
+					await options.setup?.(sessionManager);
+				}
+			: seedSetup;
+		const afterReplaceHook = this.createAfterReplaceHook(options?.afterReplace);
+		const withSession = options?.withSession
+			? async (ctx: ReplacedSessionContext) => {
+					await options.withSession?.(ctx);
+					await afterReplaceHook?.();
+				}
+			: afterReplaceHook;
 		return this.runtimeHost.newSession({
 			parentSession: options?.parentSession,
-			setup:
-				seedMessages && seedMessages.length > 0
-					? async (sessionManager) => {
-							for (const message of seedMessages) {
-								sessionManager.appendMessage(seedMessageToSessionMessage(message));
-							}
-						}
-					: undefined,
-			withSession: this.createAfterReplaceHook(options?.afterReplace),
+			setup,
+			withSession,
 		});
 	}
 
@@ -530,9 +552,16 @@ export class InProcessAgentConnection implements AgentConnection {
 		sessionPath: string,
 		options?: AgentConnectionSwitchSessionOptions,
 	): Promise<{ cancelled: boolean }> {
+		const afterReplaceHook = this.createAfterReplaceHook(options?.afterReplace);
+		const withSession = options?.withSession
+			? async (ctx: ReplacedSessionContext) => {
+					await options.withSession?.(ctx);
+					await afterReplaceHook?.();
+				}
+			: afterReplaceHook;
 		return this.runtimeHost.switchSession(sessionPath, {
 			cwdOverride: options?.cwdOverride,
-			withSession: this.createAfterReplaceHook(options?.afterReplace),
+			withSession,
 		});
 	}
 
@@ -540,9 +569,16 @@ export class InProcessAgentConnection implements AgentConnection {
 		entryId: string,
 		options?: AgentConnectionForkOptions,
 	): Promise<{ cancelled: boolean; selectedText?: string }> {
+		const afterReplaceHook = this.createAfterReplaceHook(options?.afterReplace);
+		const withSession = options?.withSession
+			? async (ctx: ReplacedSessionContext) => {
+					await options.withSession?.(ctx);
+					await afterReplaceHook?.();
+				}
+			: afterReplaceHook;
 		return this.runtimeHost.fork(entryId, {
 			position: options?.position,
-			withSession: this.createAfterReplaceHook(options?.afterReplace),
+			withSession,
 		});
 	}
 
@@ -709,6 +745,8 @@ export class InProcessAgentConnection implements AgentConnection {
 					source: "extension" as const,
 					sourceInfo: entry.sourceInfo,
 				})),
+			getKeyboardShortcuts: (resolvedKeybindings) => this.session.extensionRunner.getShortcuts(resolvedKeybindings),
+			getMessageRenderer: (customType) => this.session.extensionRunner.getMessageRenderer(customType),
 			getToolRendererDefinition: async (name) => {
 				const definition = this.session.getToolDefinition(name);
 				if (!definition) {

--- a/packages/coding-agent/src/modes/agent-connection/index.ts
+++ b/packages/coding-agent/src/modes/agent-connection/index.ts
@@ -71,6 +71,7 @@ export type {
 	AgentConnectionSwitchSessionOptions,
 	AgentConnectionThinkingLevelChangeEntry,
 	AgentConnectionToolDefinition,
+	AgentConnectionToolRendererDefinition,
 	AgentConnectionUserMessage,
 } from "./types.js";
-export { AgentConnectionPromptAdmissionError } from "./types.js";
+export { AgentConnectionPromptAdmissionError, AgentConnectionUnsupportedError } from "./types.js";

--- a/packages/coding-agent/src/modes/agent-connection/types.ts
+++ b/packages/coding-agent/src/modes/agent-connection/types.ts
@@ -1,5 +1,6 @@
 import type { AgentEvent, AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Api, ImageContent, Model, ServiceTier, TextContent, Transport, Usage } from "@earendil-works/pi-ai";
+import type { KeybindingsConfig, KeyId } from "@earendil-works/pi-tui";
 import type { AgentSessionMessageReceipt, AgentSessionMessageSafetyStatus } from "../../core/agent-messages.js";
 import type { AuthSourceToken } from "../../core/auth-storage.js";
 import type { AgentAutonomousStatus } from "../../core/autonomous.js";
@@ -15,7 +16,10 @@ import type {
 import type {
 	AutocompleteItem,
 	ExtensionBindings,
+	ExtensionShortcut,
 	InputSource,
+	MessageRenderer,
+	ReplacedSessionContext,
 	ReplayBuiltInToolName,
 	ToolDefinition,
 } from "../../core/extensions/index.js";
@@ -25,6 +29,7 @@ import type { RefinementResult } from "../../core/refinement/index.js";
 import type { RlmMaxDepthStatus, SetRlmMaxDepthResult } from "../../core/rlm-max-depth.js";
 import type { SessionActionSnapshot } from "../../core/session-action-store.js";
 import type { DeleteSessionFileResult } from "../../core/session-file-actions.js";
+import type { ReadonlySessionManager, SessionManager } from "../../core/session-manager.js";
 import type { SessionStats } from "../../core/session-stats.js";
 
 /**
@@ -526,18 +531,33 @@ export interface AgentConnectionNewSessionOptions {
 	seedMessages?: AgentConnectionSeedMessage[];
 	/** Called once after the replacement session is live, with the client-bound context above. */
 	afterReplace?: (ctx: AgentConnectionReplacedClientContext) => void | Promise<void>;
+	/**
+	 * Process-local only: runs against the live SessionManager before the swap.
+	 * Daemon adapters throw AgentConnectionUnsupportedError. Prefer seedMessages
+	 * for portable clients.
+	 */
+	setup?: (sessionManager: SessionManager) => Promise<void>;
+	/**
+	 * Process-local only: receives the full ReplacedSessionContext after the swap.
+	 * Daemon adapters throw. Prefer afterReplace for portable clients.
+	 */
+	withSession?: (ctx: ReplacedSessionContext) => Promise<void>;
 }
 
 export interface AgentConnectionForkOptions {
 	position?: "before" | "at";
 	/** Called once after the replacement session is live, with the client-bound context above. */
 	afterReplace?: (ctx: AgentConnectionReplacedClientContext) => void | Promise<void>;
+	/** Process-local only; see AgentConnectionNewSessionOptions.withSession. */
+	withSession?: (ctx: ReplacedSessionContext) => Promise<void>;
 }
 
 export interface AgentConnectionSwitchSessionOptions {
 	cwdOverride?: string;
 	/** Called once after the replacement session is live, with the client-bound context above. */
 	afterReplace?: (ctx: AgentConnectionReplacedClientContext) => void | Promise<void>;
+	/** Process-local only; see AgentConnectionNewSessionOptions.withSession. */
+	withSession?: (ctx: ReplacedSessionContext) => Promise<void>;
 }
 
 export interface AgentConnectionNavigateTreeOptions {
@@ -717,8 +737,17 @@ export interface AgentConnectionExtensions {
 	getArgumentCompletions(commandName: string, argumentPrefix: string): Promise<AutocompleteItem[] | null>;
 	getCommandDiagnostics(): Promise<AgentConnectionResourceDiagnostic[]>;
 	getShortcutDiagnostics(): Promise<AgentConnectionResourceDiagnostic[]>;
-	/** Resolved extension commands; same shape as getCommands() entries sourced from extensions. */
+	/** Resolved extension slash commands; same shape as getCommands() entries sourced from extensions. */
 	getShortcuts(): Promise<AgentConnectionSlashCommand[]>;
+	/**
+	 * Keyboard shortcuts registered by extensions, resolved against the client's
+	 * effective keybindings. Returns executable handlers — process-local only.
+	 * Synchronous because ExtensionRunner.getShortcuts is sync and the TUI
+	 * shortcut path must stay synchronous.
+	 */
+	getKeyboardShortcuts(resolvedKeybindings: KeybindingsConfig): Map<KeyId, ExtensionShortcut>;
+	/** Custom-message renderer for a given customType; process-local (executable callback). */
+	getMessageRenderer(customType: string): MessageRenderer | undefined;
 	getToolRendererDefinition(name: string): Promise<AgentConnectionToolRendererDefinition | undefined>;
 	bindExtensions(bindings: ExtensionBindings): Promise<void>;
 }
@@ -744,6 +773,18 @@ export interface AgentConnection {
 	 * free; each accessor performs a fresh async read.
 	 */
 	getSessionView(): AgentConnectionSessionView;
+	/**
+	 * Synchronous ReadonlySessionManager for ExtensionContext construction.
+	 * Process-local: daemon adapters throw because the live SessionManager
+	 * cannot cross the wire. Prefer getSessionView() for serializable reads.
+	 */
+	getReadonlySessionManager(): ReadonlySessionManager;
+	/**
+	 * Synchronous system-prompt read for ExtensionContext. Prefer the async
+	 * getSystemPrompt() for connection-backed clients; this sync form exists
+	 * only because ExtensionContext.getSystemPrompt is sync today.
+	 */
+	getSystemPromptSync(): string;
 	getCommands(): Promise<AgentConnectionSlashCommand[]>;
 	getResourceSnapshot(): Promise<AgentConnectionResourceSnapshot>;
 	getModelCatalog(): Promise<AgentConnectionModelCatalog>;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -88,7 +88,7 @@ import type {
 	EditorFactory,
 	ExtensionCommandContext,
 	ExtensionContext,
-	ExtensionRunner,
+	ExtensionShortcut,
 	ExtensionUIContext,
 	ExtensionUIDialogOptions,
 	ExtensionWidgetOptions,
@@ -160,8 +160,9 @@ import type {
 	AgentConnectionSourceInfo,
 	AgentConnectionState,
 	AgentConnectionToolDefinition,
+	AgentConnectionToolRendererDefinition,
 } from "../agent-connection/index.js";
-import { AgentConnectionPromptAdmissionError } from "../agent-connection/index.js";
+import { AgentConnectionPromptAdmissionError, AgentConnectionUnsupportedError } from "../agent-connection/index.js";
 import { getModelArgumentCompletions } from "../model-autocomplete.js";
 import {
 	checkForPackageUpdates,
@@ -232,11 +233,7 @@ import {
 	imageMarkerIds,
 	remapImageMarkers,
 } from "./image-markers.js";
-import type {
-	InteractiveModeLocalSessionHost,
-	InteractiveModeLocalToolRendererDefinition,
-	InteractiveModeUiServices,
-} from "./interactive-mode-services.js";
+import type { InteractiveModeUiServices } from "./interactive-mode-services.js";
 import {
 	isOnboardingModelReady,
 	type OnboardingStartupState,
@@ -772,13 +769,12 @@ export interface InteractiveModeOptions {
 	/** Exact daemon socket to preserve across an interactive self-update restart. */
 	daemonSocketPath?: string;
 	/**
-	 * Local-only host for in-process extension binding and callback-bearing session operations.
-	 * This must remain optional adapter glue, not a generic execution dependency.
+	 * Bind extension handlers through the connection's process-local extension
+	 * surface (AgentConnection.extensions). Disabled for daemon/gateway-backed
+	 * clients whose wire transport cannot carry executable extension callbacks.
 	 */
-	localSessionHost?: InteractiveModeLocalSessionHost;
-	/** Bind extension handlers in the local session host. Disabled for daemon/gateway-backed clients. */
 	bindLocalSessionExtensions?: boolean;
-	/** UI-local services used for settings, auth, resources, and rendering. Defaults to services from localSessionHost. */
+	/** UI-local services used for settings, auth, resources, and rendering. */
 	uiServices?: InteractiveModeUiServices;
 	/** Extra cleanup for externally-owned UI service hosts. Runs after the connection is disposed and before process exit. */
 	onShutdown?: () => void | Promise<void>;
@@ -818,7 +814,6 @@ export class InteractiveMode {
 
 	private uiServices: InteractiveModeUiServices;
 	private agentConnection: AgentConnection;
-	private localSessionHost: InteractiveModeLocalSessionHost | undefined;
 	private bindLocalSessionExtensions: boolean;
 	private ui: TUI;
 	private chatContainer: Container;
@@ -962,6 +957,19 @@ export class InteractiveMode {
 	private connectionModelsRefreshInFlight: { version: number; promise: Promise<AgentConnectionModel[]> } | undefined;
 	private connectionState: AgentConnectionState | undefined;
 	private connectionResourceSnapshot: AgentConnectionResourceSnapshot | undefined;
+	/**
+	 * Async-fetched extension command+shortcut diagnostics. The extension surface
+	 * reads are async (connection boundary), so they are refreshed ahead of render
+	 * and cached here; diagnostic rendering stays synchronous. Daemon transports
+	 * leave this empty (their surface throws Unsupported until PR3).
+	 */
+	private extensionRuntimeDiagnostics: AgentConnectionResourceDiagnostic[] = [];
+	/**
+	 * Cached keyboard shortcuts from the extension surface. Refresh via
+	 * refreshExtensionKeyboardShortcuts(); setupExtensionShortcuts and the
+	 * shortcut guide read this cache so they stay synchronous.
+	 */
+	private extensionKeyboardShortcuts: Map<KeyId, ExtensionShortcut> = new Map();
 	private sessionHasMessages = false;
 	private heartbeatCatalog: AgentConnectionHeartbeat[] = [];
 	private heartbeats: AgentConnectionHeartbeat[] = [];
@@ -1026,12 +1034,34 @@ export class InteractiveMode {
 	// Custom header from extension (undefined = use built-in header)
 	private customHeader: (Component & { dispose?(): void }) | undefined = undefined;
 
-	private getLocalSessionHost(): InteractiveModeLocalSessionHost {
-		if (!this.localSessionHost) {
-			throw new Error("Local session host is not available in connection-backed interactive mode");
+	/**
+	 * Wrap a synchronous extension-surface read so daemon/gateway-backed
+	 * connections (whose `extensions` members throw AgentConnectionUnsupportedError
+	 * until the wire protocol covers them) degrade to the fallback instead of
+	 * blowing up the interactive UI. PR3 removes this dual-shape entirely.
+	 */
+	private tryExtensionSurface<T>(read: () => T, fallback: T): T {
+		try {
+			return read();
+		} catch (error: unknown) {
+			if (error instanceof AgentConnectionUnsupportedError) {
+				return fallback;
+			}
+			throw error;
 		}
-		return this.localSessionHost;
 	}
+
+	private async tryExtensionSurfaceAsync<T>(read: () => Promise<T>, fallback: T): Promise<T> {
+		try {
+			return await read();
+		} catch (error: unknown) {
+			if (error instanceof AgentConnectionUnsupportedError) {
+				return fallback;
+			}
+			throw error;
+		}
+	}
+
 	private get settingsManager() {
 		return this.uiServices.settingsManager;
 	}
@@ -1040,9 +1070,9 @@ export class InteractiveMode {
 	}
 
 	constructor(private options: InteractiveModeOptions) {
-		const uiServices = options.uiServices ?? options.localSessionHost?.createUiServices();
+		const uiServices = options.uiServices;
 		if (!uiServices) {
-			throw new Error("InteractiveMode requires uiServices when no localSessionHost is supplied");
+			throw new Error("InteractiveMode requires uiServices");
 		}
 		this.uiServices = uiServices;
 		this.agentConnection = options.agentConnection;
@@ -1053,11 +1083,10 @@ export class InteractiveMode {
 				? this.promptStashStore.forSession(this.promptStashSessionId)
 				: {};
 		this.hydratePromptStash();
-		this.localSessionHost = options.localSessionHost;
-		this.bindLocalSessionExtensions = options.bindLocalSessionExtensions ?? options.localSessionHost !== undefined;
-		if (this.bindLocalSessionExtensions && !options.localSessionHost) {
-			throw new Error("Local extension binding requires localSessionHost");
-		}
+		// Extension binding now goes through AgentConnection.extensions; default to
+		// enabled because the in-process connection supplies a working surface, while
+		// daemon-backed callers opt out explicitly (their surface throws Unsupported).
+		this.bindLocalSessionExtensions = options.bindLocalSessionExtensions ?? true;
 		this.agentConnection.onBeforeSessionInvalidate(() => {
 			this.resetExtensionUI();
 			this.resetSideQuestion();
@@ -1297,8 +1326,15 @@ export class InteractiveMode {
 				name: cmd.name,
 				description: cmd.description,
 				sourceTag: this.getAutocompleteSourceLabel(cmd.sourceInfo),
+				// Argument completions resolve through the connection's extension surface
+				// (invocation-name lookup); daemon transports degrade to no completions
+				// until the wire protocol covers them (PR3).
 				getArgumentCompletions: this.bindLocalSessionExtensions
-					? this.getLocalSessionHost().getExtensionRunner().getCommand(cmd.name)?.getArgumentCompletions
+					? (argumentPrefix: string) =>
+							this.tryExtensionSurfaceAsync(
+								() => this.agentConnection.extensions.getArgumentCompletions(cmd.name, argumentPrefix),
+								null,
+							)
 					: undefined,
 			}));
 
@@ -2371,16 +2407,12 @@ export class InteractiveMode {
 				...(resourceSnapshot?.diagnostics.extensions ?? []),
 			];
 
+			// Command/shortcut diagnostics come from the cached extension-surface read
+			// (refreshExtensionRuntimeDiagnostics), keeping this render path synchronous.
 			if (this.bindLocalSessionExtensions) {
-				const commandDiagnostics = this.getLocalSessionHost().getExtensionRunner().getCommandDiagnostics();
-				extensionDiagnostics.push(...commandDiagnostics);
+				extensionDiagnostics.push(...this.extensionRuntimeDiagnostics);
 			}
 			extensionDiagnostics.push(...this.getBuiltInCommandConflictDiagnostics(this.connectionCommands));
-
-			if (this.bindLocalSessionExtensions) {
-				const shortcutDiagnostics = this.getLocalSessionHost().getExtensionRunner().getShortcutDiagnostics();
-				extensionDiagnostics.push(...shortcutDiagnostics);
-			}
 
 			if (extensionDiagnostics.length > 0) {
 				const warningLines = this.formatDiagnostics(extensionDiagnostics, sourceInfos);
@@ -2413,21 +2445,19 @@ export class InteractiveMode {
 	 * Initialize the extension system with TUI-based UI context.
 	 */
 	private async bindCurrentSessionExtensions(): Promise<void> {
-		const localSessionHost = this.getLocalSessionHost();
 		const uiContext = this.createExtensionUIContext();
-		await localSessionHost.bindExtensions({
+		await this.agentConnection.extensions.bindExtensions({
 			uiContext,
 			commandContextActions: {
 				waitForIdle: () => this.agentConnection.waitForIdle(),
 				newSession: async (options) => {
 					this.stopWorkingLoader();
 					try {
-						const result =
-							options?.setup || options?.withSession
-								? await localSessionHost.newSession(options)
-								: await this.agentConnection.newSession(
-										options?.parentSession ? { parentSession: options.parentSession } : undefined,
-									);
+						const result = await this.agentConnection.newSession({
+							parentSession: options?.parentSession,
+							setup: options?.setup,
+							withSession: options?.withSession,
+						});
 						if (!result.cancelled) {
 							await this.renderCurrentSessionState();
 							this.ui.requestRender();
@@ -2439,9 +2469,10 @@ export class InteractiveMode {
 				},
 				fork: async (entryId, options) => {
 					try {
-						const result = options?.withSession
-							? await localSessionHost.fork(entryId, options)
-							: await this.agentConnection.fork(entryId, { position: options?.position });
+						const result = await this.agentConnection.fork(entryId, {
+							position: options?.position,
+							withSession: options?.withSession,
+						});
 						if (!result.cancelled) {
 							await this.renderCurrentSessionState();
 							this.editor.setText("selectedText" in result ? (result.selectedText ?? "") : "");
@@ -2488,8 +2519,9 @@ export class InteractiveMode {
 		await this.refreshConnectionCatalog();
 		this.setupAutocompleteProvider();
 
-		const extensionRunner = localSessionHost.getExtensionRunner();
-		this.setupExtensionShortcuts(extensionRunner);
+		await this.refreshExtensionKeyboardShortcuts();
+		this.setupExtensionShortcuts();
+		await this.refreshExtensionRuntimeDiagnostics();
 		this.showLoadedResources({ force: false, showDiagnosticsWhenQuiet: true });
 	}
 
@@ -2529,6 +2561,23 @@ export class InteractiveMode {
 		this.applyConnectionModelCatalog(modelCatalog);
 		this.connectionModelsFetchedAt = Date.now();
 		this.connectionResourceSnapshot = resources;
+	}
+
+	/**
+	 * Refresh cached extension command+shortcut diagnostics from the connection's
+	 * extension surface. Daemon transports degrade to an empty list because their
+	 * surface members throw AgentConnectionUnsupportedError (PR3 covers the wire).
+	 */
+	private async refreshExtensionRuntimeDiagnostics(): Promise<void> {
+		if (!this.bindLocalSessionExtensions) {
+			this.extensionRuntimeDiagnostics = [];
+			return;
+		}
+		const [commandDiagnostics, shortcutDiagnostics] = await Promise.all([
+			this.tryExtensionSurfaceAsync(() => this.agentConnection.extensions.getCommandDiagnostics(), []),
+			this.tryExtensionSurfaceAsync(() => this.agentConnection.extensions.getShortcutDiagnostics(), []),
+		]);
+		this.extensionRuntimeDiagnostics = [...commandDiagnostics, ...shortcutDiagnostics];
 	}
 
 	private refreshHeartbeatCatalog(): Promise<void> {
@@ -2777,9 +2826,6 @@ export class InteractiveMode {
 	private async rebindCurrentSession(): Promise<void> {
 		this.unsubscribe?.();
 		this.unsubscribe = undefined;
-		if (this.localSessionHost) {
-			this.uiServices = this.localSessionHost.createUiServices();
-		}
 		this.toolDefinitionCache.clear();
 		this.applyRuntimeSettings();
 		if (this.bindLocalSessionExtensions) {
@@ -2927,10 +2973,14 @@ export class InteractiveMode {
 		if (this.toolDefinitionCache.has(toolName)) {
 			return this.toolDefinitionCache.get(toolName);
 		}
+		const rendererDefinition = await this.tryExtensionSurfaceAsync(
+			() => this.agentConnection.extensions.getToolRendererDefinition(toolName),
+			undefined,
+		);
 		const definition = this.createToolExecutionDefinition(
 			toolName,
 			await this.agentConnection.getToolDefinition(toolName),
-			this.localSessionHost?.getToolRendererDefinition(toolName),
+			rendererDefinition,
 		);
 		this.toolDefinitionCache.set(toolName, definition);
 		return definition;
@@ -3007,7 +3057,7 @@ export class InteractiveMode {
 	private createToolExecutionDefinition(
 		toolName: string,
 		connectionDefinition: AgentConnectionToolDefinition | undefined,
-		localRendererDefinition: InteractiveModeLocalToolRendererDefinition | undefined,
+		localRendererDefinition: AgentConnectionToolRendererDefinition | undefined,
 	): ToolExecutionDefinition | undefined {
 		if (!connectionDefinition && !localRendererDefinition) {
 			return undefined;
@@ -3042,10 +3092,14 @@ export class InteractiveMode {
 		}
 		await Promise.all(
 			missingToolNames.map(async (toolName) => {
+				const rendererDefinition = await this.tryExtensionSurfaceAsync(
+					() => this.agentConnection.extensions.getToolRendererDefinition(toolName),
+					undefined,
+				);
 				const definition = this.createToolExecutionDefinition(
 					toolName,
 					await this.agentConnection.getToolDefinition(toolName),
-					this.localSessionHost?.getToolRendererDefinition(toolName),
+					rendererDefinition,
 				);
 				this.toolDefinitionCache.set(toolName, definition);
 			}),
@@ -3055,21 +3109,22 @@ export class InteractiveMode {
 	/**
 	 * Set up keyboard shortcuts registered by extensions.
 	 */
-	private setupExtensionShortcuts(extensionRunner: ExtensionRunner): void {
-		const shortcuts = extensionRunner.getShortcuts(this.keybindings.getEffectiveConfig());
-		if (shortcuts.size === 0) return;
+	private setupExtensionShortcuts(): void {
+		const shortcuts = this.extensionKeyboardShortcuts;
+		if (shortcuts.size === 0) {
+			this.defaultEditor.onExtensionShortcut = undefined;
+			return;
+		}
 
-		// Create a context for shortcut handlers
-		const localSessionHost = this.getLocalSessionHost();
 		const createContext = (): ExtensionContext => ({
 			ui: this.createExtensionUIContext(),
 			hasUI: true,
 			cwd: this.getCurrentCwd(),
-			sessionManager: localSessionHost.getSessionManager(),
+			sessionManager: this.agentConnection.getReadonlySessionManager(),
 			modelRegistry: this.modelRegistry,
 			model: this.getCurrentModel(),
 			isIdle: () => !this.isAgentStreaming(),
-			signal: localSessionHost.getAbortSignal(),
+			signal: this.agentConnection.getAbortSignal(),
 			abort: () => this.agentConnection.abort(),
 			hasPendingMessages: () => this.getQueuedActionCount() > 0,
 			shutdown: () => {
@@ -3087,15 +3142,12 @@ export class InteractiveMode {
 					}
 				})();
 			},
-			getSystemPrompt: () => localSessionHost.getSystemPrompt(),
+			getSystemPrompt: () => this.agentConnection.getSystemPromptSync(),
 		});
 
-		// Set up the extension shortcut handler on the default editor
 		this.defaultEditor.onExtensionShortcut = (data: string) => {
 			for (const [shortcutStr, shortcut] of shortcuts) {
-				// Cast to KeyId - extension shortcuts use the same format
 				if (matchesKey(data, shortcutStr as KeyId)) {
-					// Run handler async, don't block input
 					Promise.resolve(shortcut.handler(createContext())).catch((err) => {
 						this.showError(`Shortcut handler error: ${err instanceof Error ? err.message : String(err)}`);
 					});
@@ -3104,6 +3156,17 @@ export class InteractiveMode {
 			}
 			return false;
 		};
+	}
+
+	private async refreshExtensionKeyboardShortcuts(): Promise<void> {
+		if (!this.bindLocalSessionExtensions) {
+			this.extensionKeyboardShortcuts = new Map();
+			return;
+		}
+		this.extensionKeyboardShortcuts = this.tryExtensionSurface(
+			() => this.agentConnection.extensions.getKeyboardShortcuts(this.keybindings.getEffectiveConfig()),
+			new Map(),
+		);
 	}
 
 	/**
@@ -5086,6 +5149,14 @@ export class InteractiveMode {
 					}
 				} else if (event.type === "heartbeats_changed") {
 					await this.refreshHeartbeatCatalog();
+				} else if (event.type === "client_notice") {
+					if (event.level === "error") {
+						this.showError(event.message);
+					} else {
+						this.showStatus(event.message, event.level === "warning" ? "warning" : "dim");
+					}
+				} else if (event.type === "client_set_editor_text") {
+					this.editor.setText(event.text);
 				} else if (event.type === "closed") {
 					this.showError(event.error ?? "Agent connection closed");
 				}
@@ -6241,9 +6312,13 @@ export class InteractiveMode {
 												: new CustomMessageComponent(
 														message,
 														this.bindLocalSessionExtensions
-															? this.getLocalSessionHost()
-																	.getExtensionRunner()
-																	.getMessageRenderer(message.customType)
+															? this.tryExtensionSurface(
+																	() =>
+																		this.agentConnection.extensions.getMessageRenderer(
+																			message.customType,
+																		),
+																	undefined,
+																)
 															: undefined,
 														this.getMarkdownThemeWithSettings(),
 													);
@@ -8193,11 +8268,9 @@ export class InteractiveMode {
 	): Promise<{ cancelled: boolean }> {
 		this.stopWorkingLoader();
 		try {
-			const result = options?.withSession
-				? await this.getLocalSessionHost().switchSession(sessionPath, {
-						withSession: options.withSession,
-					})
-				: await this.agentConnection.switchSession(sessionPath);
+			const result = await this.agentConnection.switchSession(sessionPath, {
+				withSession: options?.withSession,
+			});
 			if (result.cancelled) {
 				return result;
 			}
@@ -8211,12 +8284,10 @@ export class InteractiveMode {
 					this.showStatus("Resume cancelled");
 					return { cancelled: true };
 				}
-				const result = options?.withSession
-					? await this.getLocalSessionHost().switchSession(sessionPath, {
-							cwdOverride: selectedCwd,
-							withSession: options.withSession,
-						})
-					: await this.agentConnection.switchSession(sessionPath, { cwdOverride: selectedCwd });
+				const result = await this.agentConnection.switchSession(sessionPath, {
+					cwdOverride: selectedCwd,
+					withSession: options?.withSession,
+				});
 				if (result.cancelled) {
 					return result;
 				}
@@ -8589,8 +8660,8 @@ export class InteractiveMode {
 			await this.refreshConnectionCatalog();
 			this.setupAutocompleteProvider();
 			if (this.bindLocalSessionExtensions) {
-				const runner = this.getLocalSessionHost().getExtensionRunner();
-				this.setupExtensionShortcuts(runner);
+				await this.refreshExtensionKeyboardShortcuts();
+				this.setupExtensionShortcuts();
 			}
 			await this.rebuildChatFromMessages();
 			dismissReloadBox(this.editor as Component);
@@ -9558,9 +9629,7 @@ ${interrupt ? `| \`${interrupt}\` | Interrupt current operation |\n` : ""}${shor
 | mouse drag | Select and copy text |
 `;
 
-		const shortcuts = this.bindLocalSessionExtensions
-			? this.getLocalSessionHost().getExtensionRunner().getShortcuts(this.keybindings.getEffectiveConfig())
-			: undefined;
+		const shortcuts = this.bindLocalSessionExtensions ? this.extensionKeyboardShortcuts : undefined;
 		if (shortcuts && shortcuts.size > 0) {
 			hotkeys += `
 **Extensions**

--- a/packages/coding-agent/test/interactive-mode-boundary-awareness.test.ts
+++ b/packages/coding-agent/test/interactive-mode-boundary-awareness.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Behavioral boundary awareness: InteractiveMode must reach extension /
+ * session reads through AgentConnection, not InteractiveModeLocalSessionHost.
+ *
+ * Complements interactive-mode-boundary.test.ts (import lint) with a throwing
+ * fake that fails loudly if a migrated path still touches a host-only shape.
+ */
+import { describe, expect, test, vi } from "vitest";
+import type { AgentConnection, AgentConnectionExtensions } from "../src/modes/agent-connection/types.js";
+import { AgentConnectionUnsupportedError } from "../src/modes/agent-connection/types.js";
+
+function createThrowingFakeAgentConnection(
+	overrides: Partial<AgentConnection> & { extensions?: Partial<AgentConnectionExtensions> } = {},
+): AgentConnection {
+	const throwUnstubbed = (name: string): never => {
+		throw new Error(`FakeAgentConnection: unstubbed method ${name}`);
+	};
+
+	const extensions: AgentConnectionExtensions = {
+		getArgumentCompletions: async () => null,
+		getCommandDiagnostics: async () => [],
+		getShortcutDiagnostics: async () => [],
+		getShortcuts: async () => [],
+		getKeyboardShortcuts: () => new Map(),
+		getMessageRenderer: () => undefined,
+		getToolRendererDefinition: async () => undefined,
+		bindExtensions: async () => undefined,
+		...overrides.extensions,
+	};
+
+	const base = new Proxy({} as AgentConnection, {
+		get(_target, prop) {
+			if (prop === "extensions") return extensions;
+			if (prop === "then") return undefined;
+			if (typeof prop === "string" && prop in overrides) {
+				return (overrides as Record<string, unknown>)[prop];
+			}
+			return () => throwUnstubbed(String(prop));
+		},
+	});
+
+	return base;
+}
+
+describe("interactive-mode boundary awareness", () => {
+	test("createFakeAgentConnection throws on unstubbed methods", () => {
+		const fake = createThrowingFakeAgentConnection({
+			getAbortSignal: () => undefined,
+		});
+		expect(fake.getAbortSignal()).toBeUndefined();
+		expect(() => fake.getReadonlySessionManager()).toThrow(/unstubbed method getReadonlySessionManager/);
+	});
+
+	test("extensions surface is reachable without a local session host", async () => {
+		const bindExtensions = vi.fn(async () => undefined);
+		const getArgumentCompletions = vi.fn(async () => [{ value: "gpt", label: "gpt" }]);
+		const fake = createThrowingFakeAgentConnection({
+			extensions: {
+				bindExtensions,
+				getArgumentCompletions,
+				getCommandDiagnostics: async () => [],
+				getShortcutDiagnostics: async () => [],
+				getShortcuts: async () => [],
+				getKeyboardShortcuts: () => new Map(),
+				getMessageRenderer: () => undefined,
+				getToolRendererDefinition: async () => undefined,
+			},
+		});
+
+		await fake.extensions.bindExtensions({});
+		const completions = await fake.extensions.getArgumentCompletions("model", "g");
+		expect(bindExtensions).toHaveBeenCalledOnce();
+		expect(completions).toEqual([{ value: "gpt", label: "gpt" }]);
+	});
+
+	test("daemon-shaped unsupported errors are distinguishable", () => {
+		const error = new AgentConnectionUnsupportedError(
+			"extensions.bindExtensions requires DAEMON_PROTOCOL_VERSION >= 8",
+			"extensions.bindExtensions",
+		);
+		expect(error).toBeInstanceOf(AgentConnectionUnsupportedError);
+		expect(error.feature).toBe("extensions.bindExtensions");
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-boundary.test.ts
+++ b/packages/coding-agent/test/interactive-mode-boundary.test.ts
@@ -22,6 +22,16 @@ function expectNoImports(source: string, forbiddenModules: readonly string[]): v
 	}
 }
 
+function expectNoValueImports(source: string, forbiddenModules: readonly string[]): void {
+	for (const modulePath of forbiddenModules) {
+		// Allow `import type { ... } from "..."` — type-only coupling is fine for
+		// the connection contract. Forbid value imports that would pull runtime.
+		expect(source, `unexpected value import from ${modulePath}`).not.toMatch(
+			new RegExp(`import\\s+(?!type\\b)[^;]*from\\s+["']${escapeRegExp(modulePath)}["']`),
+		);
+	}
+}
+
 describe("InteractiveMode execution boundary", () => {
 	it("does not import core runtimes, sessions, session managers, or daemon transports", async () => {
 		const source = await readSource("modes/interactive/interactive-mode.ts");
@@ -39,13 +49,20 @@ describe("InteractiveMode execution boundary", () => {
 		]);
 	});
 
-	it("keeps local runtime/session imports out of the generic connection contract", async () => {
+	it("keeps local runtime/session value imports out of the generic connection contract", async () => {
 		const source = await readSource("modes/agent-connection/types.ts");
 
-		expectNoImports(source, [
+		expectNoValueImports(source, [
 			"../../core/agent-session.js",
 			"../../core/agent-session-runtime.js",
 			"../../core/session-manager.js",
+			"../daemon/daemon-client.js",
+			"../daemon/daemon-protocol.js",
+			"../daemon/daemon-socket.js",
+		]);
+		expectNoImports(source, [
+			"../../core/agent-session.js",
+			"../../core/agent-session-runtime.js",
 			"../daemon/daemon-client.js",
 			"../daemon/daemon-protocol.js",
 			"../daemon/daemon-socket.js",

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -1192,7 +1192,6 @@ describe("InteractiveMode connection events", () => {
 		) =>
 			({
 				unsubscribe: undefined,
-				localSessionHost: undefined,
 				toolDefinitionCache: { clear: vi.fn() },
 				applyRuntimeSettings: vi.fn(),
 				bindLocalSessionExtensions: true,


### PR DESCRIPTION
## Summary

PR2 of killing `InteractiveModeLocalSessionHost`. Migrates InteractiveMode call sites onto the widened `AgentConnection` seam from PR1.

## Changes

- InteractiveMode no longer accepts/holds `localSessionHost`
- Extension binding, completions, diagnostics, tool/message renderers, keyboard shortcuts go through `connection.extensions`
- Abort signal / readonly session / sync system prompt go through connection methods
- Session-swap `setup`/`withSession` become process-local optional hooks on connection options (daemon throws; prefer `seedMessages`/`afterReplace` for portable clients)
- `main.ts` passes `uiServices` directly via `createInteractiveModeUiServices`
- Behavioral boundary-awareness test with throwing fake; import-lint allows type-only `session-manager` imports on the connection contract

Host file still exists (deleted in PR3 along with the protocol v8 bump).

## Test plan

- [x] `test/interactive-mode-boundary-awareness.test.ts`
- [x] `test/interactive-mode-boundary.test.ts`
- [x] `test/agent-connection-in-process.test.ts`
- [x] `test/agent-connection-daemon.test.ts` (65 tests)
- [x] `npm run check` (pre-commit)

Depends on #1 (`feat/c1-connection-types`).