### PR TITLE
docs(web): document the packages vs web/ split

### DIFF
--- a/.react-doctor/false-positives.md
+++ b/.react-doctor/false-positives.md
@@ -5,7 +5,7 @@ authoritative suppression lives in `doctor.config.jsonc` (`ignore.overrides`);
 this file records the evidence so future agent triage runs do not relitigate
 these findings.
 
-## Waiver 1 — `effect-needs-cleanup` @ `apps/web/src/lib/pi/use-pi-chat.ts:384`
+## Waiver 1 — `effect-needs-cleanup` @ `web/app/src/lib/pi/use-pi-chat.ts:384`
 
 - **Rule:** `react-doctor/effect-needs-cleanup` (severity: error)
 - **Predicate the detector claims:** "`EventSource` creates a connection in
@@ -20,7 +20,7 @@ these findings.
   Q6). Review condition: re-verify if the reconnect logic moves outside the
   effect or `source` stops being the closure's latest binding.
 
-## Waiver 2 — `effect-needs-cleanup` @ `packages/web-design/src/hooks/use-proximity-hover.ts:90`
+## Waiver 2 — `effect-needs-cleanup` @ `web/design/src/hooks/use-proximity-hover.ts:90`
 
 - **Rule:** `react-doctor/effect-needs-cleanup` (severity: error)
 - **Predicate the detector claims:** "`observe` creates a subscription in a
@@ -35,7 +35,7 @@ these findings.
   Q6). Review condition: re-verify if the per-index registry or the unmount
   effect is removed.
 
-## Waiver 3 — `no-multi-comp` @ `packages/web-design/src/components/openui/charts.tsx`
+## Waiver 3 — `no-multi-comp` @ `web/design/src/components/openui/charts.tsx`
 
 - **Rule:** `react-doctor/no-multi-comp` (severity: warning).
 - **Predicate the detector claims:** the two chart components should be split
@@ -49,7 +49,7 @@ these findings.
   if a third independent chart family or unrelated UI component is added to
   `charts.tsx`.
 
-## Waiver 4 — `no-loading-flag-reset-outside-finally` @ `packages/web-design/src/components/fleet-pi/pi/workspace-panel.tsx:161`
+## Waiver 4 — `no-loading-flag-reset-outside-finally` @ `web/design/src/components/fleet-pi/pi/workspace-panel.tsx:161`
 
 - **Rule:** `react-doctor/no-loading-flag-reset-outside-finally` (severity:
   warning).
@@ -64,7 +64,7 @@ these findings.
 - **Outcome:** waived with evidence, 2026-08-11. Review condition: re-verify
   if the reset moves out of `finally` or cancellation semantics change.
 
-## Waiver 5 — `js-set-map-lookups` @ `packages/web-design/src/components/fleet-pi/pi/config-panel/sections/add-models-dialog.tsx:59`
+## Waiver 5 — `js-set-map-lookups` @ `web/design/src/components/fleet-pi/pi/config-panel/sections/add-models-dialog.tsx:59`
 
 - **Rule:** `react-doctor/js-set-map-lookups` (severity: warning).
 - **Predicate the detector claims:** an `includes()` call inside candidate-model

--- a/.react-doctor/intentional-exceptions.md
+++ b/.react-doctor/intentional-exceptions.md
@@ -7,7 +7,7 @@ corresponding narrow scanner overrides are in `doctor.config.jsonc`.
 ## 1. WorkspacePanel selected-path reconciliation
 
 `WorkspacePanelContent` intentionally supports both controlled and uncontrolled
-selection. In controlled mode, `apps/web` owns the selected path so assistant
+selection. In controlled mode, `web/app` owns the selected path so assistant
 and file-navigation actions can coordinate the workspace and artifacts panels.
 After a workspace refresh, the selection effect clears a path that is no longer
 present or falls outside the active scope, together with its preview and preview
@@ -16,7 +16,7 @@ error.
 This is not a detector false positive. Moving this ownership requires a
 purposeful parent-state redesign that changes the workspace tree source and its
 selection owner together. That work would also touch the currently user-modified
-`apps/web/src/routes/index.tsx`, so it is deliberately deferred.
+`web/app/src/routes/index.tsx`, so it is deliberately deferred.
 
 **Re-evaluate:** when the selection owner and workspace tree source are
 redesigned together.
@@ -44,10 +44,9 @@ The following side-effect-free modules form a coherent future authentication and
 mode-selection surface and are retained by explicit user direction while OpenUI
 is expanded alongside the current chat interface:
 
-- `packages/web-design/src/components/agent-elements/input/mode-selector.tsx`
-- `packages/web-design/src/components/fleet-pi/auth/login-page.tsx`
-- `packages/web-design/src/components/fleet-pi/icons/google-icon.tsx`
-- `packages/web-design/src/components/fleet-pi/primitives/centered-loader.tsx`
+- `web/design/src/components/agent-elements/input/mode-selector.tsx`
+- `web/design/src/components/fleet-pi/icons/google-icon.tsx`
+- `web/design/src/components/fleet-pi/primitives/centered-loader.tsx`
 
 **Re-evaluate:** when that integration either imports these modules or removes
 the future surface intentionally.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,19 +7,35 @@
 - No emojis in commits, issues, PR comments, or code
 - Technical prose only, be kind but direct (e.g., "Thanks @user" not "Thanks so much @user!")
 
-## Web adapter (`../web/`)
+## Web interface (`web/`)
 
-- The prime-agent web frontend lives outside this repo at `../web/`. It drives
-  `@earendil-works/pi-coding-agent` via `createAgentSession()` and
-  `ExtensionUIContext` (see `../web/server/prime-bridge.ts`).
-- When a change in `packages/coding-agent` touches the public surface the web
-  adapter consumes — `createAgentSession`, `AgentSessionEvent`, `ExtensionUIContext`,
-  `IpythonKernelProvisioner`, `SessionManager` — update
-  `../web/server/event-mapper.ts` and/or `../web/server/prime-bridge.ts` in the
-  same change.
-- Chat wire contract lives in `../web/packages/protocol/src/chat-protocol.ts`;
-  the web side translates `AgentSessionEvent → ChatStreamEvent` in
-  `event-mapper.ts`.
+This repo's web UI is a standalone Qredence product. It is not merged into
+upstream `PrimeIntellect-ai/prime-agent`. In-tree `packages/coding-agent` is the
+backend; the web stack is the interface.
+
+- Interface: `web/app` (TanStack Start) + `web/design`
+- Adapter: `web/server` (`prime-bridge.ts`, `event-mapper.ts`, HTTP handlers)
+- Contract: `web/protocol/src/chat-protocol.ts`
+- Browser code talks HTTP (NDJSON + SSE) only. Do not import `@earendil-works/*`
+  from `web/app/src` or `web/design`.
+- When a change in `packages/coding-agent` touches the public surface the adapter
+  consumes — `createAgentSession`, `AgentSessionEvent`, `ExtensionUIContext`,
+  `IpythonKernelProvisioner`, `SessionManager` — update `web/server`
+  in the same change. Do not add web-specific exports to coding-agent.
+
+Prime Agent lives under `packages/` (npm workspaces). The Qredence UI lives
+under `web/` (pnpm workspace). Merge `PrimeIntellect-ai/prime-agent` into
+`packages/{ai,agent,tui,coding-agent}` only — never into `web/`.
+
+Install: `npm install` at the repo root, then `pnpm install` in `web/`. Never
+`npm install` inside `web/`, and never `pnpm install` at the repo root.
+pnpm 11 settings live in `web/pnpm-workspace.yaml` (not `.npmrc`).
+
+`web/server` links `@earendil-works/*` with pnpm `link:` (not `file:`) so
+nested agent deps resolve through the root npm tree. Do not add
+`packages/{ai,agent,tui,coding-agent}` to `web/pnpm-workspace.yaml`.
+
+Dev: `pnpm --dir web --filter @prime-agent/web dev` (or `npm run dev:web`).
 
 ## Code Quality
 

--- a/README.md
+++ b/README.md
@@ -2,22 +2,22 @@
 
 A self-improving RLM (Recursive Language Model) coding and research agent. It ships as a web chat interface, a terminal UI, and a headless daemon — all three drive the same core session runtime (`@earendil-works/pi-coding-agent`) through a single typed connection seam.
 
-The **web chat interface** is the primary surface: a React 19 chat application (`apps/web`) that streams agent turns over NDJSON, pushes out-of-turn events over SSE, and renders every model action — IPython cells, shell commands, file edits, plans, subagent runs, and interactive questions — as dedicated UI cards.
+The **web chat interface** is the primary surface: a React 19 chat application (`web/app`) that streams agent turns over NDJSON, pushes out-of-turn events over SSE, and renders every model action — IPython cells, shell commands, file edits, plans, subagent runs, and interactive questions — as dedicated UI cards.
 
 ## Web chat interface
 
 Run it with a single command:
 
 ```bash
-npm run dev -w @prime-agent/web
+pnpm --dir web --filter @prime-agent/web dev
 ```
 
-Open http://127.0.0.1:3000. The browser talks to a single-process Node dev server (TanStack Start + Vite) which drives the coding-agent runtime through `PrimeBridge` (`apps/web/server/prime-bridge.ts`): one bridge per process, one `AgentSession` per chat session, with the IPython kernel provisioned per working directory.
+Open http://127.0.0.1:3000. The browser talks to a single-process Node dev server (TanStack Start + Vite) which drives the coding-agent runtime through `PrimeBridge` (`web/server/src/prime-bridge.ts`): one bridge per process, one `AgentSession` per chat session, with the IPython kernel provisioned per working directory.
 
 ### Conversation
 
 - **Turn-based timeline** — messages are grouped into user→assistant turns; the latest turn streams in place with a "Processing…" shimmer placeholder and a breathing space that keeps the input bar in view while the agent works.
-- **Streaming markdown** — assistant text renders through the generative text renderer (`packages/web-design/src/components/openui/`) with syntax-highlighted code.
+- **Streaming markdown** — assistant text renders through the generative text renderer (`web/design/src/components/openui/`) with syntax-highlighted code.
 - **Live activity line** — a composer loader above the input shows the current activity ("Running cell…", plan progress, queue state for steering/follow-up turns).
 - **Copy toolbars** — hover-copy for user messages and whole assistant turns, with timestamps.
 - **Auto-scroll** — pinned to the latest message, with reduced-motion support.
@@ -33,7 +33,7 @@ Open http://127.0.0.1:3000. The browser talks to a single-process Node dev serve
 
 ### Tool cards
 
-Every tool call the agent makes lands as a card with a lifecycle (`input-streaming → output-available | output-error`), rendered by `packages/web-design/src/components/agent-elements/tools/`:
+Every tool call the agent makes lands as a card with a lifecycle (`input-streaming → output-available | output-error`), rendered by `web/design/src/components/agent-elements/tools/`:
 
 | Tool | Card |
 | --- | --- |
@@ -65,7 +65,7 @@ Every tool call the agent makes lands as a card with a lifecycle (`input-streami
 
 ## Repository layout
 
-npm-workspace monorepo (all packages share one version):
+npm-workspace for Prime Agent (`packages/*`); pnpm workspace for the Qredence UI (`web/`):
 
 | Path | Package | Purpose |
 | --- | --- | --- |
@@ -73,17 +73,19 @@ npm-workspace monorepo (all packages share one version):
 | `packages/agent` | `@earendil-works/pi-agent-core` | Core agent session runtime |
 | `packages/coding-agent` | `@earendil-works/pi-coding-agent` | Coding agent CLI, SDK entry point, and daemon |
 | `packages/tui` | `@earendil-works/pi-tui` | Terminal UI |
-| `packages/web-protocol` | `@prime-agent/web-protocol` | Web wire contract (`ChatStreamEvent`, zod schemas, provider catalog) |
-| `packages/web-design` | `@prime-agent/web-design` | Shared web chat components and tool renderers |
-| `apps/web` | `@prime-agent/web` | Web chat frontend plus Node server (PrimeBridge) |
+| `web/protocol` | `@prime-agent/web-protocol` | Web wire contract (`ChatStreamEvent`, zod schemas, provider catalog) |
+| `web/design` | `@prime-agent/web-design` | Shared web chat components and tool renderers |
+| `web/server` | `@prime-agent/web-server` | HTTP adapter (`PrimeBridge`, event mapper, handlers) |
+| `web/app` | `@prime-agent/web` | Web chat frontend (TanStack Start host) |
 | `prime-agent-runtime` | — | Python IPython kernel shim (requires Python >= 3.10) |
 
-The web frontend (`apps/web`) and its shared UI kit (`packages/web-design`) import chat components from `packages/web-protocol` (types + zod schemas); the `fleet-pi` chat shell in `web-design` composes the reusable `agent-elements` layer (message list, input bar, tool renderers) and the openui text renderer.
+The web frontend (`web/app`) and its UI kit (`web/design`) import the wire contract from `web/protocol`; `web/server` is the only web package that imports `@earendil-works/*`. Install Prime Agent with npm at the repo root, then the UI with `pnpm install` in `web/`.
 
 ## Requirements
 
 - Node.js >= 22.8.0
-- npm >= 11.10 (enforces the 7-day minimum release age for dependency updates; older npm silently ignores it)
+- npm >= 11.10 (enforces the 7-day minimum release age for Prime Agent dependency updates; older npm silently ignores it)
+- pnpm >= 11 (Qredence UI under `web/`; `minimumReleaseAge: 10080` in `web/pnpm-workspace.yaml`)
 - Python >= 3.10 (only needed for the IPython runtime — `prime-agent-runtime`)
 
 ## Getting started
@@ -92,12 +94,13 @@ Install workspace dependencies:
 
 ```bash
 npm ci
+pnpm install --dir web
 ```
 
 ### Web chat
 
 ```bash
-npm run dev -w @prime-agent/web
+pnpm --dir web --filter @prime-agent/web dev
 ```
 
 Open http://127.0.0.1:3000. Install the Python runtime shim for full kernel functionality:
@@ -178,9 +181,9 @@ API surface:
 | POST | `/api/workspace/root` | Set the workspace root |
 | GET | `/api/health` | Liveness + kernel readiness |
 
-The event mapper (`apps/web/server/event-mapper.ts`) is a pure function `AgentSessionEvent → ChatStreamEvent[]`; tool names pass through `toPascalCase` (`tool-IPython`, `tool-Bash`, `tool-Edit`, `tool-Thinking`, …). Tool renderers live in `packages/web-design/src/components/agent-elements/tools/` and dispatch on `part.type`.
+The event mapper (`web/server/src/event-mapper.ts`) is a pure function `AgentSessionEvent → ChatStreamEvent[]`; tool names pass through `toPascalCase` (`tool-IPython`, `tool-Bash`, `tool-Edit`, `tool-Thinking`, …). Tool renderers live in `web/design/src/components/agent-elements/tools/` and dispatch on `part.type`.
 
-Current limitations (v2): no daemon-backed attach (in-process connection), no multi-user auth (binds to `127.0.0.1` with no tokens), partial workspace tree/reads, and some settings endpoints are stubs. See `apps/web/ARCHITECTURE.md` for details.
+Current limitations: no daemon-backed attach (in-process connection), no multi-user auth (binds to `127.0.0.1` with no tokens), and pending dialogs are not persisted across restart. See `web/app/ARCHITECTURE.md` for details.
 
 ## Documentation
 
@@ -188,13 +191,14 @@ Current limitations (v2): no daemon-backed attach (in-process connection), no mu
 - `packages/coding-agent/docs/quickstart.md` — install, authenticate, run a first session
 - `packages/coding-agent/docs/rlm.md` — RLM programming model, IPython, subagents, skills, trust model
 - `packages/coding-agent/docs/development.md` — build and run from source
-- `apps/web/ARCHITECTURE.md` — web chat architecture
+- `web/app/ARCHITECTURE.md` — web chat architecture
 - `AGENTS.md` — contribution rules and required validation
 
 ## Development
 
 ```bash
-npm ci                  # Install workspace dependencies
+npm ci                  # Install Prime Agent (packages/*)
+pnpm install --dir web  # Install Qredence UI
 npm run check           # Format, lint, type-check, installer/browser-smoke/rendering checks (does not run tests)
 ```
 

--- a/web/app/ARCHITECTURE.md
+++ b/web/app/ARCHITECTURE.md
@@ -1,0 +1,113 @@
+# Prime-Agent Web Architecture
+
+Standalone Qredence web UI for in-tree Prime Agent (`packages/coding-agent`).
+The UI is not merged into `PrimeIntellect-ai/prime-agent`. `web/app` is the
+TanStack Start host; `web/server` is the only web package that imports
+`@earendil-works/*`. Install the UI with pnpm (`web/`); Prime Agent stays on npm.
+
+## Process boundary
+
+```
+browser ─ EventSource/fetch ─▶ TanStack Start (web/app /api routes)
+                                   │  thin wrappers
+                                   ▼
+                         web/server handlers
+                                   │
+                                   ▼
+                              PrimeBridge
+                                   │  (1 instance per Node process — singleton.ts)
+                                   ├─ sessions: Map<sessionId, BridgeSession>
+                                   ├─ ringBuffers: Map<sessionId, RingBuffer>   (500 frames)
+                                   ├─ pendingDialogs: PendingDialogRegistry     (60s timeout)
+                                   └─ kernelReady: Promise<void>                (IpythonKernelProvisioner.ensure)
+                                             │
+                                             ▼
+                              packages/coding-agent
+                                   │
+                                   ├─ createAgentSession({cwd}) ─▶ AgentSession
+                                   ├─ SessionManager.list/openAsync ─▶ JSONL transcripts
+                                   └─ IpythonKernelProvisioner ─▶ Jupyter kernel readiness
+```
+
+The bridge binds an `ExtensionUIContext` per session. `confirm/select/input`
+become `tool-Question` frames + pending-dialog promises resolved via
+`POST /api/chat/question`. `notify/setStatus/setWidget` become `state` frames.
+Sessions subscribe via `session.subscribe(mapAgentSessionEvent)` → ring buffer
+→ listeners.
+
+## Wire surface
+
+NDJSON-over-POST for streaming a turn (`POST /api/chat`), SSE for out-of-turn
+pushes (`GET /api/chat/events?sessionId=`, ring-buffer replay with
+`Last-Event-ID`). After a 0.5s+ drop, the client reconnects with the last seq
+and the server replays missed frames; overflow emits a `state: resync-required`
+frame so the UI falls back to `GET /api/chat/session`.
+
+Optional `VITE_FLEET_PI_CHAT_RUNTIME_URL` points the browser at a remote
+runtime; handlers are process-agnostic `Request → Response` functions.
+
+| Method | Path                       | Purpose                                       |
+| ------ | -------------------------- | --------------------------------------------- |
+| POST   | /api/chat                  | Run a turn, returns NDJSON `ChatStreamEvent`  |
+| POST   | /api/chat/abort            | Abort + cancel pending dialogs                |
+| POST   | /api/chat/question         | Answer a pending dialog                       |
+| POST   | /api/chat/new              | Create session (`{cwd,model?,thinkingLevel?}`)|
+| POST   | /api/chat/resume           | Resume by `sessionId` / `sessionFile`         |
+| POST   | /api/chat/model            | `session.setModel()`                          |
+| GET    | /api/chat/session          | One session + messages                        |
+| GET    | /api/chat/sessions?cwd?=   | Session picker                                |
+| GET    | /api/chat/models           | `ModelRegistry.getAll()`                      |
+| GET    | /api/chat/settings         | Resolved settings                             |
+| PATCH  | /api/chat/settings         | Persist settings via `SettingsManager`        |
+| GET    | /api/chat/providers        | Provider catalog + credentials                |
+| GET    | /api/chat/resources        | Skills, prompts, extensions                   |
+| GET    | /api/chat/commands         | Slash command autocomplete                    |
+| POST   | /api/chat/models/discover  | OCC `/v1/models` probe                        |
+| GET    | /api/workspace/tree        | Workspace file tree                           |
+| GET    | /api/workspace/file        | File preview                                  |
+| GET    | /api/workspace/browse      | Directory picker                              |
+| POST   | /api/workspace/root        | Rebind default cwd                            |
+| GET    | /api/chat/events           | SSE + ring-buffer replay                      |
+| GET    | /api/health                | Liveness + kernel readiness                   |
+
+## Mapper
+
+`web/server/src/event-mapper.ts` is a pure function `AgentSessionEvent →
+ChatStreamEvent[]`. Tool names pass through `toPascalCase` with `IPython` and
+short-acronym special-casing, producing `tool-IPython | tool-Bash | tool-Edit |
+tool-Thinking | …`. All tool parts land on `ChatToolPart.state: input-streaming
+→ output-available | output-error`.
+
+## Tool renderers
+
+`web/design/src/components/agent-elements/tools/` dispatches on
+`part.type`:
+
+- `tool-IPython` → `ipython-tool.tsx`
+- `tool-Bash`, `tool-Edit` → bash/edit cards
+- `tool-Thinking`, `tool-TodoWrite`, `tool-PlanWrite`, `tool-Task`, `tool-Agent`,
+  `tool-Question`, `tool-WebSearch|Grep|Glob`
+- everything else → `GenericTool` from `toolRegistry`
+
+`PI_TOOL_RENDERERS` is an empty table so the chat shell stays type-safe without
+forking default renderers.
+
+## Client SSE flow
+
+`usePiChat` opens one `EventSource` per in-flight `sessionId`. The NDJSON turn
+stream remains authoritative during an active turn (frames are skipped by the
+SSE handler when `status === "streaming" | "submitted"`); out-of-turn pushes
+(`tool-Question` requests, `state` frames for `notify`/`setStatus`,
+`ipython_sent_agent_message`) are applied to the same reducer.
+
+`Last-Event-ID` sequence numbers persist in `sessionStorage` so a page reload
+resumes the SSE cursor without a server round-trip; session-reload requests
+continue through `chatClient.resumeSession` (fetches history) *plus* the SSE
+replay (delivers frames emitted while the tab was closed).
+
+## Gaps
+
+- No daemon-backed attach (`AgentConnection`). Web uses in-process
+  `createAgentSession` via the HTTP adapter.
+- Pending dialogs are not persisted across server restart.
+- No multi-user auth (binds to `127.0.0.1`, no tokens).


### PR DESCRIPTION
## Summary
- Document the two-tree layout: Prime Agent stays on npm under `packages/`; the Qredence UI lives under `web/` as its own pnpm workspace.
- Update AGENTS.md, README, `web/app/ARCHITECTURE.md`, and react-doctor waiver paths.

## Test plan
- [ ] Paths in AGENTS.md match `web/app`, `web/design`, `web/server`, `web/protocol`
- [ ] README install/dev commands use `pnpm --dir web`
