### PR TITLE
fix(web): harden chat against XSS, stale sessions, and a11y gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ packages/*/dist-firefox/
 *.swo
 *~
 
+.agents/skills
 # Package specific
 .npm/
 coverage/

--- a/.react-doctor/intentional-exceptions.md
+++ b/.react-doctor/intentional-exceptions.md
@@ -64,3 +64,19 @@ rather than silently breaking external TypeScript consumers in a minor release.
 
 **Re-evaluate:** at the next documented major-version migration, when flat props
 can be deprecated and removed with a published replacement guide.
+
+## 5. Reserved client plan-mode state machine
+
+`web/app/src/lib/pi/plan-state.ts` still exports the client-side plan-mode
+helpers (`restorePlanState`, `applyPlanModeSelection`,
+`updatePlanStateFromAssistantText`, `updatePlanExecutionProgress`,
+`createPlanEvent`, `createPlanToolPart`, `bindPendingPlanDecisionToolCallId`,
+`resolvePlanDecision`). Live callers currently import only
+`isPlanDecisionToolCall`. The rest is retained as the reserved state machine
+for wiring plan mode in the web UI.
+
+This is not a detector false positive. Deleting the unused exports would remove
+the plan-mode client model before that integration lands.
+
+**Re-evaluate:** when the helpers are imported by the chat session owner, or
+when plan mode is removed from the web client on purpose.

--- a/doctor.config.jsonc
+++ b/doctor.config.jsonc
@@ -94,6 +94,13 @@
 					"src/components/fleet-pi/primitives/centered-loader.tsx"
 				],
 				"rules": ["deslop/unused-file"]
+			},
+			{
+				// Intentional reserved client plan-mode state machine; see
+				// .react-doctor/intentional-exceptions.md §5. Live callers only
+				// import isPlanDecisionToolCall; the rest stays until wired.
+				"files": ["src/lib/pi/plan-state.ts"],
+				"rules": ["deslop/unused-export"]
 			}
 		]
 	}

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -20,7 +20,6 @@
     "@tanstack/react-query": "^5.101.1",
     "@tanstack/react-router": "^1.170.16",
     "@tanstack/react-start": "^1.168.26",
-    "@tanstack/router-plugin": "^1.168.18",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "tailwindcss": "^4.3.1",

--- a/web/app/src/lib/analytics-stub.ts
+++ b/web/app/src/lib/analytics-stub.ts
@@ -1,12 +1,6 @@
 // v1: no analytics. All imports of @/lib/analytics/posthog funnel through here.
 
-export function isAnalyticsEnabled(): boolean {
-	return false;
-}
-
 export function initAnalytics(): void {}
-
-export function trackEvent(_name: string, _properties?: Record<string, unknown>): void {}
 
 export function identifyAnalyticsUser(_user: unknown): void {}
 
@@ -29,8 +23,3 @@ export function captureConversationSaved(_input: {
 	cwd?: string;
 	messageCount?: number;
 }): void {}
-
-export const analytics = {
-	capture: (_name: string, _properties?: Record<string, unknown>) => {},
-	identify: (_id: string) => {},
-};

--- a/web/app/src/lib/auth-stub.ts
+++ b/web/app/src/lib/auth-stub.ts
@@ -6,18 +6,6 @@ export type AuthUser = {
 	email: string;
 };
 
-export function useAuth(): {
-	user: AuthUser | null;
-	isLoading: boolean;
-	isAuthenticated: boolean;
-} {
-	return {
-		user: null,
-		isLoading: false,
-		isAuthenticated: true,
-	};
-}
-
 export function useOptionalUser(): AuthUser | null {
 	return null;
 }
@@ -27,7 +15,5 @@ export function getChatAuthBearerToken(): string | null {
 }
 
 export function clearChatAuthBearerTokenCache(): void {}
-
-export async function signIn(_credentials?: unknown): Promise<void> {}
 
 export async function signOut(): Promise<void> {}

--- a/web/app/src/lib/pi/chat-message-helpers.ts
+++ b/web/app/src/lib/pi/chat-message-helpers.ts
@@ -78,39 +78,6 @@ export function createThinkingToolPart({
 	};
 }
 
-export function upsertThinkingPart(
-	parts: Array<ChatMessagePart>,
-	messageId: string,
-	thought: string,
-	options?: {
-		index?: number;
-		state?: string;
-	},
-) {
-	return upsertToolPart(
-		parts,
-		createThinkingToolPart({
-			messageId,
-			thought,
-			index: options?.index,
-			state: options?.state,
-		}),
-	);
-}
-
-export function finalizeThinkingToolParts(parts: Array<ChatMessagePart>) {
-	return parts.map((part) => {
-		if (part.type !== "tool-Thinking" || part.state !== "input-streaming") {
-			return part;
-		}
-
-		return {
-			...part,
-			state: "output-available",
-		};
-	});
-}
-
 export function appendAssistantDelta(messages: Array<ChatMessage>, assistantId: string, delta: string) {
 	return messages.map((message) => {
 		if (message.id !== assistantId) return message;

--- a/web/app/src/lib/pi/chat-panel.tsx
+++ b/web/app/src/lib/pi/chat-panel.tsx
@@ -3,56 +3,78 @@ import { FleetPiAgentChat } from "@prime-agent/web-design/components/fleet-pi/ch
 import type { FleetPiAgentChatProps } from "@prime-agent/web-design/components/fleet-pi/chat/fleet-pi-agent-chat"
 import type { ChatMessage, ChatStatus } from "@prime-agent/web-protocol/chat-types"
 import type { QuestionAnswer } from "@prime-agent/web-design/components/agent-elements/question/question-prompt"
+import { useCallback, useMemo } from "react"
 
 type ChatPanelProps = {
-  messages: Array<ChatMessage>
-  status: ChatStatus
-  error: Error | undefined
-  inputSuggestionItems: FleetPiAgentChatProps["suggestions"]
-  suppressQuestionTool: boolean
-  inputBar: FleetPiAgentChatProps["inputBar"]
-  onSend: (text: string, altKey?: boolean) => void
-  onOpenUIAction: (text: string) => void
-  onStop: () => void
-  onQuestionAnswer: (input: {
-    toolCallId?: string
-    answer: QuestionAnswer
-  }) => void
+	messages: Array<ChatMessage>
+	status: ChatStatus
+	error: Error | undefined
+	inputSuggestionItems: FleetPiAgentChatProps["suggestions"]
+	suppressQuestionTool: boolean
+	inputBar: FleetPiAgentChatProps["inputBar"]
+	onSend: (text: string, altKey?: boolean) => void
+	onOpenUIAction: (text: string) => void
+	onStop: () => void
+	onQuestionAnswer: (input: {
+		toolCallId?: string
+		answer: QuestionAnswer
+	}) => void
 }
 
 export function ChatPanel({
-  messages,
-  status,
-  error,
-  inputSuggestionItems,
-  suppressQuestionTool,
-  inputBar,
-  onSend,
-  onOpenUIAction,
-  onStop,
-  onQuestionAnswer,
+	messages,
+	status,
+	error,
+	inputSuggestionItems,
+	suppressQuestionTool,
+	inputBar,
+	onSend,
+	onOpenUIAction,
+	onStop,
+	onQuestionAnswer,
 }: ChatPanelProps) {
-  return (
-    <UiErrorBoundary>
-      <FleetPiAgentChat
-        messages={messages}
-        status={status}
-        onSend={(msg) => onSend(msg.content, msg.altKey)}
-        onOpenUIAction={(message) => onOpenUIAction(message)}
-        onStop={onStop}
-        questionTool={{
-          submitLabel: "Continue",
-          allowSkip: true,
-          onAnswer: ({ toolCallId, answer }) => {
-            void onQuestionAnswer({ toolCallId, answer })
-          },
-        }}
-        suppressQuestionTool={suppressQuestionTool}
-        error={error ?? undefined}
-        emptyStatePosition="default"
-        suggestions={inputSuggestionItems}
-        inputBar={inputBar}
-      />
-    </UiErrorBoundary>
-  )
+	const handleSend = useCallback(
+		(msg: { content: string; altKey?: boolean }) => {
+			onSend(msg.content, msg.altKey)
+		},
+		[onSend],
+	)
+	const handleOpenUIAction = useCallback(
+		(message: string) => {
+			onOpenUIAction(message)
+		},
+		[onOpenUIAction],
+	)
+	const handleQuestionAnswer = useCallback(
+		({ toolCallId, answer }: { toolCallId?: string; answer: QuestionAnswer }) => {
+			void onQuestionAnswer({ toolCallId, answer })
+		},
+		[onQuestionAnswer],
+	)
+	const questionTool = useMemo(
+		() => ({
+			submitLabel: "Continue",
+			allowSkip: true,
+			onAnswer: handleQuestionAnswer,
+		}),
+		[handleQuestionAnswer],
+	)
+
+	return (
+		<UiErrorBoundary>
+			<FleetPiAgentChat
+				messages={messages}
+				status={status}
+				onSend={handleSend}
+				onOpenUIAction={handleOpenUIAction}
+				onStop={onStop}
+				questionTool={questionTool}
+				suppressQuestionTool={suppressQuestionTool}
+				error={error ?? undefined}
+				emptyStatePosition="default"
+				suggestions={inputSuggestionItems}
+				inputBar={inputBar}
+			/>
+		</UiErrorBoundary>
+	)
 }

--- a/web/app/src/lib/pi/slash-commands.ts
+++ b/web/app/src/lib/pi/slash-commands.ts
@@ -201,12 +201,6 @@ export function resolveLocalSlashAction(command: string, args = ""): LocalSlashA
 	}
 }
 
-const WEB_BUILTIN_COMMAND_NAMES = new Set(WEB_BUILTIN_SLASH_COMMANDS.map((command) => command.name));
-
-export function isWebBuiltinSlashCommand(commandName: string) {
-	return WEB_BUILTIN_COMMAND_NAMES.has(commandName);
-}
-
 export type SlashCommandSuggestion = {
 	id: string;
 	label: string;

--- a/web/app/src/lib/pi/use-chat-workspace-data.ts
+++ b/web/app/src/lib/pi/use-chat-workspace-data.ts
@@ -1,3 +1,5 @@
+import type { QuestionAnswer } from "@prime-agent/web-design/components/agent-elements/question/question-prompt";
+import { notify } from "@prime-agent/web-design/lib/notify";
 import { type ChatModelOption, queueLabel, toModelOption } from "@prime-agent/web-design/lib/pi/chat-helpers";
 import type { ChatPiSettingsUpdate, ChatSettingsResponse } from "@prime-agent/web-protocol/chat-protocol";
 import { useQueryClient } from "@tanstack/react-query";
@@ -172,11 +174,18 @@ export function useChatWorkspaceData() {
 	});
 
 	const infoDescription = queueLabel(queue) ?? activityLabel ?? planLabel;
+	const handleQuestionAnswer = useCallback(
+		({ toolCallId, answer }: { toolCallId?: string; answer: QuestionAnswer }) => {
+			void answerQuestion({ toolCallId, answer }).catch((err) => {
+				const message = err instanceof Error ? err.message : String(err);
+				notify.error(message);
+			});
+		},
+		[answerQuestion],
+	);
 	const pendingQuestionBar = usePendingQuestionBar({
 		messages,
-		answerQuestion: ({ toolCallId, answer }) => {
-			void answerQuestion({ toolCallId, answer }).catch(() => undefined);
-		},
+		answerQuestion: handleQuestionAnswer,
 	});
 	const activeSessionLabel = useActiveSessionLabel({
 		activeSessionId: sessionMetadata.sessionId,
@@ -288,6 +297,7 @@ export function useChatWorkspaceData() {
 		commandPaletteOpen,
 		error,
 		handleLocalSlashSubmit,
+		handleQuestionAnswer,
 		handleResourceCanvasResizeStart,
 		handleSlashCommandSelect,
 		handleThemePreferenceChange,

--- a/web/app/src/lib/pi/use-pi-chat-messaging.ts
+++ b/web/app/src/lib/pi/use-pi-chat-messaging.ts
@@ -145,34 +145,39 @@ export function usePiChatMessaging({
 			setMessagesSynced((current) => [...current, userMessage]);
 			setError(null);
 
-			await client.streamMessage(
-				{
-					message: trimmed,
-					model,
-					sessionFile: sessionMetadataRef.current.sessionFile,
-					sessionId: sessionMetadataRef.current.sessionId,
-					streamingBehavior,
-				},
-				(event) => {
-					if (event.type === "queue") {
-						setQueueSynced({
-							steering: event.steering,
-							followUp: event.followUp,
-						});
-						setActivityLabelSynced(streamingBehavior === "steer" ? "Steered" : "Follow-up queued");
-					}
-					if (event.type === "error") {
-						throw new Error(event.message);
-					}
-				},
-			);
+			try {
+				await client.streamMessage(
+					{
+						message: trimmed,
+						model,
+						sessionFile: sessionMetadataRef.current.sessionFile,
+						sessionId: sessionMetadataRef.current.sessionId,
+						streamingBehavior,
+					},
+					(event) => {
+						if (event.type === "queue") {
+							setQueueSynced({
+								steering: event.steering,
+								followUp: event.followUp,
+							});
+							setActivityLabelSynced(streamingBehavior === "steer" ? "Steered" : "Follow-up queued");
+						}
+						if (event.type === "error") {
+							throw new Error(event.message);
+						}
+					},
+				);
 
-			// The steered message is queued server-side, but the `queue` event only
-			// ever lands on the *main* turn's NDJSON stream (which this POST didn't
-			// open). Refresh the sessions list so the queue badge in the shell
-			// reflects the just-steered item instead of waiting for the current
-			// turn to end. Cheap, one extra round-trip.
-			await refreshSessions();
+				// The steered message is queued server-side, but the `queue` event only
+				// ever lands on the *main* turn's NDJSON stream (which this POST didn't
+				// open). Refresh the sessions list so the queue badge in the shell
+				// reflects the just-steered item instead of waiting for the current
+				// turn to end. Cheap, one extra round-trip.
+				await refreshSessions();
+			} catch (err) {
+				setMessagesSynced((current) => current.filter((message) => message.id !== userMessage.id));
+				throw err;
+			}
 		},
 		[
 			client,

--- a/web/app/src/lib/pi/use-pi-chat-messaging.ts
+++ b/web/app/src/lib/pi/use-pi-chat-messaging.ts
@@ -167,16 +167,21 @@ export function usePiChatMessaging({
 						}
 					},
 				);
-
-				// The steered message is queued server-side, but the `queue` event only
-				// ever lands on the *main* turn's NDJSON stream (which this POST didn't
-				// open). Refresh the sessions list so the queue badge in the shell
-				// reflects the just-steered item instead of waiting for the current
-				// turn to end. Cheap, one extra round-trip.
-				await refreshSessions();
 			} catch (err) {
 				setMessagesSynced((current) => current.filter((message) => message.id !== userMessage.id));
 				throw err;
+			}
+
+			// The steered message is queued server-side, but the `queue` event only
+			// ever lands on the *main* turn's NDJSON stream (which this POST didn't
+			// open). Refresh the sessions list so the queue badge in the shell
+			// reflects the just-steered item instead of waiting for the current
+			// turn to end. Best-effort: a refresh failure must not roll back the
+			// optimistic message after streamMessage already succeeded.
+			try {
+				await refreshSessions();
+			} catch {
+				// Ignore — the queue submission already landed server-side.
 			}
 		},
 		[

--- a/web/app/src/lib/pi/use-pi-chat.ts
+++ b/web/app/src/lib/pi/use-pi-chat.ts
@@ -50,6 +50,7 @@ export function usePiChat(model: ChatModelSelection | undefined, options: UsePiC
 	const planLabelRef = useRef(planLabel);
 	const queueRef = useRef(queue);
 	const abortRef = useRef<AbortController | null>(null);
+	const statusRef = useRef(status);
 	const sendMessageRef = useRef<(input: SendMessageInput) => Promise<void>>(() => Promise.resolve());
 	const setMessagesSynced = useCallback(
 		(updater: Array<ChatMessage> | ((current: Array<ChatMessage>) => Array<ChatMessage>)) => {
@@ -175,6 +176,10 @@ export function usePiChat(model: ChatModelSelection | undefined, options: UsePiC
 	}, [sessionMetadata]);
 
 	useEffect(() => {
+		statusRef.current = status;
+	}, [status]);
+
+	useEffect(() => {
 		initialSessionMetadataRef.current = initialSessionMetadata;
 	}, [initialSessionMetadata]);
 
@@ -196,50 +201,47 @@ export function usePiChat(model: ChatModelSelection | undefined, options: UsePiC
 	}, [refreshSessions]);
 
 	useEffect(() => {
-		let cancelled = false;
-		const loadActiveSession = async () => {
-			abortRef.current?.abort();
-			abortRef.current = null;
-			setStatus("ready");
-			setError(null);
-			setQueueSynced(EMPTY_QUEUE_STATE);
-			setActivityLabelSynced(undefined);
-			setPlanLabelSynced(undefined);
-			setMessagesSynced([]);
+		const controller = new AbortController();
+		abortRef.current?.abort();
+		abortRef.current = null;
+		setStatus("ready");
+		setError(null);
+		setQueueSynced(EMPTY_QUEUE_STATE);
+		setActivityLabelSynced(undefined);
+		setPlanLabelSynced(undefined);
+		setMessagesSynced([]);
 
-			const storedSession = initialSessionMetadataRef.current;
-			const hasStoredSession = storedSession.sessionFile || storedSession.sessionId;
-			if (!hasStoredSession) {
-				setSessionMetadataSynced({});
-				return;
-			}
+		const storedSession = initialSessionMetadataRef.current;
+		const hasStoredSession = storedSession.sessionFile || storedSession.sessionId;
+		if (!hasStoredSession) {
+			setSessionMetadataSynced({});
+			return () => controller.abort();
+		}
 
-			const result = await client.loadSession(storedSession);
-			if (cancelled) return;
-			setSessionMetadataSynced(result.session);
-			setMessagesSynced(result.messages);
-			setActivityLabelSynced(result.sessionReset ? "Started a fresh Pi session" : undefined);
-		};
-
-		void loadActiveSession().catch(async (err) => {
-			if (cancelled) return;
-			if (
-				await tryRecoverForbiddenSession(err, recoverFromForbiddenSession, {
+		void client
+			.loadSession(storedSession)
+			.then((result) => {
+				if (controller.signal.aborted) return;
+				setSessionMetadataSynced(result.session);
+				setMessagesSynced(result.messages);
+				setActivityLabelSynced(result.sessionReset ? "Started a fresh Pi session" : undefined);
+			})
+			.catch((err) => {
+				if (controller.signal.aborted) return;
+				return tryRecoverForbiddenSession(err, recoverFromForbiddenSession, {
 					setError,
 					setStatus,
-				})
-			) {
-				return;
-			}
-
-			const nextError = err instanceof Error ? err : new Error(String(err));
-			setError(nextError);
-			setStatus("error");
-			notify.error(nextError.message);
-		});
+				}).then((recovered) => {
+					if (recovered || controller.signal.aborted) return;
+					const nextError = err instanceof Error ? err : new Error(String(err));
+					setError(nextError);
+					setStatus("error");
+					notify.error(nextError.message);
+				});
+			});
 
 		return () => {
-			cancelled = true;
+			controller.abort();
 		};
 	}, [
 		client,
@@ -374,7 +376,7 @@ export function usePiChat(model: ChatModelSelection | undefined, options: UsePiC
 				return;
 			}
 			// In-flight NDJSON stream is authoritative; only act on out-of-turn pushes.
-			const currentStatus = status;
+			const currentStatus = statusRef.current;
 			if (currentStatus === "streaming" || currentStatus === "submitted") return;
 			if (frame.type === "tool" && frame.part?.type === "tool-Question") {
 				setMessagesSynced((current) => {
@@ -406,9 +408,11 @@ export function usePiChat(model: ChatModelSelection | undefined, options: UsePiC
 				if (frame.state?.name === "agent_settled") {
 					// Server asked us to resync — refetch the session transcript and
 					// rebuild the UI state without spinning up a new turn.
+					const settledSessionId = sessionId;
 					void client
-						.loadSession({ sessionId })
+						.loadSession({ sessionId: settledSessionId })
 						.then((result) => {
+							if (sessionMetadataRef.current.sessionId !== settledSessionId) return;
 							setMessagesSynced(result.messages);
 							setSessionMetadataSynced(result.session);
 							setQueueSynced(EMPTY_QUEUE_STATE);
@@ -432,6 +436,7 @@ export function usePiChat(model: ChatModelSelection | undefined, options: UsePiC
 				params.set("lastEventId", String(lastEventId));
 			}
 			const url = resolveChatApiUrl(`/api/chat/events?${params}`);
+			source?.close();
 			source = new EventSource(url);
 			source.onmessage = (event) => {
 				const seq = Number.parseInt(event.lastEventId ?? "", 10);
@@ -446,6 +451,7 @@ export function usePiChat(model: ChatModelSelection | undefined, options: UsePiC
 				if (closedByEffect) return;
 				// Exponential-ish backoff, capped. EventSource does its own reconnect,
 				// but a manual retry makes timing deterministic for the dialog flow.
+				if (reconnectTimer) clearTimeout(reconnectTimer);
 				reconnectTimer = setTimeout(connect, 2_000);
 			};
 		};
@@ -459,7 +465,6 @@ export function usePiChat(model: ChatModelSelection | undefined, options: UsePiC
 	}, [
 		client,
 		sessionMetadata.sessionId,
-		status,
 		setActivityLabelSynced,
 		setMessagesSynced,
 		setQueueSynced,

--- a/web/app/src/routes/index.tsx
+++ b/web/app/src/routes/index.tsx
@@ -5,6 +5,7 @@ import { RightPanelShell } from "@prime-agent/web-design/components/fleet-pi/lay
 import { RightPanelProvider } from "@prime-agent/web-design/components/fleet-pi/layout/right-panel-context"
 import { ChatWorkspaceLayout } from "@prime-agent/web-design/components/fleet-pi/layout/chat-workspace-layout"
 import { SettingsDialog } from "@prime-agent/web-design/components/fleet-pi/pi/settings-dialog"
+import { useCallback } from "react"
 import { ChatPanel } from "@/lib/pi/chat-panel"
 import { useChatWorkspaceData } from "@/lib/pi/use-chat-workspace-data"
 
@@ -12,11 +13,11 @@ export const Route = createFileRoute("/")({ component: Chat })
 
 function ChatWorkspaceShell() {
   const {
-    answerQuestion,
     chatPanelData,
     commandPaletteOpen,
     error,
     handleLocalSlashSubmit,
+    handleQuestionAnswer,
     handleResourceCanvasResizeStart,
     handleSlashCommandSelect,
     handleThemePreferenceChange,
@@ -48,6 +49,26 @@ function ChatWorkspaceShell() {
     themePreference,
     workspaceTreeContext,
   } = useChatWorkspaceData()
+
+  const handleSend = useCallback(
+    (text: string, altKey?: boolean) => {
+      void sendMessage({ text, altKey })
+    },
+    [sendMessage],
+  )
+  const handleOpenUIAction = useCallback(
+    (message: string) => {
+      void sendMessage({ text: message, altKey: false })
+    },
+    [sendMessage],
+  )
+  const handleSettingsOpenChange = useCallback(
+    (open: boolean) => {
+      setSettingsDialogOpen(open)
+      if (!open) setSettingsInitialTab(undefined)
+    },
+    [setSettingsDialogOpen, setSettingsInitialTab],
+  )
 
   return (
     <>
@@ -106,22 +127,15 @@ function ChatWorkspaceShell() {
               modelPickerOpen,
               onModelPickerOpenChange: setModelPickerOpen,
             }}
-            onSend={(text, altKey) => sendMessage({ text, altKey })}
-            onOpenUIAction={(message) =>
-              sendMessage({ text: message, altKey: false })
-            }
+            onSend={handleSend}
+            onOpenUIAction={handleOpenUIAction}
             onStop={stop}
-            onQuestionAnswer={({ toolCallId, answer }) => {
-              void answerQuestion({ toolCallId, answer }).catch(() => undefined)
-            }}
+            onQuestionAnswer={handleQuestionAnswer}
           />
         </ChatWorkspaceLayout>
         <SettingsDialog
           open={settingsDialogOpen}
-          onOpenChange={(open) => {
-            setSettingsDialogOpen(open)
-            if (!open) setSettingsInitialTab(undefined)
-          }}
+          onOpenChange={handleSettingsOpenChange}
           initialTab={settingsInitialTab}
         />
       </RightPanelProvider>

--- a/web/design/scripts/openui-render-check.tsx
+++ b/web/design/scripts/openui-render-check.tsx
@@ -33,6 +33,7 @@ import {
 	stripOpenUIWrapper,
 } from "../src/components/openui/openui-utils";
 import type { OpenUIContentSegment } from "../src/components/openui/openui-utils";
+import { sanitizeChartColor } from "../src/components/chart";
 
 // --- happy-dom window + node globalThis shims ---
 const win = new Window();
@@ -123,7 +124,7 @@ const payload = [
 	'sel = Select("s", $s, [{"value": "a", "label": "A"}], "Pick")',
 	'sw = Switch("on", $on, "Toggle")',
 	'mdl = Modal("m", $on, "Confirm", "body text")',
-	'traffic = LineChart("Traffic", "Weekly visits", "week", [{"dataKey":"visits","label":"Visits"}], [{"week":"W1","visits":10},{"week":"W2","visits":24},{"week":"W3","visits":18}])',
+	'traffic = LineChart("Traffic", "Weekly visits", "week", [{"dataKey":"visits","label":"Visits","color":"red;}</style><img src=x onerror=alert(1)>"},{"dataKey":"views","label":"Views","color":"var(--chart-1)"}], [{"week":"W1","visits":10,"views":5},{"week":"W2","visits":24,"views":8},{"week":"W3","visits":18,"views":6}])',
 	'share = DonutChart("Share", null, [{"label":"Alpha","value":40},{"label":"Beta","value":60}], "100%")',
 	'scores = DataTable("Scores", [{"key":"name","label":"Name"},{"key":"points","label":"Points","type":"number"}], [{"name":"Ada","points":7},{"name":"Bo","points":12}])',
 	'kpis = MetricGroup([{"label":"Users","value":"12,403","delta":"+4.2%","deltaTone":"up","sparkline":[3,5,4,8,9]},{"label":"Errors","value":"3","delta":"-66%","deltaTone":"down"}])',
@@ -137,6 +138,21 @@ function assertIncludes(html: string, expected: string) {
 	} else {
 		console.error(`  FAIL html missing "${expected}"`);
 		failures += 1;
+	}
+}
+
+function styleTagContents(html: string): string {
+	return [...html.matchAll(/<style\b[^>]*>([\s\S]*?)<\/style>/gi)]
+		.map((match) => match[1] ?? "")
+		.join("\n");
+}
+
+function assertExcludes(html: string, unexpected: string, label: string) {
+	if (html.includes(unexpected)) {
+		console.error(`  FAIL ${label} — html contains ${JSON.stringify(unexpected)}`);
+		failures += 1;
+	} else {
+		console.log(`  PASS ${label}`);
 	}
 }
 
@@ -211,6 +227,14 @@ assertEqual(formatCurrency(12000), "$12,000", "formatCurrency(12000)");
 assertEqual(formatPercent(0.124), "12.4%", "formatPercent(0.124)");
 assertEqual(formatPercent(12.4), "12.4%", "formatPercent(12.4)");
 
+assertEqual(sanitizeChartColor("#3b82f6"), "#3b82f6", "sanitizeChartColor hex");
+assertEqual(sanitizeChartColor("var(--chart-1)"), "var(--chart-1)", "sanitizeChartColor CSS variable");
+assertEqual(
+	sanitizeChartColor("red;}</style><img src=x onerror=alert(1)>"),
+	undefined,
+	"sanitizeChartColor rejects style breakout",
+);
+
 assertEqual(cycleSortState("a", null), { key: "a", dir: "asc" }, 'cycleSortState("a", null)');
 assertEqual(
 	cycleSortState("a", { key: "a", dir: "asc" }),
@@ -282,9 +306,14 @@ if (staticHtml.length === 0) {
 }
 console.log("RENDER OK (static)");
 
-for (const expected of ["Traffic", "Weekly visits", "Share", "100%", "Scores", "Ada", "Bo", "Points", "Users", "12,403", "+4.2%", "Errors"]) {
+for (const expected of ["Traffic", "Weekly visits", "Share", "100%", "Scores", "Ada", "Bo", "Points", "Users", "12,403", "+4.2%", "Errors", "var(--chart-1)"]) {
 	assertIncludes(staticHtml, expected);
 }
+assertExcludes(
+	styleTagContents(staticHtml),
+	"</style><img",
+	"malicious chart color does not break out of <style>",
+);
 
 // --- Stage 3: DOM render in happy-dom (flushes effects; recharts SVG paints) ---
 let domHtml = "";
@@ -321,9 +350,15 @@ for (const expected of [
 	"12,403",
 	"+4.2%",
 	"Errors",
+	"var(--chart-1)",
 ]) {
 	assertIncludes(domHtml, expected);
 }
+assertExcludes(
+	styleTagContents(domHtml),
+	"</style><img",
+	"malicious chart color does not break out of <style> (dom)",
+);
 
 if (failures > 0) {
 	console.error(`${failures} assertion(s) failed`);

--- a/web/design/src/components/agent-elements/composer-loader.tsx
+++ b/web/design/src/components/agent-elements/composer-loader.tsx
@@ -40,8 +40,6 @@ export function ComposerLoader({
 
   return (
     <div
-      aria-live="polite"
-      aria-atomic="true"
       className={cn(
         "flex items-center gap-2 px-an-context-padding py-1 text-xs text-foreground/70",
         className
@@ -53,8 +51,18 @@ export function ComposerLoader({
       >
         {LOADER_DOTS[tick % LOADER_DOTS.length]}
       </span>
-      <span className="truncate">{label}</span>
-      <span className="tabular-nums text-foreground/50">{elapsed}s</span>
+      <span className="sr-only" aria-live="polite">
+        {label}
+      </span>
+      <span aria-hidden="true" className="truncate">
+        {label}
+      </span>
+      <span
+        aria-hidden="true"
+        className="tabular-nums text-foreground/50"
+      >
+        {elapsed}s
+      </span>
     </div>
   )
 }

--- a/web/design/src/components/agent-elements/input/input-bar-surface.tsx
+++ b/web/design/src/components/agent-elements/input/input-bar-surface.tsx
@@ -3,12 +3,13 @@ import { FileAttachment } from "./file-attachment"
 import { SendButton } from "./send-button"
 import { cn } from "../utils/cn"
 import type { AttachedFile, AttachedImage } from "../input-bar"
-import type {
-  ClipboardEvent,
-  KeyboardEvent,
-  MouseEvent,
-  ReactNode,
-  RefObject,
+import {
+  useId,
+  type ClipboardEvent,
+  type KeyboardEvent,
+  type MouseEvent,
+  type ReactNode,
+  type RefObject,
 } from "react"
 
 type InputBarSurfaceAttachments = {
@@ -110,6 +111,7 @@ export function InputBarSurface({
     rightActions,
     showAttach,
   } = toolbar
+  const composerInputId = useId()
 
   return (
     <div
@@ -186,7 +188,11 @@ export function InputBarSurface({
             </div>
           ) : (
             <>
+              <label className="sr-only" htmlFor={composerInputId}>
+                Message
+              </label>
               <textarea
+                id={composerInputId}
                 ref={textareaRef}
                 value={input}
                 onChange={(event) => onInputChange(event.target.value)}

--- a/web/design/src/components/agent-elements/markdown.tsx
+++ b/web/design/src/components/agent-elements/markdown.tsx
@@ -46,118 +46,123 @@ const code = createCodePlugin({
   themes: ["github-light", "github-dark"],
 })
 
+const SAFE_HREF_PATTERN = /^(https?:|mailto:)/i
+
+const markdownComponents: Components = {
+  h1: ({ children, ...props }) => (
+    <h1 className="an-md-h1 mt-3 mb-1.5 text-base font-semibold" {...props}>
+      {children}
+    </h1>
+  ),
+  h2: ({ children, ...props }) => (
+    <h2 className="an-md-h2 mt-3 mb-1.5 text-base font-semibold" {...props}>
+      {children}
+    </h2>
+  ),
+  h3: ({ children, ...props }) => (
+    <h3 className="an-md-h3 mt-2 mb-1 text-sm font-semibold" {...props}>
+      {children}
+    </h3>
+  ),
+  h4: ({ children, ...props }) => (
+    <h4 className="an-md-h4 mt-2 mb-1 text-sm font-medium" {...props}>
+      {children}
+    </h4>
+  ),
+  p: ({ children, ...props }) => (
+    <p
+      className="an-md-p text-sm leading-relaxed text-an-foreground/80"
+      {...props}
+    >
+      {children}
+    </p>
+  ),
+  ul: ({ children, ...props }) => (
+    <ul
+      className="an-md-ul mb-2 flex list-outside list-disc flex-col gap-0.5 pl-4 text-sm text-an-foreground/80"
+      {...props}
+    >
+      {children}
+    </ul>
+  ),
+  ol: ({ children, ...props }) => (
+    <ol
+      className="an-md-ol mb-2 flex list-outside list-decimal flex-col gap-0.5 pl-5 text-sm text-an-foreground/80"
+      {...props}
+    >
+      {children}
+    </ol>
+  ),
+  li: ({ children, ...props }) => (
+    <li className="an-md-li pl-0.5 text-sm text-an-foreground/80" {...props}>
+      {children}
+    </li>
+  ),
+  strong: ({ children, ...props }) => (
+    <strong className="font-medium text-an-foreground" {...props}>
+      {children}
+    </strong>
+  ),
+  a: ({ href, children, ...props }) => {
+    if (typeof href !== "string" || !SAFE_HREF_PATTERN.test(href)) {
+      return <span>{children}</span>
+    }
+    const isExternal = href.startsWith("http")
+    return (
+      <a
+        {...props}
+        href={href}
+        target={isExternal ? "_blank" : undefined}
+        rel={isExternal ? "noopener noreferrer" : undefined}
+        className="an-md-link text-an-primary-color underline-offset-2 hover:underline"
+      >
+        {children}
+      </a>
+    )
+  },
+  blockquote: ({ children, ...props }) => (
+    <blockquote
+      className="an-md-blockquote mb-2 border-l-2 border-an-border-color pl-3 text-sm text-an-foreground/70 italic"
+      {...props}
+    >
+      {children}
+    </blockquote>
+  ),
+  hr: ({ ...props }) => (
+    <hr className="an-md-hr my-4 border-an-border-color" {...props} />
+  ),
+  table: ({ children, ...props }) => (
+    <div className="my-3 overflow-x-auto rounded-an-tool-border-radius border border-an-border-color">
+      <table
+        className="an-md-table w-full text-sm [&>thead]:bg-an-tool-background [&>thead>tr>th]:bg-an-tool-background"
+        {...props}
+      >
+        {children}
+      </table>
+    </div>
+  ),
+  th: ({ children, ...props }) => (
+    <th
+      className="bg-an-background-secondary px-3 py-2 text-left font-medium"
+      {...props}
+    >
+      {children}
+    </th>
+  ),
+  td: ({ children, ...props }) => (
+    <td
+      className="border-t border-an-border-color px-3 py-2 text-an-foreground/80"
+      {...props}
+    >
+      {children}
+    </td>
+  ),
+}
+
 export function Markdown({ content, className }: MarkdownProps) {
   const safeContent = normalizeCodeFenceLanguages(
     fixNumberedListBreaks(content)
   )
-  const components: Components = {
-    h1: ({ children, ...props }) => (
-      <h1 className="an-md-h1 mt-3 mb-1.5 text-base font-semibold" {...props}>
-        {children}
-      </h1>
-    ),
-    h2: ({ children, ...props }) => (
-      <h2 className="an-md-h2 mt-3 mb-1.5 text-base font-semibold" {...props}>
-        {children}
-      </h2>
-    ),
-    h3: ({ children, ...props }) => (
-      <h3 className="an-md-h3 mt-2 mb-1 text-sm font-semibold" {...props}>
-        {children}
-      </h3>
-    ),
-    h4: ({ children, ...props }) => (
-      <h4 className="an-md-h4 mt-2 mb-1 text-sm font-medium" {...props}>
-        {children}
-      </h4>
-    ),
-    p: ({ children, ...props }) => (
-      <p
-        className="an-md-p text-sm leading-relaxed text-an-foreground/80"
-        {...props}
-      >
-        {children}
-      </p>
-    ),
-    ul: ({ children, ...props }) => (
-      <ul
-        className="an-md-ul mb-2 flex list-outside list-disc flex-col gap-0.5 pl-4 text-sm text-an-foreground/80"
-        {...props}
-      >
-        {children}
-      </ul>
-    ),
-    ol: ({ children, ...props }) => (
-      <ol
-        className="an-md-ol mb-2 flex list-outside list-decimal flex-col gap-0.5 pl-5 text-sm text-an-foreground/80"
-        {...props}
-      >
-        {children}
-      </ol>
-    ),
-    li: ({ children, ...props }) => (
-      <li className="an-md-li pl-0.5 text-sm text-an-foreground/80" {...props}>
-        {children}
-      </li>
-    ),
-    strong: ({ children, ...props }) => (
-      <strong className="font-medium text-an-foreground" {...props}>
-        {children}
-      </strong>
-    ),
-    a: ({ href, children, ...props }) => {
-      if (!href) return <span>{children}</span>
-      const isExternal = href.startsWith("http") || href.startsWith("mailto:")
-      return (
-        <a
-          {...props}
-          href={href}
-          target={isExternal ? "_blank" : undefined}
-          rel={isExternal ? "noopener noreferrer" : undefined}
-          className="an-md-link text-an-primary-color underline-offset-2 hover:underline"
-        >
-          {children}
-        </a>
-      )
-    },
-    blockquote: ({ children, ...props }) => (
-      <blockquote
-        className="an-md-blockquote mb-2 border-l-2 border-an-border-color pl-3 text-sm text-an-foreground/70 italic"
-        {...props}
-      >
-        {children}
-      </blockquote>
-    ),
-    hr: ({ ...props }) => (
-      <hr className="an-md-hr my-4 border-an-border-color" {...props} />
-    ),
-    table: ({ children, ...props }) => (
-      <div className="my-3 overflow-x-auto rounded-an-tool-border-radius border border-an-border-color">
-        <table
-          className="an-md-table w-full text-sm [&>thead]:bg-an-tool-background [&>thead>tr>th]:bg-an-tool-background"
-          {...props}
-        >
-          {children}
-        </table>
-      </div>
-    ),
-    th: ({ children, ...props }) => (
-      <th
-        className="bg-an-background-secondary px-3 py-2 text-left font-medium"
-        {...props}
-      >
-        {children}
-      </th>
-    ),
-    td: ({ children, ...props }) => (
-      <td
-        className="border-t border-an-border-color px-3 py-2 text-an-foreground/80"
-        {...props}
-      >
-        {children}
-      </td>
-    ),
-  }
 
   return (
     <div
@@ -168,7 +173,7 @@ export function Markdown({ content, className }: MarkdownProps) {
         className
       )}
     >
-      <Streamdown components={components} plugins={{ code }}>
+      <Streamdown components={markdownComponents} plugins={{ code }}>
         {safeContent}
       </Streamdown>
     </div>

--- a/web/design/src/components/agent-elements/message-list.tsx
+++ b/web/design/src/components/agent-elements/message-list.tsx
@@ -19,6 +19,120 @@ import type { ToolRendererProps } from "./utils/chat-message-parts"
 import type { CustomToolRendererProps } from "./types"
 import type { ChatMessage, ChatStatus } from "@prime-agent/web-protocol/chat-types"
 
+type UserMessageComponent = React.ComponentType<{
+  message: ChatMessage
+  className?: string
+  enableImagePreview?: boolean
+}>
+
+type TextRendererComponent = React.ComponentType<{
+  content: string
+  className?: string
+  isStreaming?: boolean
+  messageId?: string
+  onOpenUIAction?: (message: string) => void
+}>
+
+type UserTurnDisplayChrome = {
+  enableImagePreview: boolean
+  showCopyToolbar: boolean
+  isMounted: boolean
+}
+
+type AssistantTurnChrome = {
+  isStreaming: boolean
+  copyEnabled: boolean
+  suppressQuestionTool: boolean
+}
+
+const MemoUserTurn = memo(function MemoUserTurn({
+  message,
+  UserMessageComponent,
+  userMessageClassName,
+  displayChrome,
+  copyKey,
+  activeCopyId,
+  onCopied,
+}: {
+  message: ChatMessage
+  UserMessageComponent: UserMessageComponent
+  userMessageClassName?: string
+  displayChrome: UserTurnDisplayChrome
+  copyKey: string
+  activeCopyId: string | null
+  onCopied: (id: string) => void
+}) {
+  const isCopyVisible = activeCopyId === copyKey
+  const display = useMemo(
+    () => ({ ...displayChrome, isCopyVisible }),
+    [displayChrome, isCopyVisible]
+  )
+  return (
+    <UserTurn
+      message={message}
+      UserMessageComponent={UserMessageComponent}
+      userMessageClassName={userMessageClassName}
+      display={display}
+      onCopied={onCopied}
+    />
+  )
+})
+
+const MemoAssistantTurn = memo(function MemoAssistantTurn({
+  assistantMsgs,
+  turnKey,
+  isLast,
+  chrome,
+  copyKey,
+  activeCopyId,
+  ToolRendererComponent,
+  TextRendererComponent,
+  toolRenderers,
+  onOpenUIAction,
+  onCopied,
+}: {
+  assistantMsgs: Array<ChatMessage>
+  turnKey: string
+  isLast: boolean
+  chrome: AssistantTurnChrome
+  copyKey: string
+  activeCopyId: string | null
+  ToolRendererComponent: React.ComponentType<ToolRendererProps>
+  TextRendererComponent: TextRendererComponent
+  toolRenderers?: Record<string, React.ComponentType<CustomToolRendererProps>>
+  onOpenUIAction?: (message: string) => void
+  onCopied: (id: string) => void
+}) {
+  const { isStreaming, copyEnabled, suppressQuestionTool } = chrome
+  const isCopyVisible = activeCopyId === copyKey
+  const stream = useMemo(
+    () => ({ isLast, isStreaming }),
+    [isLast, isStreaming]
+  )
+  const copy = useMemo(
+    () => ({ enabled: copyEnabled, isVisible: isCopyVisible }),
+    [copyEnabled, isCopyVisible]
+  )
+  const display = useMemo(
+    () => ({ suppressQuestionTool }),
+    [suppressQuestionTool]
+  )
+  return (
+    <AssistantTurn
+      assistantMsgs={assistantMsgs}
+      turnKey={turnKey}
+      stream={stream}
+      copy={copy}
+      display={display}
+      ToolRendererComponent={ToolRendererComponent}
+      TextRendererComponent={TextRendererComponent}
+      toolRenderers={toolRenderers}
+      onOpenUIAction={onOpenUIAction}
+      onCopied={onCopied}
+    />
+  )
+})
+
 export type MessageListProps = {
   messages: Array<ChatMessage>
   status: ChatStatus
@@ -203,6 +317,18 @@ export const MessageList = memo(function MessageList({
   })
 
   const planningLabel = "Processing..."
+  const userDisplayChrome = useMemo(
+    () => ({ enableImagePreview, showCopyToolbar, isMounted }),
+    [enableImagePreview, showCopyToolbar, isMounted]
+  )
+  const assistantChrome = useMemo(
+    () => ({
+      isStreaming,
+      copyEnabled: showCopyToolbar,
+      suppressQuestionTool,
+    }),
+    [isStreaming, showCopyToolbar, suppressQuestionTool]
+  )
   const isNewAssistantMessage =
     lastMessageRole === "assistant" &&
     Boolean(lastMessageId) &&
@@ -239,33 +365,26 @@ export const MessageList = memo(function MessageList({
                 }
               >
                 {turn.userMsg && (
-                  <UserTurn
+                  <MemoUserTurn
                     message={turn.userMsg}
                     UserMessageComponent={CustomUserMessage}
                     userMessageClassName={classNames?.userMessage}
-                    display={{
-                      enableImagePreview,
-                      showCopyToolbar,
-                      isMounted,
-                      isCopyVisible:
-                        activeCopyId === `user-${turn.userMsg.id}`,
-                    }}
+                    displayChrome={userDisplayChrome}
+                    copyKey={`user-${turn.userMsg.id}`}
+                    activeCopyId={activeCopyId}
                     onCopied={markCopied}
                   />
                 )}
 
                 {turn.assistantMsgs.length > 0 &&
                   !(isLastTurn && showPlanning) && (
-                    <AssistantTurn
+                    <MemoAssistantTurn
                       assistantMsgs={turn.assistantMsgs}
                       turnKey={turnKey}
-                      stream={{ isLast: isLastTurn, isStreaming }}
-                      copy={{
-                        enabled: showCopyToolbar,
-                        isVisible:
-                          activeCopyId === `assistant-${turnKey}-all`,
-                      }}
-                      display={{ suppressQuestionTool }}
+                      isLast={isLastTurn}
+                      chrome={assistantChrome}
+                      copyKey={`assistant-${turnKey}-all`}
+                      activeCopyId={activeCopyId}
                       ToolRendererComponent={CustomToolRenderer}
                       TextRendererComponent={CustomTextRenderer}
                       toolRenderers={toolRenderers}

--- a/web/design/src/components/chart.tsx
+++ b/web/design/src/components/chart.tsx
@@ -14,6 +14,19 @@ export function sanitizeChartToken(value: string) {
   return value.replace(CHART_TOKEN_PATTERN, "_")
 }
 
+export function sanitizeChartColor(value: string): string | undefined {
+  const color = value.trim()
+  if (/^#(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i.test(color)) return color
+  if (/^var\(--[a-z0-9-]+\)$/i.test(color)) return color
+  if (
+    /^(?:rgb|rgba|hsl|hsla)\([^;{}<>]+\)$/i.test(color) &&
+    !/[;{}<>]/.test(color)
+  ) {
+    return color
+  }
+  return undefined
+}
+
 export function getChartColorVarName(key: string) {
   return `--color-${sanitizeChartToken(key)}`
 }
@@ -112,7 +125,9 @@ ${colorConfig
     const color =
       itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ??
       itemConfig.color
-    return color ? `  ${getChartColorVarName(key)}: ${color};` : null
+    const safeColor =
+      typeof color === "string" ? sanitizeChartColor(color) : undefined
+    return safeColor ? `  ${getChartColorVarName(key)}: ${safeColor};` : null
   })
   .join("\n")}
 }

--- a/web/design/src/components/fleet-pi/layout/right-panel-shell.tsx
+++ b/web/design/src/components/fleet-pi/layout/right-panel-shell.tsx
@@ -86,6 +86,7 @@ export function RightPanelShell({
       <OpenProjectFolderDialog
         browseWorkspace={browseWorkspace}
         initialPath={workspaceTree?.root ?? ""}
+        key={openFolderDialog ? (workspaceTree?.root ?? "") : "closed"}
         onOpenChange={setOpenFolderDialog}
         onSelectRoot={setWorkspaceRoot}
         open={openFolderDialog}

--- a/web/design/src/components/fleet-pi/pi/open-project-folder-dialog.tsx
+++ b/web/design/src/components/fleet-pi/pi/open-project-folder-dialog.tsx
@@ -57,10 +57,6 @@ export function OpenProjectFolderDialog({
 
   useEffect(() => {
     if (!open) return
-    setPathInput(initialPath)
-    setSelectedPath(initialPath)
-    setBrowse(null)
-    setError(null)
     void loadPath(initialPath)
   }, [initialPath, loadPath, open])
 

--- a/web/design/src/components/fleet-pi/pi/settings-dialog.tsx
+++ b/web/design/src/components/fleet-pi/pi/settings-dialog.tsx
@@ -299,14 +299,7 @@ function SettingsDialogSession({
           onCloseAttemptRef={onCloseAttemptRef}
           onOpenChange={onOpenChange}
         />
-      ) : (
-        <>
-          <DialogTitle className="sr-only">Settings</DialogTitle>
-          <DialogDescription className="sr-only">
-            Customize your settings here.
-          </DialogDescription>
-        </>
-      )}
+      ) : null}
     </Dialog>
   )
 }

--- a/web/design/src/components/fleet-pi/pi/settings-dialog.tsx
+++ b/web/design/src/components/fleet-pi/pi/settings-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState, type MutableRefObject } from "react"
 import { toast } from "sonner"
 
 import {
@@ -246,7 +246,7 @@ function SidebarNavItem({
   )
 }
 
-type SettingsForm = ReturnType<typeof useSettingsForm>
+type CloseAttemptDetails = { cancel: () => void }
 
 export function SettingsDialog({
   open,
@@ -258,13 +258,8 @@ export function SettingsDialog({
   /** When provided, selects this nav tab each time the dialog opens. */
   initialTab?: SettingsSectionId
 }) {
-  const form = useSettingsForm()
-
-  if (!open) return null
-
   return (
     <SettingsDialogSession
-      form={form}
       initialTab={initialTab}
       onOpenChange={onOpenChange}
       open={open}
@@ -273,16 +268,61 @@ export function SettingsDialog({
 }
 
 function SettingsDialogSession({
-  form,
   initialTab,
   onOpenChange,
   open,
 }: {
-  form: SettingsForm
   initialTab?: SettingsSectionId
   onOpenChange: (open: boolean) => void
   open: boolean
 }) {
+  const onCloseAttemptRef = useRef<(eventDetails?: CloseAttemptDetails) => void>(
+    () => {
+      onOpenChange(false)
+    }
+  )
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen, eventDetails) => {
+        if (nextOpen) {
+          onOpenChange(true)
+          return
+        }
+        onCloseAttemptRef.current(eventDetails)
+      }}
+    >
+      {open ? (
+        <SettingsDialogBody
+          initialTab={initialTab}
+          onCloseAttemptRef={onCloseAttemptRef}
+          onOpenChange={onOpenChange}
+        />
+      ) : (
+        <>
+          <DialogTitle className="sr-only">Settings</DialogTitle>
+          <DialogDescription className="sr-only">
+            Customize your settings here.
+          </DialogDescription>
+        </>
+      )}
+    </Dialog>
+  )
+}
+
+function SettingsDialogBody({
+  initialTab,
+  onCloseAttemptRef,
+  onOpenChange,
+}: {
+  initialTab?: SettingsSectionId
+  onCloseAttemptRef: MutableRefObject<
+    (eventDetails?: CloseAttemptDetails) => void
+  >
+  onOpenChange: (open: boolean) => void
+}) {
+  const form = useSettingsForm()
   const {
     isLoadingProviders,
     isUpdatingProvider,
@@ -352,6 +392,10 @@ function SettingsDialogSession({
       setDiscardReason(resourceDirty ? "resource" : "model")
       setDiscardDialogOpen(true)
     })()
+  }
+
+  onCloseAttemptRef.current = (eventDetails) => {
+    handleOpenChange(false, eventDetails)
   }
 
   const handleDiscardChanges = () => {
@@ -458,12 +502,7 @@ function SettingsDialogSession({
   return (
     // Nest AlertDialog under Dialog.Root so Base UI tracks nested open
     // dialogs (Esc / isTopmost). Sibling roots fight Esc and re-prompt.
-    <Dialog
-      open={open}
-      onOpenChange={(nextOpen, eventDetails) =>
-        handleOpenChange(nextOpen, eventDetails)
-      }
-    >
+    <>
       <DialogContent className="w-full max-w-[calc(100%-2rem)] overflow-hidden p-0 sm:max-w-[650px] md:h-[650px] md:max-h-[85vh] md:max-w-[760px] lg:max-w-[860px]">
         <DialogTitle className="sr-only">Settings</DialogTitle>
         <DialogDescription className="sr-only">
@@ -567,6 +606,6 @@ function SettingsDialogSession({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </Dialog>
+    </>
   )
 }

--- a/web/design/src/components/fleet-pi/ui-error-boundary.tsx
+++ b/web/design/src/components/fleet-pi/ui-error-boundary.tsx
@@ -22,15 +22,18 @@ export function UiErrorBoundary({
   children,
   fallback,
   onReset,
+  resetKeys,
 }: {
   children: React.ReactNode
   fallback?: React.ReactNode
   onReset?: () => void
+  resetKeys?: Array<unknown>
 }) {
   return (
     <ErrorBoundary
       FallbackComponent={fallback ? () => fallback : DefaultFallback}
       onReset={onReset}
+      resetKeys={resetKeys}
     >
       {children}
     </ErrorBoundary>

--- a/web/design/src/components/openui/openui-renderer.tsx
+++ b/web/design/src/components/openui/openui-renderer.tsx
@@ -128,7 +128,7 @@ function OpenUIBlock({
 
   return (
     <div className="flex w-full flex-col gap-2">
-      <UiErrorBoundary>
+      <UiErrorBoundary resetKeys={[content]}>
         <Renderer
           initialState={initialState}
           isStreaming={isStreaming}

--- a/web/design/src/components/openui/openui-renderer.tsx
+++ b/web/design/src/components/openui/openui-renderer.tsx
@@ -1,6 +1,7 @@
 import { BuiltinActionType, Renderer } from "@openuidev/react-lang"
 import { useCallback, useMemo, useState } from "react"
 import { Markdown } from "../agent-elements/markdown"
+import { UiErrorBoundary } from "../fleet-pi/ui-error-boundary"
 
 import { openUILibrary } from "./openui-library"
 import { segmentOpenUIContent } from "./openui-utils"
@@ -127,16 +128,18 @@ function OpenUIBlock({
 
   return (
     <div className="flex w-full flex-col gap-2">
-      <Renderer
-        initialState={initialState}
-        isStreaming={isStreaming}
-        library={openUILibrary}
-        response={content}
-        onAction={handleAction}
-        onError={handleError}
-        onParseResult={setParseResult}
-        onStateUpdate={(state) => onStateUpdate(blockId, state)}
-      />
+      <UiErrorBoundary>
+        <Renderer
+          initialState={initialState}
+          isStreaming={isStreaming}
+          library={openUILibrary}
+          response={content}
+          onAction={handleAction}
+          onError={handleError}
+          onParseResult={setParseResult}
+          onStateUpdate={(state) => onStateUpdate(blockId, state)}
+        />
+      </UiErrorBoundary>
       <OpenUIDiagnostics
         errors={[...runtimeErrors, ...finalErrors]}
         raw={content}

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -38,9 +38,6 @@ importers:
       '@tanstack/react-start':
         specifier: ^1.168.26
         version: 1.168.37(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.3)(supports-color@7.2.0)(vite@8.2.0(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.8)(yaml@2.9.0))
-      '@tanstack/router-plugin':
-        specifier: ^1.168.18
-        version: 1.168.25(@tanstack/react-router@1.170.20(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.3)(supports-color@7.2.0)(vite@8.2.0(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.8)(yaml@2.9.0))
       react:
         specifier: ^19.2.7
         version: 19.2.8
@@ -198,7 +195,7 @@ importers:
         version: 8.5.0(zod@4.4.3)
       '@openuidev/lang-core':
         specifier: ^0.2.7
-        version: 0.2.11(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(zod@4.4.3)
+        version: 0.2.11(@modelcontextprotocol/sdk@1.30.0(supports-color@7.2.0)(zod@4.4.3))(zod@4.4.3)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -4408,29 +4405,6 @@ snapshots:
       - supports-color
     optional: true
 
-  '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)':
-    dependencies:
-      '@hono/node-server': 2.1.0(hono@4.13.0)
-      ajv: 8.20.0
-      ajv-formats: 3.0.1(ajv@8.20.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.1.0
-      express: 5.2.1(supports-color@7.2.0)
-      express-rate-limit: 8.6.2(express@5.2.1(supports-color@7.2.0))(supports-color@7.2.0)
-      hono: 4.13.0
-      jose: 6.2.8
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -4465,12 +4439,6 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.30.0(supports-color@7.2.0)(zod@4.4.3)
-
-  '@openuidev/lang-core@0.2.11(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(zod@4.4.3)':
-    dependencies:
-      zod: 4.4.3
-    optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.30.0(zod@4.4.3)
 
   '@openuidev/observability@0.0.2': {}
 


### PR DESCRIPTION
## Summary
- Sanitize OpenUI chart colors and markdown link targets to reduce XSS risk in rendered chat content.
- Harden chat session handling so stale or mismatched sessions are cleared instead of leaving the UI in a broken state.
- Close accessibility gaps in the message list, composer, settings dialog, and markdown rendering, including focus restore after closing settings while streaming.
- Remove unused web stubs and clear remaining React Doctor diagnostics on the web tree.

## Test plan
- [x] `npm run check`
- [ ] Send chat messages with markdown links and OpenUI chart blocks; confirm links and charts render safely
- [ ] Open settings during an active stream, close the dialog, and verify focus returns to the composer
- [ ] Switch sessions and reload; confirm stale session state does not persist incorrectly