### PR TITLE
feat(web): put reasoning effort in the composer input bar

### DIFF
--- a/web/app/src/lib/pi/chat-helpers.test.ts
+++ b/web/app/src/lib/pi/chat-helpers.test.ts
@@ -1,0 +1,34 @@
+import {
+	availableThinkingLevels,
+	clampThinkingLevel,
+	thinkingLevelLabel,
+} from "@prime-agent/web-design/lib/pi/chat-helpers";
+import { describe, expect, it } from "vitest";
+
+describe("clampThinkingLevel", () => {
+	it("keeps a level the model supports", () => {
+		expect(clampThinkingLevel("max", ["off", "medium", "max"])).toBe("max");
+	});
+
+	it("falls back to medium when available, otherwise the first level", () => {
+		expect(clampThinkingLevel("max", ["off", "low", "medium"])).toBe("medium");
+		expect(clampThinkingLevel(undefined, ["off"])).toBe("off");
+	});
+});
+
+describe("availableThinkingLevels", () => {
+	it("uses catalog levels when present", () => {
+		expect(availableThinkingLevels({ thinkingLevels: ["off", "high"], reasoning: true })).toEqual(["off", "high"]);
+	});
+
+	it("falls back to off for non-reasoning models without a catalog list", () => {
+		expect(availableThinkingLevels({ reasoning: false })).toEqual(["off"]);
+	});
+});
+
+describe("thinkingLevelLabel", () => {
+	it("uses short display names for the picker trigger", () => {
+		expect(thinkingLevelLabel("max")).toBe("Max");
+		expect(thinkingLevelLabel("xhigh")).toBe("Extra high");
+	});
+});

--- a/web/app/src/lib/pi/slash-commands.test.ts
+++ b/web/app/src/lib/pi/slash-commands.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { resolveLocalSlashAction } from "./slash-commands";
+
+describe("resolveLocalSlashAction", () => {
+	it("opens the effort picker for /effort and sets a named thinking level", () => {
+		expect(resolveLocalSlashAction("effort")).toEqual({ type: "open-effort-picker" });
+		expect(resolveLocalSlashAction("thinking")).toEqual({ type: "open-effort-picker" });
+		expect(resolveLocalSlashAction("effort", "max")).toEqual({
+			type: "set-thinking-level",
+			level: "max",
+		});
+		expect(resolveLocalSlashAction("effort", "nope")).toEqual({
+			type: "open-effort-picker",
+			unknownLevel: "nope",
+		});
+	});
+});

--- a/web/app/src/lib/pi/slash-commands.ts
+++ b/web/app/src/lib/pi/slash-commands.ts
@@ -1,4 +1,9 @@
-import type { ChatResourcesResponse, ChatSlashCommandInfo } from "@prime-agent/web-protocol/chat-protocol";
+import type {
+	ChatResourcesResponse,
+	ChatSlashCommandInfo,
+	ChatThinkingLevel,
+} from "@prime-agent/web-protocol/chat-protocol";
+import { ChatThinkingLevelSchema } from "@prime-agent/web-protocol/chat-protocol.zod";
 
 /**
  * Web port of prime-agent's builtin slash-command dispatcher
@@ -42,6 +47,8 @@ export type SettingsSlashTab = "appearance" | "sandbox" | "providers" | "llm-mod
 
 export type LocalSlashAction =
 	| { type: "open-model-picker"; modelKey?: string }
+	| { type: "open-effort-picker"; unknownLevel?: string }
+	| { type: "set-thinking-level"; level: ChatThinkingLevel }
 	| { type: "open-settings"; tab: SettingsSlashTab }
 	| { type: "new-session" }
 	| { type: "session-info" }
@@ -83,6 +90,11 @@ const SLASH_COMMAND_ALIASES: Record<string, string> = {
 	side: "btw",
 };
 
+function parseThinkingLevelArg(args: string): ChatThinkingLevel | undefined {
+	const parsed = ChatThinkingLevelSchema.safeParse(args.trim().toLowerCase());
+	return parsed.success ? parsed.data : undefined;
+}
+
 export function resolveSlashCommandAlias(command: string): string {
 	return SLASH_COMMAND_ALIASES[command] ?? command;
 }
@@ -123,11 +135,12 @@ export function resolveLocalSlashAction(command: string, args = ""): LocalSlashA
 			const modelKey = trimmedArgs ? trimmedArgs.replace(/:[\w.-]+$/, "") : undefined;
 			return { type: "open-model-picker", modelKey };
 		}
-		case "effort":
-			// TUI parity: /effort opens the same model settings surface where the
-			// thinking-level drop-down lives (the model picker doesn't currently
-			// expose per-provider thinking levels on the wire).
-			return { type: "open-settings", tab: "llm-models" };
+		case "effort": {
+			if (!trimmedArgs) return { type: "open-effort-picker" };
+			const level = parseThinkingLevelArg(trimmedArgs);
+			if (level) return { type: "set-thinking-level", level };
+			return { type: "open-effort-picker", unknownLevel: trimmedArgs };
+		}
 		case "models":
 		case "scoped-models":
 			return { type: "open-settings", tab: "llm-models" };

--- a/web/app/src/lib/pi/use-chat-shell-state.ts
+++ b/web/app/src/lib/pi/use-chat-shell-state.ts
@@ -9,9 +9,18 @@ import {
 	storeThemePreference,
 } from "@prime-agent/web-design/lib/canvas-utils";
 import { startHorizontalResize } from "@prime-agent/web-design/lib/horizontal-resize";
-import { toModelOption, toModelSelection } from "@prime-agent/web-design/lib/pi/chat-helpers";
+import {
+	availableThinkingLevels,
+	clampThinkingLevel,
+	toModelOption,
+	toModelSelection,
+} from "@prime-agent/web-design/lib/pi/chat-helpers";
 import { resolveWorkspacePanelTarget } from "@prime-agent/web-design/lib/workspace-path-nav";
-import type { ChatModelsResponse, ChatSessionMetadata } from "@prime-agent/web-protocol/chat-protocol";
+import type {
+	ChatModelsResponse,
+	ChatSessionMetadata,
+	ChatThinkingLevel,
+} from "@prime-agent/web-protocol/chat-protocol";
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useChatStorage } from "./use-chat-storage";
@@ -21,6 +30,7 @@ export function useChatShellState(modelsData: ChatModelsResponse | undefined) {
 
 	const models = useMemo(() => modelsData?.models.map(toModelOption) ?? [], [modelsData]);
 	const [modelKey, setModelKey] = useState<string | undefined>();
+	const [thinkingLevel, setThinkingLevelState] = useState<ChatThinkingLevel | undefined>();
 	const [rightPanel, setRightPanelState] = useState<RightPanel>(null);
 	const [selectedWorkspacePath, setSelectedWorkspacePath] = useState<string | null>(null);
 	const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
@@ -42,6 +52,13 @@ export function useChatShellState(modelsData: ChatModelsResponse | undefined) {
 			setModelKey(preferredKey);
 		}
 	}, [models, modelKey, modelsData]);
+
+	useEffect(() => {
+		const selected = models.find((model) => model.id === modelKey);
+		if (!selected) return;
+		const available = availableThinkingLevels(selected);
+		setThinkingLevelState((current) => clampThinkingLevel(current ?? modelsData?.defaultThinkingLevel, available));
+	}, [models, modelKey, modelsData?.defaultThinkingLevel]);
 
 	useEffect(() => {
 		applyThemePreference(themePreference);
@@ -143,7 +160,21 @@ export function useChatShellState(modelsData: ChatModelsResponse | undefined) {
 	);
 
 	const selectedModel = models.find((model) => model.id === modelKey);
-	const modelSelection = useMemo(() => toModelSelection(selectedModel), [selectedModel]);
+	const resolvedThinkingLevel = clampThinkingLevel(
+		thinkingLevel ?? modelsData?.defaultThinkingLevel,
+		availableThinkingLevels(selectedModel),
+	);
+	const setThinkingLevel = useCallback(
+		(level: ChatThinkingLevel) => {
+			const selected = models.find((model) => model.id === modelKey);
+			setThinkingLevelState(clampThinkingLevel(level, availableThinkingLevels(selected)));
+		},
+		[modelKey, models],
+	);
+	const modelSelection = useMemo(
+		() => toModelSelection(selectedModel, resolvedThinkingLevel),
+		[resolvedThinkingLevel, selectedModel],
+	);
 
 	return {
 		commandPaletteOpen,
@@ -162,6 +193,8 @@ export function useChatShellState(modelsData: ChatModelsResponse | undefined) {
 		setModelKey,
 		setRightPanel,
 		setSelectedWorkspacePath,
+		setThinkingLevel,
 		themePreference,
+		thinkingLevel: resolvedThinkingLevel,
 	};
 }

--- a/web/app/src/lib/pi/use-chat-workspace-data.ts
+++ b/web/app/src/lib/pi/use-chat-workspace-data.ts
@@ -1,7 +1,7 @@
 import type { QuestionAnswer } from "@prime-agent/web-design/components/agent-elements/question/question-prompt";
 import { notify } from "@prime-agent/web-design/lib/notify";
 import { type ChatModelOption, queueLabel, toModelOption } from "@prime-agent/web-design/lib/pi/chat-helpers";
-import type { ChatPiSettingsUpdate, ChatSettingsResponse } from "@prime-agent/web-protocol/chat-protocol";
+import type { ChatMode, ChatPiSettingsUpdate, ChatSettingsResponse } from "@prime-agent/web-protocol/chat-protocol";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { identifyAnalyticsUser } from "@/lib/analytics-stub";
@@ -48,6 +48,8 @@ export function useChatWorkspaceData() {
 	const [settingsDialogOpen, setSettingsDialogOpen] = useState(false);
 	const [settingsInitialTab, setSettingsInitialTab] = useState<SettingsSlashTab | undefined>(undefined);
 	const [modelPickerOpen, setModelPickerOpen] = useState(false);
+	const [effortPickerOpen, setEffortPickerOpen] = useState(false);
+	const [chatMode, setChatMode] = useState<ChatMode>("agent");
 
 	useEffect(() => {
 		if (user) identifyAnalyticsUser(user);
@@ -77,7 +79,9 @@ export function useChatWorkspaceData() {
 		setModelKey,
 		setRightPanel,
 		setSelectedWorkspacePath,
+		setThinkingLevel,
 		themePreference,
+		thinkingLevel,
 	} = useChatShellState(modelsData);
 
 	const {
@@ -222,12 +226,15 @@ export function useChatWorkspaceData() {
 
 	const { handleLocalSlashSubmit, handleSlashCommandSelect } = useLocalSlashActions({
 		appendLocalMessage,
+		modelKey,
 		models,
 		openSettings,
 		sessionId: sessionMetadata.sessionId,
 		sessionFile: sessionMetadata.sessionFile,
+		setEffortPickerOpen,
 		setModelKey,
 		setModelPickerOpen,
+		setThinkingLevel,
 		startNewSession,
 	});
 
@@ -293,6 +300,7 @@ export function useChatWorkspaceData() {
 
 	return {
 		answerQuestion,
+		chatMode,
 		chatPanelData,
 		commandPaletteOpen,
 		error,
@@ -305,6 +313,7 @@ export function useChatWorkspaceData() {
 		infoDescription,
 		inputSuggestionItems,
 		messages,
+		effortPickerOpen,
 		modelKey,
 		modelPickerOpen,
 		models,
@@ -313,12 +322,15 @@ export function useChatWorkspaceData() {
 		resumeSession,
 		sendMessage,
 		sessions,
+		setChatMode,
 		setCommandPaletteOpen,
+		setEffortPickerOpen,
 		setModelKey,
 		setModelPickerOpen,
 		setRightPanel,
 		setSettingsDialogOpen,
 		setSettingsInitialTab,
+		setThinkingLevel,
 		settingsActions,
 		settingsDialogOpen,
 		settingsInitialTab,
@@ -327,6 +339,7 @@ export function useChatWorkspaceData() {
 		status,
 		stop,
 		themePreference,
+		thinkingLevel,
 		workspaceTreeContext,
 	};
 }

--- a/web/app/src/lib/pi/use-local-slash-actions.ts
+++ b/web/app/src/lib/pi/use-local-slash-actions.ts
@@ -1,6 +1,11 @@
 import type { SuggestionItem } from "@prime-agent/web-design/components/agent-elements/input/suggestions";
 import { notify } from "@prime-agent/web-design/lib/notify";
-import type { ChatModelOption } from "@prime-agent/web-design/lib/pi/chat-helpers";
+import {
+	availableThinkingLevels,
+	type ChatModelOption,
+	thinkingLevelLabel,
+} from "@prime-agent/web-design/lib/pi/chat-helpers";
+import type { ChatThinkingLevel } from "@prime-agent/web-protocol/chat-protocol";
 import { useCallback } from "react";
 import type { LocalSlashAction, SettingsSlashTab } from "./slash-commands";
 import { parseSlashInput, resolveLocalSlashAction } from "./slash-commands";
@@ -9,12 +14,15 @@ const CHAT_COMMAND_URL = "/api/chat/command";
 
 type UseLocalSlashActionsArgs = {
 	appendLocalMessage: (text: string) => void;
+	modelKey: string | undefined;
 	models: Array<ChatModelOption>;
 	openSettings: (tab?: SettingsSlashTab) => void;
 	sessionId: string | undefined;
 	sessionFile: string | null | undefined;
+	setEffortPickerOpen: (open: boolean) => void;
 	setModelKey: (key: string | undefined) => void;
 	setModelPickerOpen: (open: boolean) => void;
+	setThinkingLevel: (level: ChatThinkingLevel) => void;
 	startNewSession: () => void;
 };
 
@@ -99,12 +107,15 @@ function formatSessionTree(nodes: SessionTreeBranch[], leafId: string | null): s
 
 export function useLocalSlashActions({
 	appendLocalMessage,
+	modelKey,
 	models,
 	openSettings,
 	sessionId,
 	sessionFile,
+	setEffortPickerOpen,
 	setModelKey,
 	setModelPickerOpen,
+	setThinkingLevel,
 	startNewSession,
 }: UseLocalSlashActionsArgs) {
 	/** Fire the bridge runner and echo the result into the transcript. */
@@ -181,7 +192,29 @@ export function useLocalSlashActions({
 						notify.success(`Model set to ${action.modelKey}`);
 						return true;
 					}
+					setEffortPickerOpen(false);
 					setModelPickerOpen(true);
+					return true;
+				}
+				case "open-effort-picker": {
+					if (action.unknownLevel) {
+						notify.error(`Unknown thinking level '${action.unknownLevel}'.`);
+					}
+					setModelPickerOpen(false);
+					setEffortPickerOpen(true);
+					return true;
+				}
+				case "set-thinking-level": {
+					const selected = models.find((model) => model.id === modelKey);
+					const available = availableThinkingLevels(selected);
+					if (!available.includes(action.level)) {
+						notify.error(`Unknown thinking level '${action.level}'. Available: ${available.join(", ")}`);
+						setModelPickerOpen(false);
+						setEffortPickerOpen(true);
+						return true;
+					}
+					setThinkingLevel(action.level);
+					notify.success(`Effort set to ${thinkingLevelLabel(action.level)}`);
 					return true;
 				}
 				case "open-settings":
@@ -411,12 +444,15 @@ export function useLocalSlashActions({
 			appendLocalMessage,
 			chatCommand,
 			echoBranchResult,
+			modelKey,
 			models,
 			openSettings,
 			sessionFile,
 			sessionId,
+			setEffortPickerOpen,
 			setModelKey,
 			setModelPickerOpen,
+			setThinkingLevel,
 			startNewSession,
 		],
 	);

--- a/web/app/src/routes/index.tsx
+++ b/web/app/src/routes/index.tsx
@@ -13,6 +13,7 @@ export const Route = createFileRoute("/")({ component: Chat })
 
 function ChatWorkspaceShell() {
   const {
+    chatMode,
     chatPanelData,
     commandPaletteOpen,
     error,
@@ -25,6 +26,7 @@ function ChatWorkspaceShell() {
     infoDescription,
     inputSuggestionItems,
     messages,
+    effortPickerOpen,
     modelKey,
     modelPickerOpen,
     models,
@@ -33,12 +35,15 @@ function ChatWorkspaceShell() {
     resumeSession,
     sendMessage,
     sessions,
+    setChatMode,
     setCommandPaletteOpen,
+    setEffortPickerOpen,
     setModelKey,
     setModelPickerOpen,
     setRightPanel,
     setSettingsDialogOpen,
     setSettingsInitialTab,
+    setThinkingLevel,
     settingsActions,
     settingsDialogOpen,
     settingsInitialTab,
@@ -47,6 +52,7 @@ function ChatWorkspaceShell() {
     status,
     stop,
     themePreference,
+    thinkingLevel,
     workspaceTreeContext,
   } = useChatWorkspaceData()
 
@@ -121,11 +127,17 @@ function ChatWorkspaceShell() {
               infoDescription,
               slashCommands,
               questionBar: pendingQuestionBar,
+              chatMode,
+              onChatModeChange: setChatMode,
               onModelChange: setModelKey,
+              thinkingLevel,
+              onThinkingLevelChange: setThinkingLevel,
               onSlashCommandSelect: handleSlashCommandSelect,
               onLocalSlashSubmit: handleLocalSlashSubmit,
               modelPickerOpen,
               onModelPickerOpenChange: setModelPickerOpen,
+              effortPickerOpen,
+              onEffortPickerOpenChange: setEffortPickerOpen,
             }}
             onSend={handleSend}
             onOpenUIAction={handleOpenUIAction}

--- a/web/design/src/components/agent-elements/input/effort-picker.tsx
+++ b/web/design/src/components/agent-elements/input/effort-picker.tsx
@@ -1,0 +1,101 @@
+import { memo, useCallback, useState } from "react"
+import { IconCheck, IconChevronDown } from "@tabler/icons-react"
+import type { ChatThinkingLevel } from "@prime-agent/web-protocol/chat-protocol"
+import {
+  THINKING_LEVEL_DESCRIPTIONS,
+  thinkingLevelLabel,
+} from "../../../lib/pi/chat-helpers"
+import { cn } from "../utils/cn"
+import { Popover } from "./popover"
+
+export type EffortPickerProps = {
+  levels: Array<ChatThinkingLevel>
+  value?: ChatThinkingLevel
+  onChange?: (level: ChatThinkingLevel) => void
+  className?: string
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+}
+
+export const EffortPicker = memo(function EffortPicker({
+  levels,
+  value,
+  onChange,
+  className,
+  open: controlledOpen,
+  onOpenChange,
+}: EffortPickerProps) {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false)
+  const isOpenControlled = controlledOpen !== undefined
+  const open = isOpenControlled ? controlledOpen : uncontrolledOpen
+  const activeLevel = value && levels.includes(value) ? value : levels[0]
+  const effortLabel = activeLevel ? thinkingLevelLabel(activeLevel) : "Effort"
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!isOpenControlled) setUncontrolledOpen(nextOpen)
+      onOpenChange?.(nextOpen)
+    },
+    [isOpenControlled, onOpenChange]
+  )
+
+  const handleSelect = useCallback(
+    (level: ChatThinkingLevel) => {
+      onChange?.(level)
+      handleOpenChange(false)
+    },
+    [handleOpenChange, onChange]
+  )
+
+  if (levels.length === 0) return null
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={handleOpenChange}
+      side="top"
+      align="start"
+      className="w-[220px]"
+      trigger={
+        <button
+          type="button"
+          className={cn(
+            "relative inline-flex h-7 cursor-pointer items-center gap-1 rounded-full px-2 text-[12px] leading-4 text-foreground/40 transition-[background-color,transform] duration-150 after:absolute after:inset-x-0 after:-top-1.5 after:-bottom-1.5 hover:bg-foreground/6 active:scale-[0.96]",
+            className
+          )}
+          aria-label="Select effort"
+        >
+          <span className="font-medium">{effortLabel}</span>
+          <IconChevronDown className="size-3 shrink-0 text-foreground/40" />
+        </button>
+      }
+    >
+      {levels.map((level) => {
+        const isActive = level === activeLevel
+        const label = thinkingLevelLabel(level)
+        return (
+          <button
+            key={level}
+            type="button"
+            aria-current={isActive ? "true" : undefined}
+            onClick={() => handleSelect(level)}
+            className={cn(
+              "flex w-full cursor-pointer items-start gap-2 rounded-[6px] px-2 py-2 text-left text-[12px] leading-4 text-an-foreground transition-[background-color,transform] duration-150 hover:bg-foreground/6 active:scale-[0.96]",
+              isActive && "bg-foreground/6"
+            )}
+          >
+            <span className="min-w-0 flex-1">
+              <span className="block truncate font-medium">{label}</span>
+              <span className="block truncate text-foreground/40">
+                {THINKING_LEVEL_DESCRIPTIONS[level]}
+              </span>
+            </span>
+            {isActive && (
+              <IconCheck className="mt-0.5 size-3.5 shrink-0 text-foreground/60" />
+            )}
+          </button>
+        )
+      })}
+    </Popover>
+  )
+})

--- a/web/design/src/components/fleet-pi/chat/fleet-pi-input-bar.tsx
+++ b/web/design/src/components/fleet-pi/chat/fleet-pi-input-bar.tsx
@@ -1,13 +1,20 @@
+import { Bot, ListTodo, Settings2 } from "lucide-react"
 import { useCallback, useState } from "react"
 import { InputBar } from "../../agent-elements/input-bar"
+import { EffortPicker } from "../../agent-elements/input/effort-picker"
 import { ModelPicker } from "../../agent-elements/input/model-picker"
+import { ModeSelector } from "../../agent-elements/input/mode-selector"
 import { ComposerLoader } from "../../agent-elements/composer-loader"
 import { SUGGESTION_ITEM_CLASS, SUGGESTION_LIST_CLASS } from "../styles/tokens"
 import { ChatStopControl } from "./chat-stop-control"
 import type { InputBarProps } from "../../agent-elements/input-bar"
 import type { SuggestionItem } from "../../agent-elements/input/suggestions"
 import type { ChatStatus } from "@prime-agent/web-protocol/chat-types"
-import type { ModelOption } from "../../agent-elements/types"
+import type { ChatMode, ChatThinkingLevel } from "@prime-agent/web-protocol/chat-protocol"
+import {
+  availableThinkingLevels,
+  type ChatModelOption,
+} from "../../../lib/pi/chat-helpers"
 
 export const FLEET_PI_SUGGESTION_ITEM_CLASSNAME = SUGGESTION_ITEM_CLASS
 const FLEET_PI_SUGGESTION_CLASSNAME = SUGGESTION_LIST_CLASS
@@ -33,15 +40,40 @@ export function withFleetPiSuggestionStyles(
   }
 }
 
+export const FLEET_PI_CHAT_MODES = [
+  {
+    id: "agent",
+    label: "Agent",
+    icon: Bot,
+    description: "Default coding agent",
+  },
+  {
+    id: "plan",
+    label: "Plan",
+    icon: ListTodo,
+    description: "Plan before executing",
+  },
+  {
+    id: "harness",
+    label: "Harness",
+    icon: Settings2,
+    description: "Harness-aware turn",
+  },
+] as const
+
 export type FleetPiInputBarProps = Omit<
   InputBarProps,
   "leftActions" | "rightActions" | "status"
 > & {
   modelKey: string | undefined
-  models: Array<ModelOption>
+  models: Array<ChatModelOption>
   status: ChatStatus
   infoDescription?: string | null
+  chatMode?: ChatMode
+  onChatModeChange?: (mode: ChatMode) => void
   onModelChange: (modelKey: string) => void
+  thinkingLevel?: ChatThinkingLevel
+  onThinkingLevelChange?: (level: ChatThinkingLevel) => void
   /**
    * When a slash suggestion is selected, return true to consume it
    * (clears the input instead of inserting the command text).
@@ -55,6 +87,9 @@ export type FleetPiInputBarProps = Omit<
   /** Imperatively open the model picker (e.g. from `/model`). */
   modelPickerOpen?: boolean
   onModelPickerOpenChange?: (open: boolean) => void
+  /** Imperatively open the effort picker (e.g. from `/effort`). */
+  effortPickerOpen?: boolean
+  onEffortPickerOpenChange?: (open: boolean) => void
 }
 
 export function FleetPiInputBar({
@@ -63,13 +98,19 @@ export function FleetPiInputBar({
   status,
   infoDescription,
   suggestions,
+  chatMode = "agent",
+  onChatModeChange,
   onModelChange,
+  thinkingLevel,
+  onThinkingLevelChange,
   onStop,
   onSend,
   onSlashCommandSelect,
   onLocalSlashSubmit,
   modelPickerOpen,
   onModelPickerOpenChange,
+  effortPickerOpen,
+  onEffortPickerOpenChange,
   ...inputBarProps
 }: FleetPiInputBarProps) {
   const displayStatus = status === "streaming" ? "ready" : status
@@ -79,6 +120,13 @@ export function FleetPiInputBar({
   const resolvedModelPickerOpen = isModelPickerControlled
     ? modelPickerOpen
     : uncontrolledModelPickerOpen
+  const [uncontrolledEffortPickerOpen, setUncontrolledEffortPickerOpen] =
+    useState(false)
+  const isEffortPickerControlled = effortPickerOpen !== undefined
+  const resolvedEffortPickerOpen = isEffortPickerControlled
+    ? effortPickerOpen
+    : uncontrolledEffortPickerOpen
+  const selectedModel = models.find((model) => model.id === modelKey)
 
   const handleModelPickerOpenChange = useCallback(
     (open: boolean) => {
@@ -86,6 +134,14 @@ export function FleetPiInputBar({
       onModelPickerOpenChange?.(open)
     },
     [isModelPickerControlled, onModelPickerOpenChange]
+  )
+
+  const handleEffortPickerOpenChange = useCallback(
+    (open: boolean) => {
+      if (!isEffortPickerControlled) setUncontrolledEffortPickerOpen(open)
+      onEffortPickerOpenChange?.(open)
+    },
+    [isEffortPickerControlled, onEffortPickerOpenChange]
   )
 
   const handleSend = useCallback(
@@ -115,16 +171,32 @@ export function FleetPiInputBar({
         onSlashCommandSelect={onSlashCommandSelect}
         suggestions={suggestions}
         leftActions={
-          <ModelPicker
-            models={models}
-            value={modelKey}
-            onChange={onModelChange}
-            open={resolvedModelPickerOpen}
-            onOpenChange={handleModelPickerOpenChange}
-            placeholder="Model"
-          />
+          <>
+            <ModeSelector
+              modes={[...FLEET_PI_CHAT_MODES]}
+              value={chatMode}
+              onChange={(id) => onChatModeChange?.(id as ChatMode)}
+            />
+            <ModelPicker
+              models={models}
+              value={modelKey}
+              onChange={onModelChange}
+              open={resolvedModelPickerOpen}
+              onOpenChange={handleModelPickerOpenChange}
+              placeholder="Model"
+            />
+            <EffortPicker
+              levels={availableThinkingLevels(selectedModel)}
+              value={thinkingLevel}
+              onChange={onThinkingLevelChange}
+              open={resolvedEffortPickerOpen}
+              onOpenChange={handleEffortPickerOpenChange}
+            />
+          </>
         }
-        rightActions={<ChatStopControl status={status} onStop={onStop} />}
+        rightActions={
+          <ChatStopControl status={status} onStop={onStop} />
+        }
       />
     </div>
   )

--- a/web/design/src/lib/pi/chat-helpers.ts
+++ b/web/design/src/lib/pi/chat-helpers.ts
@@ -1,4 +1,4 @@
-import type { ChatModelInfo, ChatModelSelection } from "@prime-agent/web-protocol/chat-protocol";
+import type { ChatModelInfo, ChatModelSelection, ChatThinkingLevel } from "@prime-agent/web-protocol/chat-protocol";
 import { Bot, ClipboardList, Hammer } from "lucide-react";
 import type { ModelOption } from "../../components/agent-elements/types";
 
@@ -8,7 +8,61 @@ export type ChatModelOption = ModelOption & {
 	available?: boolean;
 	reasoning?: boolean;
 	thinkingLevel?: ChatModelInfo["defaultThinkingLevel"];
+	thinkingLevels?: Array<ChatThinkingLevel>;
 };
+
+export const ALL_THINKING_LEVELS: Array<ChatThinkingLevel> = [
+	"off",
+	"minimal",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+];
+
+export const THINKING_LEVEL_LABELS: Record<ChatThinkingLevel, string> = {
+	off: "Off",
+	minimal: "Minimal",
+	low: "Low",
+	medium: "Medium",
+	high: "High",
+	xhigh: "Extra high",
+	max: "Max",
+};
+
+export const THINKING_LEVEL_DESCRIPTIONS: Record<ChatThinkingLevel, string> = {
+	off: "No reasoning",
+	minimal: "Very brief reasoning",
+	low: "Light reasoning",
+	medium: "Moderate reasoning",
+	high: "Deep reasoning",
+	xhigh: "Very deep reasoning",
+	max: "Maximum reasoning",
+};
+
+export function thinkingLevelLabel(level: ChatThinkingLevel): string {
+	return THINKING_LEVEL_LABELS[level];
+}
+
+export function availableThinkingLevels(
+	model: Pick<ChatModelOption, "thinkingLevels" | "reasoning"> | undefined,
+): Array<ChatThinkingLevel> {
+	if (model?.thinkingLevels && model.thinkingLevels.length > 0) {
+		return model.thinkingLevels;
+	}
+	if (model?.reasoning) return ALL_THINKING_LEVELS;
+	return ["off"];
+}
+
+export function clampThinkingLevel(
+	level: ChatThinkingLevel | undefined,
+	available: Array<ChatThinkingLevel>,
+): ChatThinkingLevel {
+	if (level && available.includes(level)) return level;
+	if (available.includes("medium")) return "medium";
+	return available[0] ?? "off";
+}
 
 export const CHAT_MODES = [
 	{
@@ -40,15 +94,19 @@ export function toModelOption(model: ChatModelInfo): ChatModelOption {
 		available: model.available,
 		reasoning: model.reasoning,
 		thinkingLevel: model.defaultThinkingLevel,
+		thinkingLevels: model.thinkingLevels,
 	};
 }
 
-export function toModelSelection(model: ChatModelOption | undefined): ChatModelSelection | undefined {
+export function toModelSelection(
+	model: ChatModelOption | undefined,
+	thinkingLevel?: ChatThinkingLevel,
+): ChatModelSelection | undefined {
 	if (!model) return undefined;
 	return {
 		provider: model.provider,
 		id: model.modelId,
-		thinkingLevel: model.thinkingLevel,
+		thinkingLevel: thinkingLevel ?? model.thinkingLevel,
 	};
 }
 

--- a/web/protocol/src/chat-protocol.ts
+++ b/web/protocol/src/chat-protocol.ts
@@ -233,6 +233,7 @@ export type ChatModelInfo = {
 	maxTokens?: number;
 	available: boolean;
 	defaultThinkingLevel?: ChatThinkingLevel;
+	thinkingLevels?: Array<ChatThinkingLevel>;
 };
 
 export type ChatModelsResponse = {
@@ -305,6 +306,38 @@ export type ChatProviderRemoveRequest = {
 };
 
 export type ChatProviderRemoveResponse = ChatProviderUpdateResponse;
+
+export type ChatProviderOAuthLoginStatus = "waiting" | "success" | "error";
+
+export type ChatProviderOAuthPrompt = {
+	message: string;
+	placeholder?: string;
+	allowEmpty?: boolean;
+};
+
+/**
+ * Start, poll, continue, or cancel an interactive OAuth login.
+ * Device-code providers (GitHub Copilot) return `authUrl` + `userCode` and poll
+ * until the user completes the flow. Callback providers (Anthropic, Codex)
+ * return `authUrl` and optionally accept a pasted redirect via `promptAnswer`.
+ */
+export type ChatProviderOAuthLoginRequest = {
+	providerId: string;
+	loginId?: string;
+	promptAnswer?: string;
+	cancel?: boolean;
+};
+
+export type ChatProviderOAuthLoginResponse = {
+	status: ChatProviderOAuthLoginStatus;
+	loginId?: string;
+	authUrl?: string;
+	userCode?: string;
+	instructions?: string;
+	prompt?: ChatProviderOAuthPrompt;
+	error?: string;
+	providers?: Array<ChatProviderInfo>;
+};
 
 export type ChatSessionResponse = {
 	session: ChatSessionMetadata;

--- a/web/protocol/src/chat-protocol.ts
+++ b/web/protocol/src/chat-protocol.ts
@@ -307,38 +307,6 @@ export type ChatProviderRemoveRequest = {
 
 export type ChatProviderRemoveResponse = ChatProviderUpdateResponse;
 
-export type ChatProviderOAuthLoginStatus = "waiting" | "success" | "error";
-
-export type ChatProviderOAuthPrompt = {
-	message: string;
-	placeholder?: string;
-	allowEmpty?: boolean;
-};
-
-/**
- * Start, poll, continue, or cancel an interactive OAuth login.
- * Device-code providers (GitHub Copilot) return `authUrl` + `userCode` and poll
- * until the user completes the flow. Callback providers (Anthropic, Codex)
- * return `authUrl` and optionally accept a pasted redirect via `promptAnswer`.
- */
-export type ChatProviderOAuthLoginRequest = {
-	providerId: string;
-	loginId?: string;
-	promptAnswer?: string;
-	cancel?: boolean;
-};
-
-export type ChatProviderOAuthLoginResponse = {
-	status: ChatProviderOAuthLoginStatus;
-	loginId?: string;
-	authUrl?: string;
-	userCode?: string;
-	instructions?: string;
-	prompt?: ChatProviderOAuthPrompt;
-	error?: string;
-	providers?: Array<ChatProviderInfo>;
-};
-
 export type ChatSessionResponse = {
 	session: ChatSessionMetadata;
 	messages: Array<ChatMessage>;

--- a/web/protocol/src/schemas/catalog.ts
+++ b/web/protocol/src/schemas/catalog.ts
@@ -21,6 +21,7 @@ export const ChatModelInfoSchema = z
 		maxTokens: z.number().optional(),
 		available: z.boolean(),
 		defaultThinkingLevel: ChatThinkingLevelSchema.optional(),
+		thinkingLevels: z.array(ChatThinkingLevelSchema).optional(),
 	})
 	.openapi({ description: "Chat model info" });
 
@@ -178,6 +179,40 @@ export const ChatProviderRemoveRequestSchema = z
 export const ChatProviderRemoveResponseSchema = ChatProviderUpdateResponseSchema.openapi({
 	description: "Chat provider remove response",
 });
+
+export const ChatProviderOAuthLoginStatusSchema = z
+	.enum(["waiting", "success", "error"])
+	.openapi({ description: "OAuth login status" });
+
+export const ChatProviderOAuthPromptSchema = z
+	.object({
+		message: z.string(),
+		placeholder: z.string().optional(),
+		allowEmpty: z.boolean().optional(),
+	})
+	.openapi({ description: "Interactive OAuth prompt" });
+
+export const ChatProviderOAuthLoginRequestSchema = z
+	.object({
+		providerId: z.string().min(1),
+		loginId: z.string().min(1).optional(),
+		promptAnswer: z.string().max(8192).optional(),
+		cancel: z.boolean().optional(),
+	})
+	.openapi({ description: "Chat provider OAuth login request" });
+
+export const ChatProviderOAuthLoginResponseSchema = z
+	.object({
+		status: ChatProviderOAuthLoginStatusSchema,
+		loginId: z.string().optional(),
+		authUrl: z.string().optional(),
+		userCode: z.string().optional(),
+		instructions: z.string().optional(),
+		prompt: ChatProviderOAuthPromptSchema.optional(),
+		error: z.string().optional(),
+		providers: z.array(ChatProviderInfoSchema).optional(),
+	})
+	.openapi({ description: "Chat provider OAuth login response" });
 
 export const ChatSlashCommandInfoSchema = z
 	.object({

--- a/web/protocol/src/schemas/catalog.ts
+++ b/web/protocol/src/schemas/catalog.ts
@@ -180,40 +180,6 @@ export const ChatProviderRemoveResponseSchema = ChatProviderUpdateResponseSchema
 	description: "Chat provider remove response",
 });
 
-export const ChatProviderOAuthLoginStatusSchema = z
-	.enum(["waiting", "success", "error"])
-	.openapi({ description: "OAuth login status" });
-
-export const ChatProviderOAuthPromptSchema = z
-	.object({
-		message: z.string(),
-		placeholder: z.string().optional(),
-		allowEmpty: z.boolean().optional(),
-	})
-	.openapi({ description: "Interactive OAuth prompt" });
-
-export const ChatProviderOAuthLoginRequestSchema = z
-	.object({
-		providerId: z.string().min(1),
-		loginId: z.string().min(1).optional(),
-		promptAnswer: z.string().max(8192).optional(),
-		cancel: z.boolean().optional(),
-	})
-	.openapi({ description: "Chat provider OAuth login request" });
-
-export const ChatProviderOAuthLoginResponseSchema = z
-	.object({
-		status: ChatProviderOAuthLoginStatusSchema,
-		loginId: z.string().optional(),
-		authUrl: z.string().optional(),
-		userCode: z.string().optional(),
-		instructions: z.string().optional(),
-		prompt: ChatProviderOAuthPromptSchema.optional(),
-		error: z.string().optional(),
-		providers: z.array(ChatProviderInfoSchema).optional(),
-	})
-	.openapi({ description: "Chat provider OAuth login response" });
-
 export const ChatSlashCommandInfoSchema = z
 	.object({
 		name: z.string(),

--- a/web/server/src/handlers/chat-models-discover.ts
+++ b/web/server/src/handlers/chat-models-discover.ts
@@ -52,6 +52,7 @@ export function handleChatModelsDiscoverPost(request: Request): Promise<Response
 				input: ["text"] as Array<"text" | "image">,
 				available: true,
 				defaultThinkingLevel: "off" as const,
+				thinkingLevels: ["off"] as const,
 			}));
 			return Response.json({ providerId: provider, models });
 		} catch {

--- a/web/server/src/handlers/chat-models.ts
+++ b/web/server/src/handlers/chat-models.ts
@@ -1,3 +1,5 @@
+import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
+import type { ChatThinkingLevel } from "@prime-agent/web-protocol/chat-protocol";
 import { isModelPatternEnabled } from "@prime-agent/web-protocol/model-patterns";
 import { getPrimeConfig } from "../prime-config";
 import { wrapApiHandler } from "../wrap-api-handler";
@@ -39,18 +41,23 @@ export function handleChatModelsGet(request: Request): Promise<Response> {
 		const selectedModelKey = defaultProvider && defaultModel ? `${defaultProvider}/${defaultModel}` : undefined;
 
 		return Response.json({
-			models: models.map((m) => ({
-				key: `${m.provider}/${m.id}`,
-				provider: m.provider,
-				id: m.id,
-				name: m.name,
-				reasoning: m.reasoning,
-				input: m.input,
-				contextWindow: m.contextWindow,
-				maxTokens: m.maxTokens,
-				available: registry.hasConfiguredAuth(m),
-				defaultThinkingLevel: m.reasoning ? "medium" : "off",
-			})),
+			models: models.map((m) => {
+				const thinkingLevels = getSupportedThinkingLevels(m) as Array<ChatThinkingLevel>;
+				const fallback: ChatThinkingLevel = m.reasoning ? "medium" : "off";
+				return {
+					key: `${m.provider}/${m.id}`,
+					provider: m.provider,
+					id: m.id,
+					name: m.name,
+					reasoning: m.reasoning,
+					input: m.input,
+					contextWindow: m.contextWindow,
+					maxTokens: m.maxTokens,
+					available: registry.hasConfiguredAuth(m),
+					thinkingLevels,
+					defaultThinkingLevel: thinkingLevels.includes(fallback) ? fallback : (thinkingLevels[0] ?? "off"),
+				};
+			}),
 			...(selectedModelKey ? { selectedModelKey } : {}),
 			...(defaultProvider ? { defaultProvider } : {}),
 			...(defaultModel ? { defaultModel } : {}),

--- a/web/server/src/handlers/chat.ts
+++ b/web/server/src/handlers/chat.ts
@@ -28,6 +28,9 @@ export function handleChatPost(request: Request): Promise<Response> {
 		}
 		if (model !== undefined) {
 			await bridge.setModel(session.sessionId, model);
+			if (typeof model === "object" && typeof model.thinkingLevel === "string") {
+				session.session.setThinkingLevel(model.thinkingLevel);
+			}
 		}
 		if (process.env.PRIME_BRIDGE_DEBUG === "1") {
 			process.stderr.write(

--- a/web/server/src/prime-bridge.ts
+++ b/web/server/src/prime-bridge.ts
@@ -523,9 +523,15 @@ export class PrimeBridge {
 		// for the resolved `Model` the kernel needs to stream with.
 		let resolved = model as Parameters<typeof session.session.setModel>[0];
 		if (model && typeof model === "object" && !Array.isArray(model) && "provider" in model && "id" in model) {
-			const { provider, id, ...rest } = model as {
+			const {
+				provider,
+				id,
+				thinkingLevel: _thinkingLevel,
+				...rest
+			} = model as {
 				provider: string;
 				id: string;
+				thinkingLevel?: unknown;
 			};
 			try {
 				const config = getPrimeConfig();


### PR DESCRIPTION
## Summary
- Adds a visible Effort chip in the composer next to Agent and Model, driven by each model's catalog `thinkingLevels`.
- `/effort` opens that picker; `/effort max` (and other catalog levels) sets the level when the current model supports it.
- Sends `thinkingLevel` on the selected session only (`session.setThinkingLevel`), and strips it before hydrating the registry `Model` in `setModel`.

## Test plan
- [ ] Composer shows Agent, Model, and Effort chips; Effort is not nested in the model menu
- [ ] Switching models reclamps Effort to a level the new model supports
- [ ] `/effort` opens the Effort picker; `/effort max` sets Max when supported; `/effort nope` toasts and opens the picker
- [ ] `/model` still opens the model picker
- [ ] A chat turn sends the selected thinking level (check bridge debug or the resulting reasoning behavior)