### PR TITLE
feat(web): add provider OAuth login types to the chat protocol

### DIFF
--- a/web/protocol/src/chat-protocol.ts
+++ b/web/protocol/src/chat-protocol.ts
@@ -307,6 +307,38 @@ export type ChatProviderRemoveRequest = {
 
 export type ChatProviderRemoveResponse = ChatProviderUpdateResponse;
 
+export type ChatProviderOAuthLoginStatus = "waiting" | "success" | "error";
+
+export type ChatProviderOAuthPrompt = {
+	message: string;
+	placeholder?: string;
+	allowEmpty?: boolean;
+};
+
+/**
+ * Start, poll, continue, or cancel an interactive OAuth login.
+ * Device-code providers (GitHub Copilot) return `authUrl` + `userCode` and poll
+ * until the user completes the flow. Callback providers (Anthropic, Codex)
+ * return `authUrl` and optionally accept a pasted redirect via `promptAnswer`.
+ */
+export type ChatProviderOAuthLoginRequest = {
+	providerId: string;
+	loginId?: string;
+	promptAnswer?: string;
+	cancel?: boolean;
+};
+
+export type ChatProviderOAuthLoginResponse = {
+	status: ChatProviderOAuthLoginStatus;
+	loginId?: string;
+	authUrl?: string;
+	userCode?: string;
+	instructions?: string;
+	prompt?: ChatProviderOAuthPrompt;
+	error?: string;
+	providers?: Array<ChatProviderInfo>;
+};
+
 export type ChatSessionResponse = {
 	session: ChatSessionMetadata;
 	messages: Array<ChatMessage>;

--- a/web/protocol/src/chat-protocol.zod.ts
+++ b/web/protocol/src/chat-protocol.zod.ts
@@ -10,6 +10,8 @@ export {
 	ChatModelsDiscoverResponseSchema,
 	ChatModelsResponseSchema,
 	ChatProviderInfoSchema,
+	ChatProviderOAuthLoginRequestSchema,
+	ChatProviderOAuthLoginResponseSchema,
 	ChatProviderRemoveRequestSchema,
 	ChatProviderRemoveResponseSchema,
 	ChatProvidersResponseSchema,

--- a/web/protocol/src/chat-types.ts
+++ b/web/protocol/src/chat-types.ts
@@ -30,6 +30,8 @@ export type ChatMessage = {
 	role: ChatMessageRole;
 	parts: Array<ChatMessagePart>;
 	createdAt?: Date | string | number;
+	/** Web-only echo from slash handlers; never persisted or sent to the agent. */
+	source?: "local";
 	experimental_attachments?: Array<{
 		contentType?: string;
 		url?: string;

--- a/web/protocol/src/schemas/catalog.ts
+++ b/web/protocol/src/schemas/catalog.ts
@@ -180,6 +180,40 @@ export const ChatProviderRemoveResponseSchema = ChatProviderUpdateResponseSchema
 	description: "Chat provider remove response",
 });
 
+export const ChatProviderOAuthLoginStatusSchema = z
+	.enum(["waiting", "success", "error"])
+	.openapi({ description: "OAuth login status" });
+
+export const ChatProviderOAuthPromptSchema = z
+	.object({
+		message: z.string(),
+		placeholder: z.string().optional(),
+		allowEmpty: z.boolean().optional(),
+	})
+	.openapi({ description: "Interactive OAuth prompt" });
+
+export const ChatProviderOAuthLoginRequestSchema = z
+	.object({
+		providerId: z.string().min(1),
+		loginId: z.string().min(1).optional(),
+		promptAnswer: z.string().max(8192).optional(),
+		cancel: z.boolean().optional(),
+	})
+	.openapi({ description: "Chat provider OAuth login request" });
+
+export const ChatProviderOAuthLoginResponseSchema = z
+	.object({
+		status: ChatProviderOAuthLoginStatusSchema,
+		loginId: z.string().optional(),
+		authUrl: z.string().optional(),
+		userCode: z.string().optional(),
+		instructions: z.string().optional(),
+		prompt: ChatProviderOAuthPromptSchema.optional(),
+		error: z.string().optional(),
+		providers: z.array(ChatProviderInfoSchema).optional(),
+	})
+	.openapi({ description: "Chat provider OAuth login response" });
+
 export const ChatSlashCommandInfoSchema = z
 	.object({
 		name: z.string(),


### PR DESCRIPTION
## Summary
- Adds OAuth login request/response types to the chat protocol so settings can sign in without a parallel contract.
- Marks web-only slash echoes with `source: "local"` on `ChatMessage`.

## Test plan
- [ ] `pnpm --dir web --filter @prime-agent/web-protocol typecheck`
- [ ] Confirm later stack layers type-check against these schemas

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
