### PR TITLE
feat(web): wire OAuth, slash catalog, and stream helpers on the client

### DIFF
--- a/web/app/src/lib/pi/chat-client.ts
+++ b/web/app/src/lib/pi/chat-client.ts
@@ -4,6 +4,8 @@ import type {
 	ChatModelsDiscoverResponse,
 	ChatModelsResponse,
 	ChatProviderInfo,
+	ChatProviderOAuthLoginRequest,
+	ChatProviderOAuthLoginResponse,
 	ChatProviderRemoveRequest,
 	ChatProviderRemoveResponse,
 	ChatProviderUpdateRequest,
@@ -28,6 +30,8 @@ import {
 	ChatModelsDiscoverRequestSchema,
 	ChatModelsDiscoverResponseSchema,
 	ChatModelsResponseSchema,
+	ChatProviderOAuthLoginRequestSchema,
+	ChatProviderOAuthLoginResponseSchema,
 	ChatProviderRemoveRequestSchema,
 	ChatProvidersResponseSchema,
 	ChatProviderUpdateRequestSchema,
@@ -71,6 +75,7 @@ export type ChatClient = {
 		signal?: AbortSignal,
 	) => Promise<void>;
 	getProviders: () => Promise<{ providers: Array<ChatProviderInfo> }>;
+	oauthLoginProvider: (request: ChatProviderOAuthLoginRequest) => Promise<ChatProviderOAuthLoginResponse>;
 	updateProvider: (request: ChatProviderUpdateRequest) => Promise<ChatProviderUpdateResponse>;
 	removeProvider: (request: ChatProviderRemoveRequest) => Promise<ChatProviderRemoveResponse>;
 };
@@ -209,6 +214,15 @@ export const chatClient: ChatClient = {
 
 	async getProviders() {
 		return fetchValidatedJson("/api/chat/providers", ChatProvidersResponseSchema);
+	},
+
+	async oauthLoginProvider(request) {
+		const body = ChatProviderOAuthLoginRequestSchema.parse(request);
+		return fetchValidatedJson("/api/chat/providers/oauth", ChatProviderOAuthLoginResponseSchema, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		});
 	},
 
 	async updateProvider(request) {

--- a/web/app/src/lib/pi/chat-message-helpers.ts
+++ b/web/app/src/lib/pi/chat-message-helpers.ts
@@ -92,13 +92,60 @@ export function upsertAssistantToolPart(messages: Array<ChatMessage>, assistantI
 	});
 }
 
+export function thinkingTextFromPart(part: ChatMessagePart): string {
+	if (part.type !== "tool-Thinking") return "";
+	if (part.input && typeof part.input === "object") {
+		const rec = part.input as Record<string, unknown>;
+		if (typeof rec.thought === "string") return rec.thought;
+		if (typeof rec.text === "string") return rec.text;
+	}
+	if (typeof part.output === "string") return part.output;
+	if (part.output && typeof part.output === "object") {
+		const rec = part.output as Record<string, unknown>;
+		if (typeof rec.thought === "string") return rec.thought;
+		if (typeof rec.text === "string") return rec.text;
+	}
+	return "";
+}
+
+export function assistantTextFromMessage(message: ChatMessage): string {
+	return message.parts
+		.filter((part): part is Extract<ChatMessagePart, { type: "text" }> => part.type === "text")
+		.map((part) => part.text)
+		.join("");
+}
+
+/**
+ * Models that emit only `thinking_delta` (no `text_delta`) would otherwise
+ * leave the user with a Thought fold and no assistant bubble. Promote that
+ * thinking into a text part when the turn has no visible answer.
+ */
+export function promoteThinkingToAssistantText(message: ChatMessage): ChatMessage {
+	if (message.role !== "assistant") return message;
+	if (assistantTextFromMessage(message).trim()) return message;
+	const thinking = message.parts.map(thinkingTextFromPart).join("");
+	if (!thinking.trim()) return message;
+	const tools = message.parts.filter((part) => part.type !== "text" && part.type !== "tool-Thinking");
+	return {
+		...message,
+		parts: [{ type: "text", text: thinking }, ...tools],
+	};
+}
+
 export function upsertAssistantThinkingPart(messages: Array<ChatMessage>, assistantId: string, thought: string) {
-	return upsertAssistantToolPart(
-		messages,
-		assistantId,
-		createThinkingToolPart({
-			messageId: assistantId,
-			thought,
-		}),
-	);
+	return messages.map((message) => {
+		if (message.id !== assistantId) return message;
+		const existing = message.parts.find((part) => part.type === "tool-Thinking");
+		const previous = existing ? thinkingTextFromPart(existing) : "";
+		return {
+			...message,
+			parts: upsertToolPart(
+				message.parts,
+				createThinkingToolPart({
+					messageId: assistantId,
+					thought: `${previous}${thought}`,
+				}),
+			),
+		};
+	});
 }

--- a/web/app/src/lib/pi/chat-queries.ts
+++ b/web/app/src/lib/pi/chat-queries.ts
@@ -1,4 +1,6 @@
 import type {
+	ChatProviderOAuthLoginRequest,
+	ChatProviderOAuthLoginResponse,
 	ChatProviderRemoveRequest,
 	ChatProviderRemoveResponse,
 	ChatProviderUpdateRequest,
@@ -115,6 +117,21 @@ export function useUpdateChatProvider() {
 	return useMutation<ChatProviderUpdateResponse, Error, ChatProviderUpdateRequest>({
 		mutationFn: (request) => chatClient.updateProvider(request),
 		onSuccess: (data) => {
+			queryClient.setQueryData(keys.providers, { providers: data.providers });
+			void queryClient.invalidateQueries({ queryKey: keys.models });
+			void queryClient.invalidateQueries({ queryKey: keys.modelCatalog });
+			void queryClient.invalidateQueries({ queryKey: keys.settings });
+		},
+	});
+}
+
+export function useOAuthLoginProvider() {
+	const queryClient = useQueryClient();
+
+	return useMutation<ChatProviderOAuthLoginResponse, Error, ChatProviderOAuthLoginRequest>({
+		mutationFn: (request) => chatClient.oauthLoginProvider(request),
+		onSuccess: (data) => {
+			if (data.status !== "success" || !data.providers) return;
 			queryClient.setQueryData(keys.providers, { providers: data.providers });
 			void queryClient.invalidateQueries({ queryKey: keys.models });
 			void queryClient.invalidateQueries({ queryKey: keys.modelCatalog });

--- a/web/app/src/lib/pi/chat-runtime-url.test.ts
+++ b/web/app/src/lib/pi/chat-runtime-url.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveChatApiUrl } from "./chat-runtime-url";
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
+
+describe("resolveChatApiUrl", () => {
+	it("routes health checks to the configured runtime and preserves queries", () => {
+		vi.stubEnv("VITE_FLEET_PI_CHAT_RUNTIME_URL", "https://runtime.example/");
+
+		expect(resolveChatApiUrl("/api/health")).toBe("https://runtime.example/api/health");
+		expect(resolveChatApiUrl("/api/health?session=1")).toBe("https://runtime.example/api/health?session=1");
+	});
+
+	it("leaves health checks local when no runtime is configured", () => {
+		vi.stubEnv("VITE_FLEET_PI_CHAT_RUNTIME_URL", "");
+
+		expect(resolveChatApiUrl("/api/health")).toBe("/api/health");
+	});
+});

--- a/web/app/src/lib/pi/chat-runtime-url.ts
+++ b/web/app/src/lib/pi/chat-runtime-url.ts
@@ -1,4 +1,5 @@
 const RUNTIME_API_PREFIXES = [
+	"/api/health",
 	"/api/chat",
 	"/api/chat/abort",
 	"/api/chat/question",

--- a/web/app/src/lib/pi/chat-stream-state.test.ts
+++ b/web/app/src/lib/pi/chat-stream-state.test.ts
@@ -7,6 +7,7 @@ import {
 	type ChatStreamSnapshot,
 	type ChatStreamTransition,
 	EMPTY_QUEUE_STATE,
+	normalizeSessionMetadata,
 } from "./chat-stream-state";
 
 function baseTransition(): ChatStreamTransition {
@@ -126,5 +127,52 @@ describe("applyChatStreamEvent", () => {
 			type: "text",
 			text: "orphan",
 		});
+	});
+
+	it("accumulates thinking deltas and promotes thinking-only turns to assistant text on done", () => {
+		const id = "run-1-a0";
+		let t = applyChatStreamEvent(baseTransition(), start(id));
+		t = applyChatStreamEvent(t, { type: "thinking", text: "fleet-", messageId: id });
+		t = applyChatStreamEvent(t, { type: "thinking", text: "web-ok", messageId: id });
+		const streamed = assistantMessages(t)[0];
+		const thought = streamed.parts.find((part) => part.type === "tool-Thinking");
+		expect(thought && "output" in thought ? thought.output : undefined).toBe("fleet-web-ok");
+
+		t = applyChatStreamEvent(t, {
+			type: "done",
+			runId: "run-1",
+			sessionId: "session-1",
+			message: toChatMessage(id, "assistant", [
+				{
+					type: "tool-Thinking",
+					state: "output-available",
+					input: { thought: "fleet-web-ok" },
+					output: "fleet-web-ok",
+				},
+			]),
+		});
+		expect(t.assistantId).toBeNull();
+		const doneParts = assistantMessages(t)[0].parts;
+		expect(doneParts).toEqual([{ type: "text", text: "fleet-web-ok" }]);
+	});
+
+	it("normalizeSessionMetadata drops blank fields so {} is a real clear", () => {
+		expect(normalizeSessionMetadata({})).toEqual({});
+		expect(normalizeSessionMetadata({ sessionId: "  ", sessionFile: " /tmp/s.jsonl ", cwd: "" })).toEqual({
+			sessionFile: "/tmp/s.jsonl",
+		});
+	});
+
+	it("does not clear live session metadata when done omits sessionId", () => {
+		const id = "run-1-a0";
+		let t = applyChatStreamEvent(baseTransition(), start(id));
+		expect(t.snapshot.sessionMetadata.sessionId).toBe("session-1");
+		t = applyChatStreamEvent(t, {
+			type: "done",
+			runId: "run-1",
+			sessionId: "",
+			message: toChatMessage(id, "assistant", [{ type: "text", text: "ok" }]),
+		});
+		expect(t.snapshot.sessionMetadata.sessionId).toBe("session-1");
 	});
 });

--- a/web/app/src/lib/pi/chat-stream-state.ts
+++ b/web/app/src/lib/pi/chat-stream-state.ts
@@ -5,6 +5,7 @@ import { labelForState } from "./chat-fetch";
 import {
 	appendAssistantDelta,
 	createTextMessage,
+	promoteThinkingToAssistantText,
 	upsertAssistantThinkingPart,
 	upsertAssistantToolPart,
 } from "./chat-message-helpers";
@@ -26,6 +27,31 @@ export const EMPTY_QUEUE_STATE: QueueState = {
 	steering: [],
 	followUp: [],
 };
+
+/** Drop blank session fields so `{}` is a real clear, not a keep-if-empty merge. */
+export function normalizeSessionMetadata(metadata: ChatSessionMetadata): ChatSessionMetadata {
+	const sessionId = metadata.sessionId?.trim() || undefined;
+	const sessionFile = metadata.sessionFile?.trim() || undefined;
+	const cwd = metadata.cwd?.trim() || undefined;
+	return {
+		...(sessionId ? { sessionId } : {}),
+		...(sessionFile ? { sessionFile } : {}),
+		...(cwd ? { cwd } : {}),
+	};
+}
+
+function mergeSessionMetadata(
+	current: ChatSessionMetadata,
+	incoming: { sessionId?: string; sessionFile?: string },
+): ChatSessionMetadata {
+	const sessionId = incoming.sessionId?.trim() || current.sessionId;
+	const sessionFile = incoming.sessionFile?.trim() || current.sessionFile;
+	return {
+		...current,
+		...(sessionId ? { sessionId } : {}),
+		...(sessionFile ? { sessionFile } : {}),
+	};
+}
 
 function hasRenderableParts(message: ChatMessage): boolean {
 	return (message.parts ?? []).some((part) => {
@@ -122,10 +148,10 @@ export function applyChatStreamEvent(transition: ChatStreamTransition, event: Ch
 				messages: alreadyPresent
 					? transition.snapshot.messages
 					: [...transition.snapshot.messages, createTextMessage("assistant", "", event.id)],
-				sessionMetadata: {
+				sessionMetadata: mergeSessionMetadata(transition.snapshot.sessionMetadata, {
 					sessionFile: event.sessionFile,
 					sessionId: event.sessionId,
-				},
+				}),
 			},
 		};
 	}
@@ -222,17 +248,22 @@ export function applyChatStreamEvent(transition: ChatStreamTransition, event: Ch
 	}
 
 	if (event.type === "done") {
+		const merged = replaceOrAppendInFlight(snapshot.messages, event.message, assistantId);
 		return {
 			assistantId: null,
 			snapshot: {
 				...snapshot,
 				activityLabel: undefined,
-				messages: replaceOrAppendInFlight(snapshot.messages, event.message, assistantId),
+				messages: merged.map((message) =>
+					message.role === "assistant" && (message.id === event.message.id || message.id === assistantId)
+						? promoteThinkingToAssistantText(message)
+						: message,
+				),
 				queue: EMPTY_QUEUE_STATE,
-				sessionMetadata: {
+				sessionMetadata: mergeSessionMetadata(snapshot.sessionMetadata, {
 					sessionFile: event.sessionFile,
 					sessionId: event.sessionId,
-				},
+				}),
 			},
 		};
 	}

--- a/web/app/src/lib/pi/slash-commands.test.ts
+++ b/web/app/src/lib/pi/slash-commands.test.ts
@@ -44,29 +44,22 @@ describe("resolveLocalSlashAction", () => {
 		});
 	});
 
-	it("every advertised builtin resolves to a local action", () => {
+	it("every advertised local builtin resolves to a local action", () => {
+		const backendSessionCommands = new Set(["compact", "refine", "goal", "autonomous"]);
 		const unresolved = WEB_BUILTIN_SLASH_COMMANDS.filter(
-			(command) => resolveLocalSlashAction(command.name) === null,
+			(command) => !backendSessionCommands.has(command.name) && resolveLocalSlashAction(command.name) === null,
 		).map((command) => command.name);
 		expect(unresolved).toEqual([]);
 	});
 
-	it("routes compact, refine, goal, and autonomous to local echo stubs", () => {
-		expect(resolveLocalSlashAction("compact")).toEqual({
-			type: "echo",
-			text: "/compact is not wired in the web port.",
-		});
-		expect(resolveLocalSlashAction("refine", "tighten memory")).toEqual({
-			type: "echo",
-			text: "/refine is not wired in the web port. Arguments were not applied:\ntighten memory",
-		});
-		expect(resolveLocalSlashAction("goal")).toEqual({
-			type: "echo",
-			text: "/goal is not wired in the web port.",
-		});
-		expect(resolveLocalSlashAction("autonomous", "on")).toEqual({
-			type: "echo",
-			text: "/autonomous is not wired in the web port. Arguments were not applied:\non",
-		});
+	it("leaves session commands for the backend chat transport", () => {
+		for (const [command, args] of [
+			["compact", "keep the latest context"],
+			["refine", "tighten memory"],
+			["goal", "ship the web stack"],
+			["autonomous", "on"],
+		] as const) {
+			expect(resolveLocalSlashAction(command, args)).toBeNull();
+		}
 	});
 });

--- a/web/app/src/lib/pi/slash-commands.test.ts
+++ b/web/app/src/lib/pi/slash-commands.test.ts
@@ -1,7 +1,36 @@
 import { describe, expect, it } from "vitest";
-import { resolveLocalSlashAction } from "./slash-commands";
+import { buildSlashCommands, resolveLocalSlashAction, WEB_BUILTIN_SLASH_COMMANDS } from "./slash-commands";
+
+describe("buildSlashCommands", () => {
+	it("keeps client dispatcher builtins when the API returns a short catalog", () => {
+		const suggestions = buildSlashCommands(null, false, {
+			commands: [
+				{ name: "settings", description: "Open settings menu" },
+				{ name: "session", description: "Show session info" },
+			],
+		});
+		const ids = suggestions.map((item) => item.id);
+		expect(ids).toContain("settings");
+		expect(ids).toContain("login");
+		expect(ids).toContain("fork");
+		expect(ids).toContain("traces");
+		expect(ids).toContain("mcp");
+		expect(ids).toContain("tree");
+		expect(ids.length).toBeGreaterThanOrEqual(WEB_BUILTIN_SLASH_COMMANDS.length);
+	});
+});
 
 describe("resolveLocalSlashAction", () => {
+	it("routes traces and agents locally so they do not fall through to the LLM", () => {
+		expect(resolveLocalSlashAction("traces")).toEqual({ type: "session-traces" });
+		expect(resolveLocalSlashAction("agents")).toEqual({ type: "session-agents" });
+	});
+
+	it("resolves /btw and /import without args instead of returning null", () => {
+		expect(resolveLocalSlashAction("btw")).toEqual({ type: "session-btw", question: "" });
+		expect(resolveLocalSlashAction("import")).toEqual({ type: "session-import", path: "" });
+	});
+
 	it("opens the effort picker for /effort and sets a named thinking level", () => {
 		expect(resolveLocalSlashAction("effort")).toEqual({ type: "open-effort-picker" });
 		expect(resolveLocalSlashAction("thinking")).toEqual({ type: "open-effort-picker" });
@@ -12,6 +41,32 @@ describe("resolveLocalSlashAction", () => {
 		expect(resolveLocalSlashAction("effort", "nope")).toEqual({
 			type: "open-effort-picker",
 			unknownLevel: "nope",
+		});
+	});
+
+	it("every advertised builtin resolves to a local action", () => {
+		const unresolved = WEB_BUILTIN_SLASH_COMMANDS.filter(
+			(command) => resolveLocalSlashAction(command.name) === null,
+		).map((command) => command.name);
+		expect(unresolved).toEqual([]);
+	});
+
+	it("routes compact, refine, goal, and autonomous to local echo stubs", () => {
+		expect(resolveLocalSlashAction("compact")).toEqual({
+			type: "echo",
+			text: "/compact is not wired in the web port.",
+		});
+		expect(resolveLocalSlashAction("refine", "tighten memory")).toEqual({
+			type: "echo",
+			text: "/refine is not wired in the web port. Arguments were not applied:\ntighten memory",
+		});
+		expect(resolveLocalSlashAction("goal")).toEqual({
+			type: "echo",
+			text: "/goal is not wired in the web port.",
+		});
+		expect(resolveLocalSlashAction("autonomous", "on")).toEqual({
+			type: "echo",
+			text: "/autonomous is not wired in the web port. Arguments were not applied:\non",
 		});
 	});
 });

--- a/web/app/src/lib/pi/slash-commands.ts
+++ b/web/app/src/lib/pi/slash-commands.ts
@@ -8,10 +8,10 @@ import { ChatThinkingLevelSchema } from "@prime-agent/web-protocol/chat-protocol
 /**
  * Web port of prime-agent's builtin slash-command dispatcher
  * (`packages/coding-agent/src/core/slash-commands.ts` + the handler chain in
- * `packages/coding-agent/src/modes/interactive/interactive-mode.ts`). Every
- * canonical name (and the `clear`/`usage`/`thinking`/`rename`/`side` aliases)
- * resolves to a route HERE — autocomplete can freely advertise the full
- * surface because nothing falls through to the LLM.
+ * `packages/coding-agent/src/modes/interactive/interactive-mode.ts`). Local
+ * commands (and the `clear`/`usage`/`thinking`/`rename`/`side` aliases) resolve
+ * here; session commands stay in the normal chat transport so the server can
+ * hand them to AgentSession's command executor.
  */
 export const WEB_BUILTIN_SLASH_COMMANDS: Array<ChatSlashCommandInfo> = [
 	{ name: "settings", description: "Open Settings", source: "builtin" },
@@ -162,8 +162,7 @@ export type LocalSlashAction =
 	| { type: "session-traces" } // /traces
 	| { type: "session-agents" } // /agents
 	| { type: "toggle-fullscreen" } // /fullscreen — TUI only, toast
-	| { type: "quit-app" } // /quit — TUI only, toast
-	| { type: "echo"; text: string }; // advertised builtin with no web wiring yet
+	| { type: "quit-app" }; // /quit — TUI only, toast
 
 /**
  * Aliases are resolved **server-side** by `resolveBuiltinSlashCommandName` in
@@ -208,9 +207,10 @@ export function parseQuotedPathArgument(args: string): string | undefined {
 }
 
 /**
- * Map a slash command (+ optional args) to a client-side action. Every action
- * above `// Serverwork` either calls a bridge endpoint directly or opens a
- * settings surface — nothing returns null for a canonical builtin.
+ * Map a slash command (+ optional args) to a client-side action. Session
+ * commands that the backend executes (`compact`, `refine`, `goal`, and
+ * `autonomous`) intentionally return null so the composer sends the original
+ * slash command through `POST /api/chat`.
  */
 export function resolveLocalSlashAction(command: string, args = ""): LocalSlashAction | null {
 	const canonical = resolveSlashCommandAlias(command);
@@ -288,16 +288,6 @@ export function resolveLocalSlashAction(command: string, args = ""): LocalSlashA
 			return { type: "session-traces" };
 		case "agents":
 			return { type: "session-agents" };
-		case "compact":
-		case "refine":
-		case "goal":
-		case "autonomous":
-			return {
-				type: "echo",
-				text: trimmedArgs
-					? `/${canonical} is not wired in the web port. Arguments were not applied:\n${trimmedArgs}`
-					: `/${canonical} is not wired in the web port.`,
-			};
 		// --- TUI-only; show explicit "not available in web" toast -----------
 		case "changelog":
 			return { type: "show-changelog" };

--- a/web/app/src/lib/pi/slash-commands.ts
+++ b/web/app/src/lib/pi/slash-commands.ts
@@ -14,6 +14,7 @@ import { ChatThinkingLevelSchema } from "@prime-agent/web-protocol/chat-protocol
  * surface because nothing falls through to the LLM.
  */
 export const WEB_BUILTIN_SLASH_COMMANDS: Array<ChatSlashCommandInfo> = [
+	{ name: "settings", description: "Open Settings", source: "builtin" },
 	{
 		name: "model",
 		description: "Open the model picker",
@@ -26,21 +27,104 @@ export const WEB_BUILTIN_SLASH_COMMANDS: Array<ChatSlashCommandInfo> = [
 		argumentHint: "[level]",
 		source: "builtin",
 	},
+	{ name: "fast", description: "Toggle OpenAI Fast mode", source: "builtin" },
 	{
-		name: "settings",
-		description: "Open Settings",
+		name: "scoped-models",
+		description: "Enable/disable models for cycling",
 		source: "builtin",
 	},
 	{
-		name: "new",
-		description: "Start a new chat session",
+		name: "export",
+		description: "Export session (HTML default, or .html/.jsonl path)",
+		argumentHint: "[path]",
 		source: "builtin",
 	},
 	{
-		name: "session",
-		description: "Show current session metadata",
+		name: "import",
+		description: "Import and resume a session from a JSONL file",
+		argumentHint: "<path.jsonl>",
 		source: "builtin",
 	},
+	{ name: "share", description: "Copy the transcript (Gist upload is TUI-only)", source: "builtin" },
+	{ name: "copy", description: "Copy last agent message to clipboard", source: "builtin" },
+	{
+		name: "btw",
+		description: "Ask a side question without adding it to the session",
+		argumentHint: "<question>",
+		source: "builtin",
+	},
+	{
+		name: "name",
+		description: "Set or show the session display name",
+		argumentHint: "[name]",
+		source: "builtin",
+	},
+	{ name: "session", description: "Show current session metadata", source: "builtin" },
+	{ name: "system-prompt", description: "Show the exact system prompt sent to the model", source: "builtin" },
+	{ name: "logs", description: "Show where daemon and client logs are saved", source: "builtin" },
+	{
+		name: "traces",
+		description: "Preview, upload, or configure Prime Agent traces",
+		argumentHint: "[status|on|off|preview|upload]",
+		source: "builtin",
+	},
+	{ name: "context", description: "Show token and context usage", source: "builtin" },
+	{ name: "changelog", description: "Show changelog entries", source: "builtin" },
+	{ name: "hotkeys", description: "Show keyboard shortcuts", source: "builtin" },
+	{
+		name: "fork",
+		description: "Create a new fork from a previous user message",
+		argumentHint: "[message-entry-id]",
+		source: "builtin",
+	},
+	{ name: "clone", description: "Duplicate the current session at the current position", source: "builtin" },
+	{ name: "tree", description: "Show the session tree (switch branches)", source: "builtin" },
+	{ name: "agents", description: "List saved sessions (web stand-in for the TUI agent tray)", source: "builtin" },
+	{ name: "login", description: "Configure provider authentication", source: "builtin" },
+	{ name: "logout", description: "Remove provider authentication", source: "builtin" },
+	{
+		name: "mcp",
+		description: "Open MCP connections in Settings",
+		argumentHint: "[list|login <name>|logout <name>]",
+		source: "builtin",
+	},
+	{ name: "new", description: "Start a new chat session", source: "builtin" },
+	{
+		name: "compact",
+		description: "Compact the session context",
+		argumentHint: "[instructions]",
+		source: "builtin",
+	},
+	{ name: "refine", description: "Refine continual harness prompt notes, skills, and memory", source: "builtin" },
+	{
+		name: "goal",
+		description: "Set or view a persistent goal",
+		argumentHint: "[objective]",
+		source: "builtin",
+	},
+	{
+		name: "autonomous",
+		description: "Set or view autonomous mode",
+		argumentHint: "[status|on|off]",
+		source: "builtin",
+	},
+	{
+		name: "rlm-max-depth",
+		description: "Set or view per-chat RLM max depth",
+		argumentHint: "[<int> [--global]]",
+		source: "builtin",
+	},
+	{
+		name: "heartbeat",
+		description: "Set or view a persistent heartbeat",
+		argumentHint: "[status|pause|resume|stop]",
+		source: "builtin",
+	},
+	{ name: "heartbeats", description: "View user and agent heartbeats", source: "builtin" },
+	{ name: "reload", description: "Reload keybindings, extensions, skills, prompts, and themes", source: "builtin" },
+	{ name: "update", description: "Update Prime Agent (TUI-only)", source: "builtin" },
+	{ name: "fullscreen", description: "Toggle fullscreen (TUI-only)", source: "builtin" },
+	{ name: "quit", description: "Quit (TUI-only; close this tab instead)", source: "builtin" },
 ];
 
 export type SettingsSlashTab = "appearance" | "sandbox" | "providers" | "llm-models" | "skills" | "pi-harness";
@@ -75,8 +159,11 @@ export type LocalSlashAction =
 	| { type: "rlm-max-depth"; args: string } // /rlm-max-depth
 	| { type: "heartbeat-list" } // /heartbeats
 	| { type: "heartbeat-manage"; args: string } // /heartbeat
+	| { type: "session-traces" } // /traces
+	| { type: "session-agents" } // /agents
 	| { type: "toggle-fullscreen" } // /fullscreen — TUI only, toast
-	| { type: "quit-app" }; // /quit — TUI only, toast
+	| { type: "quit-app" } // /quit — TUI only, toast
+	| { type: "echo"; text: string }; // advertised builtin with no web wiring yet
 
 /**
  * Aliases are resolved **server-side** by `resolveBuiltinSlashCommandName` in
@@ -179,11 +266,12 @@ export function resolveLocalSlashAction(command: string, args = ""): LocalSlashA
 		case "share":
 			return { type: "session-share" };
 		case "import":
-			return trimmedArgs
-				? { type: "session-import", path: parseQuotedPathArgument(trimmedArgs) ?? trimmedArgs }
-				: null;
+			return {
+				type: "session-import",
+				path: trimmedArgs ? (parseQuotedPathArgument(trimmedArgs) ?? trimmedArgs) : "",
+			};
 		case "btw":
-			return trimmedArgs ? { type: "session-btw", question: trimmedArgs } : null;
+			return { type: "session-btw", question: trimmedArgs };
 		case "fast":
 			return { type: "fast-toggle" };
 		case "reload":
@@ -196,6 +284,20 @@ export function resolveLocalSlashAction(command: string, args = ""): LocalSlashA
 			return { type: "heartbeat-manage", args: trimmedArgs };
 		case "heartbeats":
 			return { type: "heartbeat-list" };
+		case "traces":
+			return { type: "session-traces" };
+		case "agents":
+			return { type: "session-agents" };
+		case "compact":
+		case "refine":
+		case "goal":
+		case "autonomous":
+			return {
+				type: "echo",
+				text: trimmedArgs
+					? `/${canonical} is not wired in the web port. Arguments were not applied:\n${trimmedArgs}`
+					: `/${canonical} is not wired in the web port.`,
+			};
 		// --- TUI-only; show explicit "not available in web" toast -----------
 		case "changelog":
 			return { type: "show-changelog" };
@@ -226,9 +328,23 @@ function normalizeSlashCommandName(name: string) {
 	return /^[\w.-]+$/.test(normalized) ? normalized : "";
 }
 
+function toSlashSuggestion(command: {
+	name: string;
+	description?: string;
+	argumentHint?: string;
+}): SlashCommandSuggestion {
+	return {
+		id: command.name,
+		label: `/${command.name}`,
+		value: `/${command.name}${command.argumentHint ? ` ${command.argumentHint}` : ""} `,
+		description: command.description,
+	};
+}
+
 /**
- * Prefer API command catalog when present; otherwise fall back to builtins
- * (and optional skill/prompt slash commands when enabled).
+ * Merge client dispatcher builtins with the API catalog and optional
+ * skill/prompt commands. API results must not replace builtins — the server
+ * catalog is a short session-command subset.
  */
 export function buildSlashCommands(
 	resources: ChatResourcesResponse | null,
@@ -241,39 +357,27 @@ export function buildSlashCommands(
 		}>;
 	},
 ): Array<SlashCommandSuggestion> {
-	if (commandsData && commandsData.commands.length > 0) {
-		return commandsData.commands.map((command) => ({
-			id: command.name,
-			label: `/${command.name}`,
-			value: `/${command.name}${command.argumentHint ? ` ${command.argumentHint}` : ""} `,
-			description: command.description,
-		}));
+	const byId = new Map<string, SlashCommandSuggestion>();
+	for (const command of WEB_BUILTIN_SLASH_COMMANDS) {
+		byId.set(command.name, toSlashSuggestion(command));
+	}
+	for (const command of commandsData?.commands ?? []) {
+		if (!byId.has(command.name)) byId.set(command.name, toSlashSuggestion(command));
 	}
 
-	const builtins = WEB_BUILTIN_SLASH_COMMANDS.map((command) => ({
-		id: command.name,
-		label: `/${command.name}`,
-		value: `/${command.name}${command.argumentHint ? ` ${command.argumentHint}` : ""} `,
-		description: command.description,
-	}));
+	if (!enabled || !resources) return Array.from(byId.values());
 
-	if (!enabled || !resources) return builtins;
-
-	const resourceCommands = [...resources.skills, ...resources.prompts].flatMap((resource) => {
-		if (resource.activationStatus && resource.activationStatus !== "active") {
-			return [];
-		}
+	for (const resource of [...resources.skills, ...resources.prompts]) {
+		if (resource.activationStatus && resource.activationStatus !== "active") continue;
 		const commandName = normalizeSlashCommandName(resource.name);
-		if (!commandName) return [];
-		return [
-			{
-				id: commandName,
-				label: `/${commandName}`,
-				value: `/${commandName} `,
-				description: resource.description,
-			},
-		];
-	});
+		if (!commandName || byId.has(commandName)) continue;
+		byId.set(commandName, {
+			id: commandName,
+			label: `/${commandName}`,
+			value: `/${commandName} `,
+			description: resource.description,
+		});
+	}
 
-	return Array.from(new Map([...builtins, ...resourceCommands].map((item) => [item.id, item])).values());
+	return Array.from(byId.values());
 }

--- a/web/app/src/lib/pi/use-chat-view.test.ts
+++ b/web/app/src/lib/pi/use-chat-view.test.ts
@@ -1,0 +1,34 @@
+import type { ChatSessionInfo } from "@prime-agent/web-protocol/chat-protocol";
+import type { ChatMessage } from "@prime-agent/web-protocol/chat-types";
+import { describe, expect, it } from "vitest";
+import { getActiveSessionLabel } from "./use-chat-view";
+
+const session: ChatSessionInfo = {
+	path: "/tmp/session.jsonl",
+	id: "session-1",
+	cwd: "/tmp",
+	created: "2026-08-15T00:00:00.000Z",
+	modified: "2026-08-15T00:00:00.000Z",
+	messageCount: 1,
+	firstMessage: "Transcript title",
+	name: "Saved session name",
+};
+
+const messages: Array<ChatMessage> = [
+	{
+		id: "message-1",
+		role: "user",
+		parts: [{ type: "text", text: "Transcript title" }],
+	},
+];
+
+describe("getActiveSessionLabel", () => {
+	it("prefers an explicit saved session name over the transcript", () => {
+		expect(getActiveSessionLabel("session-1", [session], messages)).toBe("Saved session name");
+	});
+
+	it("falls back to the transcript when no explicit name is saved", () => {
+		const unnamed = { ...session, name: undefined };
+		expect(getActiveSessionLabel("session-1", [unnamed], messages)).toBe("Transcript title");
+	});
+});

--- a/web/app/src/lib/pi/use-chat-view.ts
+++ b/web/app/src/lib/pi/use-chat-view.ts
@@ -198,18 +198,22 @@ function extractMessageText(message: ChatMessage | undefined) {
 		.join(" ");
 }
 
-function getActiveSessionLabel(
+export function getActiveSessionLabel(
 	activeSessionId: string | undefined,
 	sessions: Array<ChatSessionInfo>,
 	messages: Array<ChatMessage>,
 ) {
+	const activeSession = sessions.find((session) => session.id === activeSessionId);
+	if (activeSession?.name?.trim()) {
+		return normalizeSessionLabel(activeSession.name);
+	}
+
 	const lastUserMessage = [...messages]
 		.reverse()
 		.find((message) => message.role === "user" && message.source !== "local");
 	const fromTranscript = normalizeSessionLabel(extractMessageText(lastUserMessage).trim());
 	if (fromTranscript) return fromTranscript;
 
-	const activeSession = sessions.find((session) => session.id === activeSessionId);
 	if (activeSession) {
 		return normalizeSessionLabel(activeSession.name || activeSession.firstMessage || activeSession.id.slice(0, 8));
 	}

--- a/web/app/src/lib/pi/use-chat-view.ts
+++ b/web/app/src/lib/pi/use-chat-view.ts
@@ -203,12 +203,16 @@ function getActiveSessionLabel(
 	sessions: Array<ChatSessionInfo>,
 	messages: Array<ChatMessage>,
 ) {
+	const lastUserMessage = [...messages]
+		.reverse()
+		.find((message) => message.role === "user" && message.source !== "local");
+	const fromTranscript = normalizeSessionLabel(extractMessageText(lastUserMessage).trim());
+	if (fromTranscript) return fromTranscript;
+
 	const activeSession = sessions.find((session) => session.id === activeSessionId);
 	if (activeSession) {
 		return normalizeSessionLabel(activeSession.name || activeSession.firstMessage || activeSession.id.slice(0, 8));
 	}
 
-	const lastUserMessage = [...messages].reverse().find((message) => message.role === "user");
-	const label = extractMessageText(lastUserMessage).trim();
-	return normalizeSessionLabel(label) || "Session";
+	return "Session";
 }

--- a/web/app/src/lib/pi/use-chat-workspace-data.ts
+++ b/web/app/src/lib/pi/use-chat-workspace-data.ts
@@ -1,4 +1,5 @@
 import type { QuestionAnswer } from "@prime-agent/web-design/components/agent-elements/question/question-prompt";
+import type { ForkPickerEntry } from "@prime-agent/web-design/components/fleet-pi/chat/fork-picker-dialog";
 import { notify } from "@prime-agent/web-design/lib/notify";
 import { type ChatModelOption, queueLabel, toModelOption } from "@prime-agent/web-design/lib/pi/chat-helpers";
 import type { ChatMode, ChatPiSettingsUpdate, ChatSettingsResponse } from "@prime-agent/web-protocol/chat-protocol";
@@ -50,6 +51,7 @@ export function useChatWorkspaceData() {
 	const [modelPickerOpen, setModelPickerOpen] = useState(false);
 	const [effortPickerOpen, setEffortPickerOpen] = useState(false);
 	const [chatMode, setChatMode] = useState<ChatMode>("agent");
+	const [forkPickerEntries, setForkPickerEntries] = useState<Array<ForkPickerEntry> | null>(null);
 
 	useEffect(() => {
 		if (user) identifyAnalyticsUser(user);
@@ -142,6 +144,8 @@ export function useChatWorkspaceData() {
 		answerQuestion,
 		appendLocalMessage,
 		error,
+		getMessages,
+		getSessionMetadata,
 		messages,
 		planLabel,
 		queue,
@@ -224,13 +228,16 @@ export function useChatWorkspaceData() {
 		setSettingsDialogOpen(true);
 	}, []);
 
-	const { handleLocalSlashSubmit, handleSlashCommandSelect } = useLocalSlashActions({
+	const { forkFromEntry, handleLocalSlashSubmit, handleSlashCommandSelect } = useLocalSlashActions({
 		appendLocalMessage,
+		getMessages,
+		getSessionMetadata,
 		modelKey,
 		models,
+		onForkPicker: setForkPickerEntries,
 		openSettings,
-		sessionId: sessionMetadata.sessionId,
-		sessionFile: sessionMetadata.sessionFile,
+		resumeSession,
+		sessions,
 		setEffortPickerOpen,
 		setModelKey,
 		setModelPickerOpen,
@@ -304,6 +311,8 @@ export function useChatWorkspaceData() {
 		chatPanelData,
 		commandPaletteOpen,
 		error,
+		forkFromEntry,
+		forkPickerEntries,
 		handleLocalSlashSubmit,
 		handleQuestionAnswer,
 		handleResourceCanvasResizeStart,
@@ -322,6 +331,7 @@ export function useChatWorkspaceData() {
 		resumeSession,
 		sendMessage,
 		sessions,
+		setForkPickerEntries,
 		setChatMode,
 		setCommandPaletteOpen,
 		setEffortPickerOpen,

--- a/web/app/src/lib/pi/use-local-slash-actions.ts
+++ b/web/app/src/lib/pi/use-local-slash-actions.ts
@@ -1,30 +1,43 @@
 import type { SuggestionItem } from "@prime-agent/web-design/components/agent-elements/input/suggestions";
+import type { ForkPickerEntry } from "@prime-agent/web-design/components/fleet-pi/chat/fork-picker-dialog";
 import { notify } from "@prime-agent/web-design/lib/notify";
 import {
 	availableThinkingLevels,
 	type ChatModelOption,
 	thinkingLevelLabel,
 } from "@prime-agent/web-design/lib/pi/chat-helpers";
-import type { ChatThinkingLevel } from "@prime-agent/web-protocol/chat-protocol";
+import type { ChatSessionInfo, ChatSessionMetadata, ChatThinkingLevel } from "@prime-agent/web-protocol/chat-protocol";
+import type { ChatMessage } from "@prime-agent/web-protocol/chat-types";
 import { useCallback } from "react";
+import { assistantTextFromMessage, thinkingTextFromPart } from "./chat-message-helpers";
 import type { LocalSlashAction, SettingsSlashTab } from "./slash-commands";
 import { parseSlashInput, resolveLocalSlashAction } from "./slash-commands";
 
 const CHAT_COMMAND_URL = "/api/chat/command";
 
+export type { ForkPickerEntry };
+
 type UseLocalSlashActionsArgs = {
 	appendLocalMessage: (text: string) => void;
+	getMessages: () => Array<ChatMessage>;
+	getSessionMetadata: () => ChatSessionMetadata;
 	modelKey: string | undefined;
 	models: Array<ChatModelOption>;
+	onForkPicker: (entries: Array<ForkPickerEntry>) => void;
 	openSettings: (tab?: SettingsSlashTab) => void;
-	sessionId: string | undefined;
-	sessionFile: string | null | undefined;
+	resumeSession: (metadata: ChatSessionMetadata) => Promise<void>;
+	sessions: Array<ChatSessionInfo>;
 	setEffortPickerOpen: (open: boolean) => void;
 	setModelKey: (key: string | undefined) => void;
 	setModelPickerOpen: (open: boolean) => void;
 	setThinkingLevel: (level: ChatThinkingLevel) => void;
 	startNewSession: () => void;
 };
+
+function liveSessionId(metadata: ChatSessionMetadata): string | undefined {
+	const id = metadata.sessionId?.trim();
+	return id ? id : undefined;
+}
 
 /** Format a payload for the conversation echo the TUI would have shown. */
 function formatSessionInfo({
@@ -36,11 +49,9 @@ function formatSessionInfo({
 	sessionFile: string | null | undefined;
 	name: string | null;
 }) {
-	return [
-		name ? `Session: ${name}` : "Session",
-		`  id:   ${sessionId}`,
-		`  file: ${sessionFile ?? "(not yet persisted)"}`,
-	].join("\n");
+	const id = sessionId.trim() || "none";
+	const file = sessionFile?.trim() || "(not yet persisted)";
+	return [name ? `Session: ${name}` : "Session", `  id:   ${id}`, `  file: ${file}`].join("\n");
 }
 
 /** Structural mirror of the bridge's session-tree node (only the fields the echo needs). */
@@ -105,13 +116,57 @@ function formatSessionTree(nodes: SessionTreeBranch[], leafId: string | null): s
 	return lines.length > 0 ? lines.join("\n") : "(empty session tree)";
 }
 
+function flattenForkCandidates(nodes: SessionTreeBranch[]): Array<ForkPickerEntry> {
+	const all: Array<ForkPickerEntry> = [];
+	const users: Array<ForkPickerEntry> = [];
+	const walk = (items: SessionTreeBranch[]) => {
+		for (const item of items) {
+			if (item.entry.type === "message") {
+				const entry = { id: item.entry.id, preview: treeEntryPreview(item) };
+				all.push(entry);
+				if (item.entry.message?.role === "user") users.push(entry);
+			}
+			walk(item.children);
+		}
+	};
+	walk(nodes);
+	return users.length > 0 ? users : all;
+}
+
+function lastAssistantCopyText(messages: Array<ChatMessage>): string | undefined {
+	for (let i = messages.length - 1; i >= 0; i -= 1) {
+		const message = messages[i];
+		if (!message || message.role !== "assistant" || message.source === "local") continue;
+		const text = assistantTextFromMessage(message).trim();
+		if (text) return text;
+		const thinking = message.parts.map(thinkingTextFromPart).join("").trim();
+		if (thinking) return thinking;
+	}
+	return undefined;
+}
+
+function transcriptMarkdown(messages: Array<ChatMessage>): string {
+	return messages
+		.filter((message) => message.source !== "local")
+		.map((message) => {
+			const text =
+				assistantTextFromMessage(message).trim() || message.parts.map(thinkingTextFromPart).join("").trim();
+			return `**${message.role}**\n\n${text}`;
+		})
+		.filter((block) => block.trim().length > 0)
+		.join("\n\n---\n\n");
+}
+
 export function useLocalSlashActions({
 	appendLocalMessage,
+	getMessages,
+	getSessionMetadata,
 	modelKey,
 	models,
+	onForkPicker,
 	openSettings,
-	sessionId,
-	sessionFile,
+	resumeSession,
+	sessions,
 	setEffortPickerOpen,
 	setModelKey,
 	setModelPickerOpen,
@@ -121,6 +176,7 @@ export function useLocalSlashActions({
 	/** Fire the bridge runner and echo the result into the transcript. */
 	const chatCommand = useCallback(
 		async (command: string, args = ""): Promise<ChatCommandResult> => {
+			const sessionId = liveSessionId(getSessionMetadata());
 			if (!sessionId) {
 				return {
 					ok: false,
@@ -155,7 +211,7 @@ export function useLocalSlashActions({
 				};
 			}
 		},
-		[sessionId],
+		[getSessionMetadata],
 	);
 
 	/**
@@ -178,9 +234,14 @@ export function useLocalSlashActions({
 				newSessionId: typeof result.payload.newSessionId === "string" ? result.payload.newSessionId : "?",
 				selectedText: typeof result.payload.selectedText === "string" ? result.payload.selectedText : "(none)",
 			};
+			notify.success(format(payload));
+			if (payload.newSessionId !== "?") {
+				await resumeSession({ sessionId: payload.newSessionId });
+				return;
+			}
 			appendLocalMessage(format(payload));
 		},
-		[appendLocalMessage],
+		[appendLocalMessage, resumeSession],
 	);
 
 	const applyLocalSlashAction = useCallback(
@@ -225,15 +286,23 @@ export function useLocalSlashActions({
 					return true;
 				case "session-info": {
 					void (async () => {
+						const metadata = getSessionMetadata();
+						const sessionId = liveSessionId(metadata);
 						const result = await chatCommand("session");
 						if (!result.ok || !sessionId) {
-							appendLocalMessage(formatSessionInfo({ sessionId: sessionId ?? "none", sessionFile, name: null }));
+							appendLocalMessage(
+								formatSessionInfo({
+									sessionId: sessionId ?? "none",
+									sessionFile: metadata.sessionFile,
+									name: null,
+								}),
+							);
 							return;
 						}
 						appendLocalMessage(
 							formatSessionInfo({
 								sessionId,
-								sessionFile,
+								sessionFile: metadata.sessionFile,
 								name: typeof result.payload.name === "string" ? result.payload.name : null,
 							}),
 						);
@@ -311,17 +380,30 @@ export function useLocalSlashActions({
 					return true;
 				}
 				case "session-fork": {
-					if (!action.args) {
-						appendLocalMessage(
-							"Usage: /fork <message-entry-id> — the web port has no fork picker yet; run /tree to list entry ids.",
+					if (action.args) {
+						void echoBranchResult(
+							chatCommand("fork", action.args),
+							"Fork",
+							(payload) => `Forked → session ${payload.newSessionId}. Selected text: ${payload.selectedText}`,
 						);
 						return true;
 					}
-					void echoBranchResult(
-						chatCommand("fork", action.args),
-						"Fork",
-						(payload) => `Forked → session ${payload.newSessionId}. Selected text: ${payload.selectedText}`,
-					);
+					void (async () => {
+						const result = await chatCommand("tree");
+						if (!result.ok) {
+							appendLocalMessage(`Fork picker failed: ${result.error}`);
+							return;
+						}
+						const payload = result.payload.tree as
+							| { tree?: SessionTreeBranch[]; leafId?: string | null }
+							| undefined;
+						const candidates = Array.isArray(payload?.tree) ? flattenForkCandidates(payload.tree) : [];
+						if (candidates.length === 0) {
+							appendLocalMessage("No fork points yet — send a user message first, then run /fork.");
+							return;
+						}
+						onForkPicker(candidates);
+					})();
 					return true;
 				}
 				case "session-clone": {
@@ -350,15 +432,56 @@ export function useLocalSlashActions({
 					})();
 					return true;
 				}
-				case "session-share":
-					appendLocalMessage("/share (Gist) is not yet wired in the web port.");
+				case "session-share": {
+					void (async () => {
+						const markdown = transcriptMarkdown(getMessages());
+						if (!markdown.trim()) {
+							appendLocalMessage("Nothing to share yet.");
+							return;
+						}
+						await navigator.clipboard.writeText(markdown);
+						notify.success("Transcript copied");
+						appendLocalMessage(
+							"Copied the transcript to the clipboard. GitHub Gist upload is TUI-only in this port.",
+						);
+					})().catch((error) => {
+						notify.error(`Share failed: ${error instanceof Error ? error.message : String(error)}`);
+					});
 					return true;
+				}
 				case "session-import":
-					appendLocalMessage("/import [path] is not yet wired in the web port.");
+					appendLocalMessage(
+						action.path
+							? `/import ${action.path} is not wired in the web port. Resume a saved conversation from the session picker instead.`
+							: "Usage: /import <path.jsonl> — JSONL import is not wired in the web port. Use the session picker to resume.",
+					);
 					return true;
 				case "session-btw":
-					appendLocalMessage("/btw side-questions are not yet wired in the web port.");
+					appendLocalMessage(
+						action.question
+							? `/btw is not wired in the web port. Side question was not sent:\n${action.question}`
+							: "Usage: /btw <question> — side questions are not wired in the web port.",
+					);
 					return true;
+				case "session-traces":
+					appendLocalMessage(
+						"Prime Agent traces (preview / upload / login) are TUI-only. The web port does not upload traces.",
+					);
+					return true;
+				case "session-agents": {
+					if (sessions.length === 0) {
+						appendLocalMessage(
+							"No saved sessions. The web port has no daemon agent tray — use the conversation picker in the header.",
+						);
+						return true;
+					}
+					const lines = sessions.map((session) => {
+						const label = session.name || session.firstMessage || "(unnamed)";
+						return `${session.id}  ${label}`;
+					});
+					appendLocalMessage(`Saved sessions (web stand-in for /agents):\n${lines.join("\n")}`);
+					return true;
+				}
 				case "open-providers":
 					openSettings("providers");
 					return true;
@@ -405,8 +528,12 @@ export function useLocalSlashActions({
 					return true;
 				case "copy-last-reply": {
 					void (async () => {
-						// Pull from the React state, mirror what the user sees (last assistant turn).
-						await navigator.clipboard.writeText("(grabbed from chat UI)");
+						const text = lastAssistantCopyText(getMessages());
+						if (!text) {
+							notify.error("No assistant message to copy");
+							return;
+						}
+						await navigator.clipboard.writeText(text);
 						notify.success("Last assistant message copied");
 					})().catch((error) => {
 						notify.error(`Copy failed: ${error instanceof Error ? error.message : String(error)}`);
@@ -431,7 +558,12 @@ export function useLocalSlashActions({
 					return true;
 				case "heartbeat-manage":
 				case "heartbeat-list":
-					appendLocalMessage("/heartbeat(s) are not yet wired in the web port.");
+					appendLocalMessage(
+						"/heartbeat(s) are not wired in the web port. Persistent heartbeats remain TUI/session-cron.",
+					);
+					return true;
+				case "echo":
+					appendLocalMessage(action.text);
 					return true;
 				default: {
 					const exhaustiveCheck: never = action;
@@ -444,11 +576,13 @@ export function useLocalSlashActions({
 			appendLocalMessage,
 			chatCommand,
 			echoBranchResult,
+			getMessages,
+			getSessionMetadata,
 			modelKey,
 			models,
+			onForkPicker,
 			openSettings,
-			sessionFile,
-			sessionId,
+			sessions,
 			setEffortPickerOpen,
 			setModelKey,
 			setModelPickerOpen,
@@ -477,8 +611,20 @@ export function useLocalSlashActions({
 		[applyLocalSlashAction],
 	);
 
+	const forkFromEntry = useCallback(
+		(entryId: string) => {
+			void echoBranchResult(
+				chatCommand("fork", entryId),
+				"Fork",
+				(payload) => `Forked → session ${payload.newSessionId}. Selected text: ${payload.selectedText}`,
+			);
+		},
+		[chatCommand, echoBranchResult],
+	);
+
 	return {
 		applyLocalSlashAction,
+		forkFromEntry,
 		handleLocalSlashSubmit,
 		handleSlashCommandSelect,
 	};

--- a/web/app/src/lib/pi/use-local-slash-actions.ts
+++ b/web/app/src/lib/pi/use-local-slash-actions.ts
@@ -562,9 +562,6 @@ export function useLocalSlashActions({
 						"/heartbeat(s) are not wired in the web port. Persistent heartbeats remain TUI/session-cron.",
 					);
 					return true;
-				case "echo":
-					appendLocalMessage(action.text);
-					return true;
 				default: {
 					const exhaustiveCheck: never = action;
 					void exhaustiveCheck;

--- a/web/app/src/lib/pi/use-pi-chat-messaging.ts
+++ b/web/app/src/lib/pi/use-pi-chat-messaging.ts
@@ -201,6 +201,7 @@ export function usePiChatMessaging({
 		async ({
 			text,
 			planAction,
+			mode,
 			/** Mirror of the Alt/Option modifier at Enter-press time. */
 			altKey,
 		}: SendMessageInput) => {
@@ -245,6 +246,7 @@ export function usePiChatMessaging({
 						message: trimmed,
 						model,
 						planAction,
+						mode,
 						sessionFile: sessionMetadataRef.current.sessionFile,
 						sessionId: sessionMetadataRef.current.sessionId,
 					},

--- a/web/app/src/lib/pi/use-pi-chat.ts
+++ b/web/app/src/lib/pi/use-pi-chat.ts
@@ -1,5 +1,6 @@
 import { notify } from "@prime-agent/web-design/lib/notify";
 import type {
+	ChatMode,
 	ChatModelSelection,
 	ChatPlanAction,
 	ChatQuestionAnswer,
@@ -13,7 +14,7 @@ import type { ChatClient } from "./chat-client";
 import { chatClient } from "./chat-client";
 import type { QueueState } from "./chat-fetch";
 import { resolveChatApiUrl } from "./chat-runtime-url";
-import { EMPTY_QUEUE_STATE } from "./chat-stream-state";
+import { EMPTY_QUEUE_STATE, normalizeSessionMetadata } from "./chat-stream-state";
 import { isPlanDecisionToolCall } from "./plan-state";
 import { runForbiddenSessionRecovery, tryRecoverForbiddenSession } from "./use-pi-chat-forbidden-session";
 import { usePiChatMessaging } from "./use-pi-chat-messaging";
@@ -22,6 +23,7 @@ import { enhancePlanDecisionMessages, resolvePlanDecisionMessages } from "./use-
 export type SendMessageInput = {
 	text: string;
 	planAction?: ChatPlanAction;
+	mode?: ChatMode;
 	/** Mirror of the Alt/Option modifier at Enter-press time. */
 	altKey?: boolean;
 };
@@ -74,6 +76,7 @@ export function usePiChat(model: ChatModelSelection | undefined, options: UsePiC
 				{
 					id: crypto.randomUUID(),
 					role: "assistant" as const,
+					source: "local",
 					createdAt: Date.now(),
 					parts: [{ type: "text" as const, text }],
 				},
@@ -84,16 +87,19 @@ export function usePiChat(model: ChatModelSelection | undefined, options: UsePiC
 
 	const setSessionMetadataSynced = useCallback(
 		(metadata: ChatSessionMetadata) => {
+			const current = sessionMetadataRef.current;
+			const next = normalizeSessionMetadata(metadata);
 			if (
-				sessionMetadataRef.current.sessionFile === metadata.sessionFile &&
-				sessionMetadataRef.current.sessionId === metadata.sessionId
+				current.sessionFile === next.sessionFile &&
+				current.sessionId === next.sessionId &&
+				current.cwd === next.cwd
 			) {
 				return;
 			}
 
-			sessionMetadataRef.current = metadata;
-			setSessionMetadata(metadata);
-			persistSession(metadata);
+			sessionMetadataRef.current = next;
+			setSessionMetadata(next);
+			persistSession(next);
 		},
 		[persistSession],
 	);
@@ -275,7 +281,10 @@ export function usePiChat(model: ChatModelSelection | undefined, options: UsePiC
 	});
 
 	const stop = useCallback(() => {
-		void client.abortSession(sessionMetadataRef.current).catch(() => undefined);
+		const metadata = sessionMetadataRef.current;
+		if (metadata.sessionId || metadata.sessionFile) {
+			void client.abortSession(metadata).catch(() => undefined);
+		}
 		abortRef.current?.abort();
 		abortRef.current = null;
 		setStatus("ready");
@@ -475,11 +484,16 @@ export function usePiChat(model: ChatModelSelection | undefined, options: UsePiC
 
 	const answerQuestion = submitQuestionAnswer;
 
+	const getSessionMetadata = useCallback(() => sessionMetadataRef.current, []);
+	const getMessages = useCallback(() => messagesRef.current, []);
+
 	return {
 		activityLabel,
 		answerQuestion,
 		appendLocalMessage,
 		error,
+		getMessages,
+		getSessionMetadata,
 		messages: enhancedMessages,
 		planLabel,
 		queue,

--- a/web/design/src/components/fleet-pi/chat/fork-picker-dialog.tsx
+++ b/web/design/src/components/fleet-pi/chat/fork-picker-dialog.tsx
@@ -1,0 +1,57 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "../../dialog"
+
+export type ForkPickerEntry = {
+  id: string
+  preview: string
+}
+
+export type ForkPickerDialogProps = {
+  entries: Array<ForkPickerEntry> | null
+  onOpenChange: (open: boolean) => void
+  onPick: (entryId: string) => void
+}
+
+export function ForkPickerDialog({
+  entries,
+  onOpenChange,
+  onPick,
+}: ForkPickerDialogProps) {
+  const open = entries !== null && entries.length > 0
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Fork from a message</DialogTitle>
+          <DialogDescription>
+            Creates a new session branched before the selected user message.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex max-h-[min(420px,60vh)] flex-col gap-1 overflow-y-auto">
+          {(entries ?? []).map((entry) => (
+            <button
+              key={entry.id}
+              type="button"
+              className="flex w-full cursor-pointer flex-col gap-0.5 rounded-md px-2 py-2 text-left text-[13px] leading-5 hover:bg-foreground/6"
+              onClick={() => {
+                onPick(entry.id)
+                onOpenChange(false)
+              }}
+            >
+              <span className="truncate font-medium">{entry.preview}</span>
+              <span className="truncate font-mono text-[11px] text-foreground/40">
+                {entry.id}
+              </span>
+            </button>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Summary
- Routes provider OAuth through the chat client and TanStack Start proxy.
- Keeps advertised slash commands from falling through to the LLM.
- Hardens stream/message helpers for local echoes and copy/share.

## Test plan
- [ ] From `web/app`: `npx tsx ../../node_modules/vitest/dist/cli.js --run src/lib/pi/slash-commands.test.ts src/lib/pi/chat-stream-state.test.ts`
- [ ] Confirm `/fork`, `/traces`, and `/echo` no longer send as user text

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
