### PR TITLE
feat(web): wire OpenUI chat artifacts

### DIFF
--- a/web/app/src/lib/pi/use-pi-chat-messaging.ts
+++ b/web/app/src/lib/pi/use-pi-chat-messaging.ts
@@ -1,5 +1,10 @@
 import { notify } from "@prime-agent/web-design/lib/notify";
-import type { ChatModelSelection, ChatSessionMetadata, ChatStreamEvent } from "@prime-agent/web-protocol/chat-protocol";
+import type {
+	ChatMode,
+	ChatModelSelection,
+	ChatSessionMetadata,
+	ChatStreamEvent,
+} from "@prime-agent/web-protocol/chat-protocol";
 import type { ChatMessage, ChatStatus } from "@prime-agent/web-protocol/chat-types";
 import type { MutableRefObject } from "react";
 import { useCallback, useRef } from "react";
@@ -139,7 +144,7 @@ export function usePiChatMessaging({
 	);
 
 	const enqueueDuringStream = useCallback(
-		async (trimmed: string, streamingBehavior: "steer" | "followUp" = "steer") => {
+		async (trimmed: string, streamingBehavior: "steer" | "followUp" = "steer", mode?: ChatMode) => {
 			await ensureSession();
 			const userMessage = createTextMessage("user", trimmed);
 			setMessagesSynced((current) => [...current, userMessage]);
@@ -150,6 +155,7 @@ export function usePiChatMessaging({
 					{
 						message: trimmed,
 						model,
+						mode,
 						sessionFile: sessionMetadataRef.current.sessionFile,
 						sessionId: sessionMetadataRef.current.sessionId,
 						streamingBehavior,
@@ -212,7 +218,7 @@ export function usePiChatMessaging({
 				try {
 					// Enter during stream = steer into the current turn.
 					// Alt+Enter during stream = queue a follow-up after this turn.
-					await enqueueDuringStream(trimmed, altKey ? "followUp" : "steer");
+					await enqueueDuringStream(trimmed, altKey ? "followUp" : "steer", mode);
 				} catch (err) {
 					const nextError = err instanceof Error ? err : new Error(String(err));
 					setError(nextError);

--- a/web/server/src/__tests__/prime-bridge.test.ts
+++ b/web/server/src/__tests__/prime-bridge.test.ts
@@ -173,6 +173,24 @@ describe("PrimeBridge.forkSession", () => {
 		return { userEntryId, assistantEntryId };
 	}
 
+	it("injects OpenUI guidance and updates it when the chat mode changes", async () => {
+		const bridge = new PrimeBridge();
+		const created = await bridge.createSession({ cwd: workDir, mode: "plan" });
+
+		const planPrompt = bridge.getSystemPrompt(created.sessionId);
+		expect(planPrompt).toContain("Every OpenUI block must start with `root = Root(...)` as its first line.");
+		expect(planPrompt).toContain("Do not use OpenUI actions in Plan mode.");
+
+		const prompt = vi.spyOn(created.session, "prompt").mockResolvedValue(undefined);
+		await bridge.prompt(created.sessionId, "show a compact status summary", { mode: "agent" });
+
+		expect(bridge.getSystemPrompt(created.sessionId)).toContain(
+			"Use OpenUI for dashboards, structured comparisons, progress/status summaries, result cards, metrics, and interactive forms.",
+		);
+		expect(bridge.getSystemPrompt(created.sessionId)).not.toContain("Do not use OpenUI actions in Plan mode.");
+		expect(prompt).toHaveBeenCalledOnce();
+	});
+
 	it("position 'before' on a user message targets the parent entry and extracts selectedText", async () => {
 		const bridge = new PrimeBridge();
 		const created = await createTestSession(bridge);

--- a/web/server/src/handlers/chat.ts
+++ b/web/server/src/handlers/chat.ts
@@ -6,7 +6,7 @@ export function handleChatPost(request: Request): Promise<Response> {
 	return wrapApiHandler(async () => {
 		const raw = await request.json();
 		const body = ChatRequestSchema.parse(raw);
-		const { sessionId, sessionFile, message, model } = body;
+		const { sessionId, sessionFile, message, model, mode, planAction } = body;
 		if (!message || typeof message !== "string") {
 			return Response.json({ message: "POST /api/chat requires a `message` string." }, { status: 400 });
 		}
@@ -81,6 +81,8 @@ export function handleChatPost(request: Request): Promise<Response> {
 				void bridge
 					.prompt(session.sessionId, message, {
 						streamingBehavior: body.streamingBehavior,
+						mode,
+						planAction,
 					})
 					.catch((error) => {
 						process.stderr.write(

--- a/web/server/src/prime-bridge.ts
+++ b/web/server/src/prime-bridge.ts
@@ -13,8 +13,22 @@
 import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage, ImageContent, UserMessage } from "@earendil-works/pi-ai";
 import type { AgentSession, AgentSessionEvent, SessionEntry, SessionInfo } from "@earendil-works/pi-coding-agent";
-import { createAgentSession, IpythonKernelProvisioner, SessionManager } from "@earendil-works/pi-coding-agent";
-import type { ChatMessage, ChatQuestionAnswer, ChatStreamEvent } from "@prime-agent/web-protocol";
+import {
+	AuthStorage,
+	createAgentSessionFromServices,
+	createAgentSessionServices,
+	IpythonKernelProvisioner,
+	SessionManager,
+} from "@earendil-works/pi-coding-agent";
+import {
+	buildOpenUIPrompt,
+	type ChatMessage,
+	type ChatMode,
+	type ChatPlanAction,
+	type ChatQuestionAnswer,
+	type ChatStreamEvent,
+	type OpenUIPromptMode,
+} from "@prime-agent/web-protocol";
 
 import {
 	createEventMapperState,
@@ -214,6 +228,7 @@ export interface BridgeSession {
 	readonly cwd: string;
 	readonly sessionPath: string;
 	readonly session: AgentSession;
+	readonly openUIPrompt: OpenUIPromptSessionState;
 	readonly mapperState: ReturnType<typeof createEventMapperState>;
 	readonly uiContext: WebUIContext;
 }
@@ -222,6 +237,7 @@ export interface CreateSessionOptions {
 	readonly cwd: string;
 	readonly model?: unknown;
 	readonly thinkingLevel?: ThinkingLevel;
+	readonly mode?: ChatMode;
 }
 
 export type BridgeEventListener = (sessionId: string, frame: ChatStreamEvent) => void;
@@ -250,6 +266,46 @@ export interface PrimeBridgeOptions {
 }
 
 type KernelReadySnapshot = { ok: true } | { ok: false; reason: string };
+
+type OpenUIPromptSessionState = {
+	mode: OpenUIPromptMode;
+	prompt: string;
+};
+
+function createOpenUIPromptSessionState(mode: OpenUIPromptMode = "agent"): OpenUIPromptSessionState {
+	return { mode, prompt: buildOpenUIPrompt(mode) };
+}
+
+function resolveOpenUIPromptMode(mode?: ChatMode, planAction?: ChatPlanAction): OpenUIPromptMode {
+	if (planAction === "execute") return "plan-execution";
+	if (planAction === "refine") return "plan";
+	return mode ?? "agent";
+}
+
+async function createWebAgentSession(options: {
+	cwd: string;
+	sessionManager?: SessionManager;
+	openUIPrompt: OpenUIPromptSessionState;
+}) {
+	const authStorage = AuthStorage.create();
+	const services = await createAgentSessionServices({
+		cwd: options.cwd,
+		authStorage,
+		// The web bridge historically used the bare SDK path. Keep its telemetry
+		// and built-in Herdr behavior unchanged while adding the web-only prompt.
+		noBuiltinHerdrReporter: true,
+		telemetryDisabled: true,
+		resourceLoaderOptions: {
+			appendSystemPromptOverride: (base) => [...base, options.openUIPrompt.prompt],
+		},
+	});
+	const result = await createAgentSessionFromServices({
+		services,
+		sessionManager: options.sessionManager ?? SessionManager.create(options.cwd),
+		telemetryDisabled: true,
+	});
+	return { ...result, openUIPrompt: options.openUIPrompt };
+}
 
 export class PrimeBridge {
 	readonly #sessions = new Map<string, BridgeSession>();
@@ -359,8 +415,13 @@ export class PrimeBridge {
 		void this.ensureKernelReady().catch(() => {
 			/* backgrounded; failures surface on first tool use */
 		});
-		const { session, extensionsResult: _ext } = await createAgentSession({
+		const {
+			session,
+			extensionsResult: _ext,
+			openUIPrompt,
+		} = await createWebAgentSession({
 			cwd: options.cwd,
+			openUIPrompt: createOpenUIPromptSessionState(resolveOpenUIPromptMode(options.mode)),
 		});
 		// Force-flush the session header to disk eagerly so /api/chat/sessions and
 		// future `resumeSessionById` calls (across Vite SSR restarts) can find it.
@@ -375,6 +436,7 @@ export class PrimeBridge {
 			session,
 			options.cwd,
 			session.sessionManager.getSessionFile() ?? "",
+			openUIPrompt,
 		);
 		if (options.model) {
 			await session.setModel(options.model as Parameters<typeof session.setModel>[0]);
@@ -390,7 +452,12 @@ export class PrimeBridge {
 	 * fork). Binds the web UI context, forwards session events into the ring
 	 * buffer, and tracks the session in `#sessions`.
 	 */
-	async #registerSession(session: AgentSession, cwd: string, sessionPath: string): Promise<BridgeSession> {
+	async #registerSession(
+		session: AgentSession,
+		cwd: string,
+		sessionPath: string,
+		openUIPrompt: OpenUIPromptSessionState,
+	): Promise<BridgeSession> {
 		const sessionId = session.sessionManager.getSessionId();
 		const uiContext = new WebUIContext({
 			sessionId,
@@ -407,6 +474,7 @@ export class PrimeBridge {
 			cwd,
 			sessionPath,
 			session,
+			openUIPrompt,
 			mapperState,
 			uiContext,
 		};
@@ -447,11 +515,17 @@ export class PrimeBridge {
 			}
 		}
 		const sessionManager = await SessionManager.openAsync(sessionPath);
-		const agentSessionResult = await createAgentSession({
+		const agentSessionResult = await createWebAgentSession({
 			cwd: sessionManager.getCwd(),
 			sessionManager,
+			openUIPrompt: createOpenUIPromptSessionState(),
 		});
-		return this.#registerSession(agentSessionResult.session, sessionManager.getCwd(), sessionPath);
+		return this.#registerSession(
+			agentSessionResult.session,
+			sessionManager.getCwd(),
+			sessionPath,
+			agentSessionResult.openUIPrompt,
+		);
 	}
 
 	async resumeSessionById(sessionId: string): Promise<BridgeSession | undefined> {
@@ -489,9 +563,12 @@ export class PrimeBridge {
 		options?: {
 			images?: ImageContent[];
 			streamingBehavior?: "steer" | "followUp";
+			mode?: ChatMode;
+			planAction?: ChatPlanAction;
 		},
 	): Promise<void> {
 		const session = this.#requireSession(sessionId);
+		this.#setOpenUIPromptMode(session, resolveOpenUIPromptMode(options?.mode, options?.planAction));
 		if (process.env.PRIME_BRIDGE_DEBUG === "1") {
 			process.stderr.write(
 				`[bridge:${sessionId.slice(0, 8)}] prompt model=${session.session.agent?.state?.model?.provider ?? "?"}/${session.session.agent?.state?.model?.id ?? "?"} thinkingLevel=${session.session.agent?.state?.thinkingLevel ?? "?"}\n`,
@@ -501,6 +578,23 @@ export class PrimeBridge {
 			images: options?.images,
 			streamingBehavior: options?.streamingBehavior,
 		});
+	}
+
+	#setOpenUIPromptMode(session: BridgeSession, mode: OpenUIPromptMode): void {
+		if (session.openUIPrompt.mode === mode) return;
+
+		const nextPrompt = buildOpenUIPrompt(mode);
+		const appendSystemPrompt = session.session.resourceLoader.getAppendSystemPrompt();
+		const currentPromptIndex = appendSystemPrompt.lastIndexOf(session.openUIPrompt.prompt);
+		if (currentPromptIndex >= 0) {
+			appendSystemPrompt[currentPromptIndex] = nextPrompt;
+		} else {
+			appendSystemPrompt.push(nextPrompt);
+		}
+
+		session.openUIPrompt.mode = mode;
+		session.openUIPrompt.prompt = nextPrompt;
+		session.session.setActiveToolsByName(session.session.getActiveToolNames());
 	}
 
 	async steer(sessionId: string, text: string): Promise<void> {
@@ -728,9 +822,10 @@ export class PrimeBridge {
 			});
 		}
 
-		const { session: forked } = await createAgentSession({
+		const { session: forked, openUIPrompt } = await createWebAgentSession({
 			cwd: bridge.cwd,
 			sessionManager: side,
+			openUIPrompt: createOpenUIPromptSessionState(bridge.openUIPrompt.mode),
 		});
 		// Carry the source session's model/thinking/service-tier over so the fork
 		// doesn't silently fall back to defaults (provider/settings may differ).
@@ -748,7 +843,7 @@ export class PrimeBridge {
 		forked.sessionManager.materializeSessionFile();
 		forked.sessionManager.flushNow();
 
-		await this.#registerSession(forked, bridge.cwd, forked.sessionManager.getSessionFile() ?? "");
+		await this.#registerSession(forked, bridge.cwd, forked.sessionManager.getSessionFile() ?? "", openUIPrompt);
 		return {
 			cancelled: false,
 			selectedText,


### PR DESCRIPTION
## Summary

- Wired the generated OpenUI guidance into web agent sessions.
- Forwarded chat mode and plan actions through the HTTP bridge, including queued steering and follow-up messages.
- Refreshes the mode-specific guidance when a session moves between agent, plan, refinement, and plan-execution modes.
- Added a regression test covering prompt injection and mode changes.

## Validation

- `npm run check`
- `pnpm --dir web --filter @prime-agent/web-server exec vitest run src/__tests__/prime-bridge.test.ts` (17/17)
- Live browser smoke check at `http://127.0.0.1:3000/` with zero console errors.
