### PR TITLE
ci: add CircleCI validation pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,283 @@
+version: 2.1
+
+executors:
+  node:
+    docker:
+      - image: cimg/node:22.14.0
+    working_directory: ~/prime-agent
+
+commands:
+  install-system-dependencies:
+    steps:
+      - run:
+          name: Install system dependencies
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y \
+              libcairo2-dev \
+              libgif-dev \
+              libjpeg-dev \
+              libpango1.0-dev \
+              librsvg2-dev \
+              fd-find \
+              python3-pip \
+              ripgrep
+            if ! command -v fd >/dev/null 2>&1; then
+              sudo ln -s "$(command -v fdfind)" /usr/local/bin/fd
+            fi
+
+  install-pnpm:
+    steps:
+      - run:
+          name: Install pnpm
+          command: |
+            sudo npm install --global pnpm@11.15.1
+            pnpm config set store-dir ~/.cache/pnpm
+            pnpm --version
+
+  install-root-dependencies:
+    steps:
+      - restore_cache:
+          keys:
+            - v1-node22-npm-{{ checksum "package-lock.json" }}
+      - run:
+          name: Install npm dependencies
+          command: npm ci
+      - save_cache:
+          key: v1-node22-npm-{{ checksum "package-lock.json" }}
+          paths:
+            - ~/.npm
+
+  install-web-dependencies:
+    steps:
+      - restore_cache:
+          keys:
+            - v1-node22-pnpm-{{ checksum "web/pnpm-lock.yaml" }}
+      - run:
+          name: Install web dependencies
+          command: pnpm install --dir web --frozen-lockfile
+      - save_cache:
+          key: v1-node22-pnpm-{{ checksum "web/pnpm-lock.yaml" }}
+          paths:
+            - ~/.cache/pnpm
+
+  install-uv:
+    steps:
+      - run:
+          name: Install uv
+          command: |
+            python3 -m pip install --user uv
+            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
+            source "$BASH_ENV"
+            uv --version
+
+jobs:
+  build-check:
+    executor: node
+    steps:
+      - checkout
+      - install-system-dependencies
+      - install-pnpm
+      - install-root-dependencies
+      - install-web-dependencies
+      - run:
+          name: Build
+          command: npm run build
+      - run:
+          name: Check
+          command: npm run check
+
+  test:
+    parameters:
+      lane:
+        type: string
+      package:
+        type: string
+      command:
+        type: string
+      install_uv:
+        type: boolean
+        default: false
+    executor: node
+    steps:
+      - checkout
+      - install-system-dependencies
+      - install-root-dependencies
+      - run:
+          name: Build packages
+          command: npm run build
+      - when:
+          condition: << parameters.install_uv >>
+          steps:
+            - install-uv
+      - run:
+          name: Prepare test results
+          command: mkdir -p << parameters.package >>/test-results
+      - run:
+          name: Run << parameters.lane >> tests
+          working_directory: << parameters.package >>
+          command: << parameters.command >>
+      - store_test_results:
+          path: << parameters.package >>/test-results
+      - store_artifacts:
+          path: << parameters.package >>/test-results
+          destination: test-results/<< parameters.lane >>
+
+  test-web:
+    executor: node
+    steps:
+      - checkout
+      - install-pnpm
+      - install-root-dependencies
+      - install-web-dependencies
+      - run:
+          name: Build packages
+          command: npm run build
+      - run:
+          name: Prepare test results
+          command: mkdir -p test-results
+      - run:
+          name: Test web app
+          command: >-
+            pnpm --dir web --filter @prime-agent/web run test
+            --reporter=default --reporter=junit
+            --outputFile="$PWD/test-results/web-app.xml"
+      - run:
+          name: Test web server
+          command: >-
+            pnpm --dir web --filter @prime-agent/web-server run test
+            --reporter=default --reporter=junit
+            --outputFile="$PWD/test-results/web-server.xml"
+      - store_test_results:
+          path: test-results
+      - store_artifacts:
+          path: test-results
+          destination: test-results/web
+
+  process-stress:
+    executor: node
+    steps:
+      - checkout
+      - install-system-dependencies
+      - install-root-dependencies
+      - run:
+          name: Build packages
+          command: npm run build
+      - install-uv
+      - run:
+          name: Prepare test results
+          command: mkdir -p packages/coding-agent/test-results
+      - run:
+          name: Run process stress tests
+          working_directory: packages/coding-agent
+          environment:
+            PRIME_AGENT_STRESS_WORKERS: "10"
+          command: >-
+            npm run test:process-stress --
+            --reporter=default --reporter=junit
+            --outputFile=test-results/process-stress.xml
+      - store_test_results:
+          path: packages/coding-agent/test-results
+      - store_artifacts:
+          path: packages/coding-agent/test-results
+          destination: test-results/process-stress
+
+  ci-success:
+    executor: node
+    steps:
+      - run:
+          name: Confirm all CI jobs passed
+          command: echo "All CircleCI validation jobs passed."
+
+workflows:
+  ci:
+    jobs:
+      - build-check
+      - test:
+          name: test-agent-core
+          lane: agent-core
+          package: packages/agent
+          command: >-
+            npm test -- --reporter=default --reporter=junit
+            --outputFile=test-results/junit.xml
+      - test:
+          name: test-ai
+          lane: ai
+          package: packages/ai
+          command: >-
+            npm test -- --reporter=default --reporter=junit
+            --outputFile=test-results/junit.xml
+      - test:
+          name: test-tui
+          lane: tui
+          package: packages/tui
+          command: >-
+            node --test --import tsx --test-reporter=junit
+            --test-reporter-destination=test-results/junit.xml test/*.test.ts
+      - test:
+          name: test-coding-agent-1-3
+          lane: coding-agent-1-3
+          package: packages/coding-agent
+          install_uv: true
+          command: >-
+            npm run test:ci -- --reporter=default --reporter=junit
+            --outputFile=test-results/junit.xml
+            --shard=1/3
+      - test:
+          name: test-coding-agent-2-3
+          lane: coding-agent-2-3
+          package: packages/coding-agent
+          install_uv: true
+          command: >-
+            npm run test:ci -- --reporter=default --reporter=junit
+            --outputFile=test-results/junit.xml
+            --shard=2/3
+      - test:
+          name: test-coding-agent-3-3
+          lane: coding-agent-3-3
+          package: packages/coding-agent
+          install_uv: true
+          command: >-
+            npm run test:ci -- --reporter=default --reporter=junit
+            --outputFile=test-results/junit.xml
+            --shard=3/3
+      - test:
+          name: test-coding-agent-process
+          lane: coding-agent-process
+          package: packages/coding-agent
+          install_uv: true
+          command: >-
+            npm run test:process -- --reporter=default --reporter=junit
+            --outputFile=test-results/junit.xml
+      - test:
+          name: test-coding-agent-kernel
+          lane: coding-agent-kernel
+          package: packages/coding-agent
+          install_uv: true
+          command: >-
+            npm run test:kernel -- --reporter=default --reporter=junit
+            --outputFile=test-results/junit.xml
+      - test-web
+      - ci-success:
+          requires:
+            - build-check
+            - test-agent-core
+            - test-ai
+            - test-tui
+            - test-coding-agent-1-3
+            - test-coding-agent-2-3
+            - test-coding-agent-3-3
+            - test-coding-agent-process
+            - test-coding-agent-kernel
+            - test-web
+
+  nightly-process-stress:
+    triggers:
+      - schedule:
+          cron: "0 9 * * *"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - process-stress

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   node:
     docker:
-      - image: cimg/node:22.14.0
+      - image: cimg/node:22.15.0
     working_directory: ~/prime-agent
 
 commands:

--- a/.circleci/info.yml
+++ b/.circleci/info.yml
@@ -1,0 +1,7 @@
+organization:
+    id: d0fc62ae-1f4a-4037-8ccb-d357adfdfda6
+    name: Qredence
+project:
+    id: 31736f70-0320-4e7e-8aa6-756cfdd93058
+    slug: circleci/SomxVLJYMpo86z6XUrZBUq/77Axvw4aep78EpwCW6Nsyh
+    name: fleet-prime-agent

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,181 @@
-#!/bin/bash
-set -euo pipefail
+#!/bin/sh
 
-echo "[fleet-prime] Installing project..."
-npm ci
-pnpm install --dir web
-npm run build
-echo "[fleet-prime] Done. Run 'fleet-prime' to start."
+set -eu
+
+prime_agent_repository_url="${PRIME_AGENT_REPOSITORY_URL:-https://github.com/Qredence/fleet-prime-agent.git}"
+prime_agent_repository_ref="${PRIME_AGENT_REPOSITORY_REF:-main}"
+prime_agent_pnpm_version="${PRIME_AGENT_PNPM_VERSION:-11.15.1}"
+prime_agent_checkout_dir=$(pwd)
+prime_agent_pnpm_mode=
+
+die() {
+	printf 'error: %s\n' "$1" >&2
+	exit 1
+}
+
+usage() {
+	cat <<'EOF'
+Usage: install.sh
+
+Install Qredence/fleet-prime-agent into the current directory, build the
+production web runtime, and link the prime-agent command globally.
+
+The current directory must be empty or an existing checkout of:
+  https://github.com/Qredence/fleet-prime-agent.git
+
+Environment overrides for testing or pinned source installs:
+  PRIME_AGENT_REPOSITORY_URL   Repository URL (default: Qredence/fleet-prime-agent)
+  PRIME_AGENT_REPOSITORY_REF   Branch or tag to clone (default: main)
+  PRIME_AGENT_PNPM_VERSION     Ephemeral pnpm version (default: 11.15.1)
+EOF
+}
+
+command_required() {
+	command -v "$1" >/dev/null 2>&1 || die "$1 is required. Install it and run this installer again."
+}
+
+node_is_supported() {
+	node -e '
+const [major, minor, patch] = process.versions.node.split(".").map(Number);
+const supported = major > 22 || (major === 22 && (minor > 8 || (minor === 8 && patch >= 0)));
+process.exit(supported ? 0 : 1);
+'
+}
+
+pnpm_is_supported() {
+	version=$(pnpm --version 2>/dev/null || true)
+	major=$(printf '%s' "$version" | awk -F. 'NR == 1 { gsub(/[^0-9].*/, "", $1); print $1 }')
+	case "$major" in
+		''|*[!0-9]*) return 1 ;;
+		*) [ "$major" -eq 11 ] ;;
+	esac
+}
+
+normalize_repository_url() {
+	printf '%s' "$1" | sed 's#/$##; s#\.git$##'
+}
+
+checkout_matches_repository() {
+	[ -e .git ] || [ -L .git ] || return 1
+
+	origin=$(git config --get remote.origin.url 2>/dev/null || true)
+	if [ -n "$origin" ] && [ "$(normalize_repository_url "$origin")" = "$(normalize_repository_url "$prime_agent_repository_url")" ]; then
+		return 0
+	fi
+
+	case "$origin" in
+		https://github.com/Qredence/fleet-prime-agent|https://github.com/Qredence/fleet-prime-agent.git|git@github.com:Qredence/fleet-prime-agent|git@github.com:Qredence/fleet-prime-agent.git)
+			return 0
+			;;
+	esac
+	return 1
+}
+
+checkout_is_empty() {
+	for entry in ./* ./.??*; do
+		if [ -e "$entry" ] || [ -L "$entry" ]; then
+			return 1
+		fi
+	done
+	return 0
+}
+
+prepare_checkout() {
+	if checkout_matches_repository; then
+		printf 'Using existing Qredence/fleet-prime-agent checkout: %s\n' "$prime_agent_checkout_dir"
+		return
+	fi
+
+	if ! checkout_is_empty; then
+		die "the current directory is not an empty Qredence/fleet-prime-agent checkout; refusing to overwrite it"
+	fi
+
+	printf 'Cloning %s (%s) into %s\n' "$prime_agent_repository_url" "$prime_agent_repository_ref" "$prime_agent_checkout_dir"
+	git clone --branch "$prime_agent_repository_ref" --single-branch "$prime_agent_repository_url" .
+}
+
+select_pnpm() {
+	if command -v pnpm >/dev/null 2>&1 && pnpm_is_supported; then
+		prime_agent_pnpm_mode=system
+		printf 'Using pnpm %s\n' "$(pnpm --version)"
+		return
+	fi
+
+	prime_agent_pnpm_mode=ephemeral
+	printf 'Using pnpm %s through npm exec\n' "$prime_agent_pnpm_version"
+}
+
+run_pnpm() {
+	if [ "$prime_agent_pnpm_mode" = system ]; then
+		pnpm "$@"
+	else
+		npm exec --yes --package="pnpm@$prime_agent_pnpm_version" -- pnpm "$@"
+	fi
+}
+
+build_checkout() {
+	printf '\nInstalling root npm dependencies...\n'
+	npm ci --no-audit --no-fund
+
+	printf '\nInstalling web workspace dependencies...\n'
+	run_pnpm install --dir web --frozen-lockfile
+
+	printf '\nBuilding Prime Agent packages...\n'
+	npm run build
+
+	printf '\nBuilding the production web runtime...\n'
+	run_pnpm --dir web --filter @prime-agent/web build
+	node scripts/build-web-release.mjs
+}
+
+link_cli() {
+	printf '\nLinking the prime-agent command globally...\n'
+	npm link --force ./packages/coding-agent
+	hash -r 2>/dev/null || true
+
+	if command -v prime-agent >/dev/null 2>&1; then
+		printf '\nPrime Agent is ready.\n'
+		printf '  Checkout: %s\n' "$prime_agent_checkout_dir"
+		printf '  Command:  %s\n' "$(command -v prime-agent)"
+		printf '\nRun from a project directory:\n  fleet-prime\n'
+		return
+	fi
+
+	global_prefix=$(npm prefix -g 2>/dev/null || true)
+	if [ -n "$global_prefix" ]; then
+		printf '\nPrime Agent was linked, but %s/bin is not on PATH.\n' "$global_prefix" >&2
+		printf 'Add %s/bin to your shell PATH, then run: fleet-prime\n' "$global_prefix" >&2
+	else
+		printf '\nPrime Agent was linked, but the global npm bin directory is not on PATH.\n' >&2
+		printf "Add npm's global bin directory to PATH, then run: fleet-prime\n" >&2
+	fi
+}
+
+main() {
+	case "${1:-}" in
+		-h|--help)
+			usage
+			return 0
+			;;
+		"")
+			;;
+		*)
+			die "unknown argument: $1 (this installer does not accept positional arguments)"
+			;;
+	esac
+
+	command_required git
+	command_required node
+	command_required npm
+
+	if ! node_is_supported; then
+		die "Node.js 22.8.0 or newer is required; found $(node --version)"
+	fi
+
+	prepare_checkout
+	select_pnpm
+	build_checkout
+	link_cli
+}
+
+main "$@"

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -46,7 +46,7 @@
 		"postinstall": "node postinstall.cjs",
 		"prepublishOnly": "npm run clean && npm run build",
 		"bundle": "node scripts/bundle.mjs",
-		"test:kernel": "vitest --run --no-file-parallelism --tagsFilter kernel-heavy test/acp-kernel-features.test.ts test/acp-cold-cli.test.ts test/kernel-goal-skill.test.ts test/kernel-state-roundtrip.test.ts"
+		"test:kernel": "vitest --run --no-file-parallelism --tagsFilter kernel-heavy test/acp-kernel-features.test.ts test/acp-cold-cli.test.ts test/kernel-goal-skill.test.ts test/kernel-state-roundtrip.test.ts test/ipython-bootstrap.test.ts"
 	},
 	"dependencies": {
 		"@agentclientprotocol/sdk": "^1.3.0",

--- a/packages/coding-agent/test/ipython-bootstrap.test.ts
+++ b/packages/coding-agent/test/ipython-bootstrap.test.ts
@@ -57,7 +57,7 @@ function resolveKernelPython(): string | null {
 const python = resolveKernelPython();
 const describeIfKernel = python ? describe : describe.skip;
 
-describeIfKernel("IPython RLM bootstrap (real kernel)", () => {
+describeIfKernel("IPython RLM bootstrap (real kernel)", { tags: ["kernel-heavy"] }, () => {
 	const dir = mkdtempSync(join(tmpdir(), "prime-agent-bootstrap-"));
 
 	afterAll(() => {

--- a/packages/coding-agent/test/suite/regressions/4685-daemon-client-modes.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4685-daemon-client-modes.test.ts
@@ -100,7 +100,7 @@ async function runCli(
 		const timeout = setTimeout(() => {
 			child.kill("SIGKILL");
 			reject(new Error(`CLI timed out\n${stderr}`));
-		}, 20_000);
+		}, 30_000);
 		child.once("exit", (code, signal) => {
 			clearTimeout(timeout);
 			resolveExit({ code, signal: signal as NodeJS.Signals | null });

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -199,16 +199,25 @@ async function walkDirectoryWithFd(
 			const results: Array<{ path: string; isDirectory: boolean }> = [];
 
 			for (const line of lines) {
-				const displayLine = toDisplayPath(line);
-				const hasTrailingSeparator = displayLine.endsWith("/");
-				const normalizedPath = hasTrailingSeparator ? displayLine.slice(0, -1) : displayLine;
+				const rawDisplayPath = toDisplayPath(line);
+				const pathWithoutLeadingDot = rawDisplayPath.replace(/^\.\//, "");
+				const normalizedPath = pathWithoutLeadingDot.endsWith("/")
+					? pathWithoutLeadingDot.slice(0, -1)
+					: pathWithoutLeadingDot;
 				if (normalizedPath === ".git" || normalizedPath.startsWith(".git/") || normalizedPath.includes("/.git/")) {
 					continue;
 				}
 
+				let isDirectory = pathWithoutLeadingDot.endsWith("/");
+				try {
+					isDirectory = statSync(join(baseDir, normalizedPath)).isDirectory();
+				} catch {
+					// Keep the fd-provided type when the path disappears during the scan.
+				}
+
 				results.push({
-					path: displayLine,
-					isDirectory: hasTrailingSeparator,
+					path: isDirectory ? `${normalizedPath}/` : normalizedPath,
+					isDirectory,
 				});
 			}
 

--- a/web/design/src/components/fleet-pi/layout/chat-header.tsx
+++ b/web/design/src/components/fleet-pi/layout/chat-header.tsx
@@ -222,10 +222,7 @@ export function SessionControls({
   )
 }
 
-export function KernelStatusChip({
-  ok,
-  reason,
-}: {
+export function KernelStatusChip(_props: {
   ok: boolean | null
   reason?: string
 }) {


### PR DESCRIPTION
## Summary

- Added a connected CircleCI 2.1 pipeline covering root checks, package test lanes, web checks, process stress, artifacts, and nightly stress scheduling.
- Repaired the source installer flow so CI validates the repository-hosted install path.
- Stabilized CI-sensitive autocomplete, kernel bootstrap, daemon cold-start, and web typecheck paths.

## Validation

- `npm run check`
- `npm run check:installer`
- `sh -n install.sh`
- `circleci config validate .circleci/config.yml`
- `circleci config process .circleci/config.yml`
- CircleCI pipeline for `8942025fcfaf83941dd5335da8b75378972bab32`: all workflows and jobs succeeded.

## Follow-up

- The existing source-installer smoke test still has a path-label expectation mismatch: the runtime intentionally redacts the workspace root while the checker expects the absolute path.