### PR TITLE
refactor(web-server): parallelize independent reads and migrate schemas to zod v4

### DIFF
--- a/web/protocol/src/fleet-contract.ts
+++ b/web/protocol/src/fleet-contract.ts
@@ -144,7 +144,7 @@ export type WorkspaceAttachment = z.infer<typeof WorkspaceAttachmentSchema>;
 
 export const UploadedAttachmentSchema = z.object({
 	kind: z.literal("upload"),
-	attachmentId: z.string().uuid(),
+	attachmentId: z.uuid(),
 	name: z.string().min(1).max(512),
 	mimeType: z.string().min(1).max(255),
 	size: z.number().int().nonnegative().max(MAX_ATTACHMENT_BYTES),

--- a/web/protocol/src/provider-catalog.ts
+++ b/web/protocol/src/provider-catalog.ts
@@ -309,9 +309,9 @@ export const KNOWN_PROVIDERS: Array<PiProviderCredentialEntry> = PI_PROVIDER_CAT
 );
 
 /** Pi LLM providers whose env vars are scrubbed on Vercel (excludes infra). */
-export const LLM_PROVIDER_ENV_SCRUB_IDS = KNOWN_PROVIDERS.filter(
-	(provider) => !INFRA_PROVIDER_IDS.includes(provider.id as (typeof INFRA_PROVIDER_IDS)[number]),
-).map((provider) => provider.id);
+export const LLM_PROVIDER_ENV_SCRUB_IDS = KNOWN_PROVIDERS.flatMap((provider) =>
+	INFRA_PROVIDER_IDS.includes(provider.id as (typeof INFRA_PROVIDER_IDS)[number]) ? [] : [provider.id],
+);
 
 /**
  * Full Pi provider ids that can pick up org env / auth.json credentials.
@@ -379,12 +379,13 @@ export const CREDENTIAL_UI_PROVIDERS = KNOWN_PROVIDERS.filter(
  */
 export const PROVIDER_ENV_SCRUB_VAR_NAMES = Array.from(
 	new Set([
-		...KNOWN_PROVIDERS.filter(
-			(provider) =>
-				LLM_PROVIDER_ENV_SCRUB_IDS.includes(provider.id) ||
-				provider.id === OPENAI_CHAT_COMPLETIONS_BASE_URL_PROVIDER_ID ||
-				provider.id === OPENAI_CHAT_COMPLETIONS_MODEL_PROVIDER_ID,
-		).map((provider) => provider.envVarName),
+		...KNOWN_PROVIDERS.flatMap((provider) =>
+			LLM_PROVIDER_ENV_SCRUB_IDS.includes(provider.id) ||
+			provider.id === OPENAI_CHAT_COMPLETIONS_BASE_URL_PROVIDER_ID ||
+			provider.id === OPENAI_CHAT_COMPLETIONS_MODEL_PROVIDER_ID
+				? [provider.envVarName]
+				: [],
+		),
 		// Pi built-ins beyond Fleet's Settings catalog
 		"HF_TOKEN",
 		"ANT_LING_API_KEY",

--- a/web/server/src/__tests__/chat-attachments-handler.test.ts
+++ b/web/server/src/__tests__/chat-attachments-handler.test.ts
@@ -1,0 +1,50 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const bridgeMock = vi.hoisted(() => ({
+	getSession: vi.fn(),
+	resumeSessionById: vi.fn(),
+}));
+
+vi.mock("../singleton", () => ({
+	getBridge: () => bridgeMock,
+}));
+
+import { handleChatAttachmentsPost } from "../handlers/chat-attachments";
+
+describe("chat attachment upload ordering", () => {
+	let root: string;
+	const session = { sessionId: "session-1", sessionPath: "" };
+
+	beforeEach(async () => {
+		root = await mkdtemp(join(tmpdir(), "prime-chat-attachments-"));
+		await mkdir(join(root, "sessions"));
+		session.sessionPath = join(root, "sessions", "session-1.jsonl");
+		bridgeMock.getSession.mockReset().mockReturnValue(session);
+		bridgeMock.resumeSessionById.mockReset();
+	});
+
+	afterEach(async () => {
+		await rm(root, { recursive: true, force: true });
+	});
+
+	it("returns attachments in the same order as the multipart files", async () => {
+		const form = new FormData();
+		form.append("sessionId", session.sessionId);
+		form.append("files", new File(["first"], "first.txt", { type: "text/plain" }));
+		form.append("files", new File(["second"], "second.txt", { type: "text/plain" }));
+
+		const response = await handleChatAttachmentsPost(
+			new Request("http://localhost/api/chat/attachments", {
+				method: "POST",
+				body: form,
+			}),
+		);
+		const body = (await response.json()) as { attachments: Array<{ name: string }> };
+
+		expect(response.status).toBe(200);
+		expect(body.attachments.map((attachment) => attachment.name)).toEqual(["first.txt", "second.txt"]);
+	});
+});

--- a/web/server/src/__tests__/chat-attachments-handler.test.ts
+++ b/web/server/src/__tests__/chat-attachments-handler.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -46,5 +46,27 @@ describe("chat attachment upload ordering", () => {
 
 		expect(response.status).toBe(200);
 		expect(body.attachments.map((attachment) => attachment.name)).toEqual(["first.txt", "second.txt"]);
+	});
+
+	it("rolls back sibling writes when one upload fails validation", async () => {
+		const form = new FormData();
+		form.append("sessionId", session.sessionId);
+		form.append("files", new File(["valid"], "valid.txt", { type: "text/plain" }));
+		form.append(
+			"files",
+			new File([new Uint8Array(26 * 1024 * 1024)], "oversize.bin", { type: "application/octet-stream" }),
+		);
+
+		const response = await handleChatAttachmentsPost(
+			new Request("http://localhost/api/chat/attachments", {
+				method: "POST",
+				body: form,
+			}),
+		);
+
+		expect(response.status).toBe(500);
+		const storageRoot = join(root, "session-attachments", session.sessionId);
+		const leftovers = await readdir(storageRoot).catch(() => [] as string[]);
+		expect(leftovers).toEqual([]);
 	});
 });

--- a/web/server/src/__tests__/chat-settings-handler.test.ts
+++ b/web/server/src/__tests__/chat-settings-handler.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+	const manager = {
+		getGlobalSettings: vi.fn(() => ({ defaultModel: "global-model" })),
+		getProjectSettings: vi.fn(() => ({ defaultProvider: "project-provider" })),
+		getCompactionSettings: vi.fn(() => ({ enabled: true, reserveTokens: 100, keepRecentTokens: 200 })),
+		getRetrySettings: vi.fn(() => ({ enabled: true, maxRetries: 2, baseDelayMs: 50 })),
+		getEnableSkillCommands: vi.fn(() => true),
+		getEnabledModels: vi.fn(() => ["global-model"]),
+		getExtensionPaths: vi.fn(() => ["extensions"]),
+		getFollowUpMode: vi.fn(() => "queue"),
+		getPackages: vi.fn(() => []),
+		getPromptTemplatePaths: vi.fn(() => ["prompts"]),
+		getSkillPaths: vi.fn(() => ["skills"]),
+		getSteeringMode: vi.fn(() => "one-at-a-time"),
+		getThemePaths: vi.fn(() => ["themes"]),
+		getTransport: vi.fn(() => "sse"),
+	};
+	return {
+		manager,
+		getPrimeConfig: vi.fn(() => ({ settingsFor: vi.fn(() => manager) })),
+		cwdForRequest: vi.fn(async () => "/workspace/project"),
+		safePathLabel: vi.fn((cwd: string) => cwd),
+	};
+});
+
+vi.mock("../prime-config", () => ({ getPrimeConfig: mocks.getPrimeConfig }));
+vi.mock("../project-request", () => ({ cwdForRequest: mocks.cwdForRequest }));
+vi.mock("../project-registry", () => ({ safePathLabel: mocks.safePathLabel }));
+
+import { handleChatSettingsGet } from "../handlers/chat-settings";
+
+describe("chat settings reads", () => {
+	it("reads the independent settings groups into one validated response", async () => {
+		const response = await handleChatSettingsGet(
+			new Request("http://localhost/api/chat/settings?projectId=project-1"),
+		);
+		const body = (await response.json()) as {
+			projectPath: string;
+			effective: { defaultModel?: string; defaultProvider?: string };
+		};
+
+		expect(response.status).toBe(200);
+		expect(body.projectPath).toBe("/workspace/project");
+		expect(body.effective.defaultModel).toBe("global-model");
+		expect(body.effective.defaultProvider).toBe("project-provider");
+		expect(mocks.manager.getGlobalSettings).toHaveBeenCalledOnce();
+		expect(mocks.manager.getProjectSettings).toHaveBeenCalledOnce();
+		expect(mocks.manager.getCompactionSettings).toHaveBeenCalledOnce();
+		expect(mocks.manager.getRetrySettings).toHaveBeenCalledOnce();
+	});
+});

--- a/web/server/src/handlers/chat-attachments.ts
+++ b/web/server/src/handlers/chat-attachments.ts
@@ -1,6 +1,11 @@
 import { SessionIdSchema } from "@prime-agent/web-protocol/fleet-contract";
 import { z } from "zod/v4";
-import { MAX_TURN_ATTACHMENT_BYTES, readManagedAttachment, storeManagedAttachment } from "../managed-attachments";
+import {
+	deleteManagedAttachment,
+	MAX_TURN_ATTACHMENT_BYTES,
+	readManagedAttachment,
+	storeManagedAttachment,
+} from "../managed-attachments";
 import { getBridge } from "../singleton";
 import { wrapApiHandler } from "../wrap-api-handler";
 
@@ -22,7 +27,19 @@ export function handleChatAttachmentsPost(request: Request): Promise<Response> {
 		}
 		const session = await resolveSession(sessionId);
 		if (!session) return Response.json({ message: `Unknown session: ${sessionId}` }, { status: 404 });
-		const attachments = await Promise.all(files.map((file) => storeManagedAttachment(session, file)));
+		const settled = await Promise.allSettled(files.map((file) => storeManagedAttachment(session, file)));
+		const failure = settled.find((result) => result.status === "rejected");
+		if (failure) {
+			// The client receives no ids on failure, so sibling writes would be
+			// unreachable. Roll them back instead of leaving orphans behind.
+			await Promise.all(
+				settled.flatMap((result) =>
+					result.status === "fulfilled" ? [deleteManagedAttachment(session, result.value.attachmentId)] : [],
+				),
+			);
+			throw failure.reason;
+		}
+		const attachments = settled.flatMap((result) => (result.status === "fulfilled" ? [result.value] : []));
 		return Response.json({ attachments });
 	});
 }

--- a/web/server/src/handlers/chat-attachments.ts
+++ b/web/server/src/handlers/chat-attachments.ts
@@ -1,4 +1,4 @@
-import { SessionIdSchema } from "@prime-agent/web-protocol/fleet-contract";
+import { SessionIdSchema, type UploadedAttachment } from "@prime-agent/web-protocol/fleet-contract";
 import { z } from "zod/v4";
 import {
 	deleteManagedAttachment,
@@ -10,6 +10,7 @@ import { getBridge } from "../singleton";
 import { wrapApiHandler } from "../wrap-api-handler";
 
 const AttachmentIdSchema = z.uuid();
+const ATTACHMENT_WRITE_CONCURRENCY = 8;
 
 async function resolveSession(sessionId: string) {
 	const bridge = getBridge();
@@ -27,7 +28,11 @@ export function handleChatAttachmentsPost(request: Request): Promise<Response> {
 		}
 		const session = await resolveSession(sessionId);
 		if (!session) return Response.json({ message: `Unknown session: ${sessionId}` }, { status: 404 });
-		const settled = await Promise.allSettled(files.map((file) => storeManagedAttachment(session, file)));
+		const settled: PromiseSettledResult<UploadedAttachment>[] = [];
+		for (let index = 0; index < files.length; index += ATTACHMENT_WRITE_CONCURRENCY) {
+			const chunk = files.slice(index, index + ATTACHMENT_WRITE_CONCURRENCY);
+			settled.push(...(await Promise.allSettled(chunk.map((file) => storeManagedAttachment(session, file)))));
+		}
 		const failure = settled.find((result) => result.status === "rejected");
 		if (failure) {
 			// The client receives no ids on failure, so sibling writes would be

--- a/web/server/src/handlers/chat-attachments.ts
+++ b/web/server/src/handlers/chat-attachments.ts
@@ -4,7 +4,7 @@ import { MAX_TURN_ATTACHMENT_BYTES, readManagedAttachment, storeManagedAttachmen
 import { getBridge } from "../singleton";
 import { wrapApiHandler } from "../wrap-api-handler";
 
-const AttachmentIdSchema = z.string().uuid();
+const AttachmentIdSchema = z.uuid();
 
 async function resolveSession(sessionId: string) {
 	const bridge = getBridge();
@@ -22,8 +22,7 @@ export function handleChatAttachmentsPost(request: Request): Promise<Response> {
 		}
 		const session = await resolveSession(sessionId);
 		if (!session) return Response.json({ message: `Unknown session: ${sessionId}` }, { status: 404 });
-		const attachments = [];
-		for (const file of files) attachments.push(await storeManagedAttachment(session, file));
+		const attachments = await Promise.all(files.map((file) => storeManagedAttachment(session, file)));
 		return Response.json({ attachments });
 	});
 }

--- a/web/server/src/handlers/chat-settings.ts
+++ b/web/server/src/handlers/chat-settings.ts
@@ -81,8 +81,7 @@ export function handleChatSettingsGet(request: Request): Promise<Response> {
 
 export function handleChatSettingsPatch(request: Request): Promise<Response> {
 	return wrapApiHandler(async () => {
-		const cwd = await cwdForRequest(request);
-		const raw = await request.json().catch(() => ({}));
+		const [cwd, raw] = await Promise.all([cwdForRequest(request), request.json().catch(() => ({}))]);
 		const body = ChatSettingsUpdateRequestSchema.parse(raw);
 		const config = getPrimeConfig();
 		const manager = config.settingsFor(cwd);

--- a/web/server/src/handlers/chat.ts
+++ b/web/server/src/handlers/chat.ts
@@ -63,9 +63,10 @@ export function handleChatPost(request: Request): Promise<Response> {
 			if (!managed) {
 				return Response.json({ message: `Unknown attachment: ${attachment.attachmentId}` }, { status: 400 });
 			}
-			if (managed.metadata.mimeType.startsWith("image/")) {
-				images.push({ type: "image", data: managed.data.toString("base64"), mimeType: managed.metadata.mimeType });
-			} else if (managed.metadata.mimeType.startsWith("text/") || managed.metadata.mimeType === "application/json") {
+			const mimeType = managed.metadata.mimeType;
+			if (mimeType.startsWith("image/")) {
+				images.push({ type: "image", data: managed.data.toString("base64"), mimeType });
+			} else if (mimeType.startsWith("text/") || mimeType === "application/json") {
 				attachmentContext.push(
 					`<attachment name="${managed.metadata.name}">\n${managed.data.toString("utf8")}\n</attachment>`,
 				);

--- a/web/server/src/handlers/projects.ts
+++ b/web/server/src/handlers/projects.ts
@@ -19,16 +19,17 @@ export function sessionStatus(info: Pick<SessionInfo, "state">, live: BridgeSess
 async function sessionProjectIds() {
 	const bridge = getBridge();
 	const sessions = await bridge.listSessions();
-	const assignments = new Map<string, string | null>();
-	for (const session of sessions) {
-		assignments.set(
-			session.id,
-			await getPrimeConfig().projectRegistry.projectIdForSession(
-				session.id,
-				bridge.getSession(session.id)?.cwd ?? session.cwd,
-			),
-		);
-	}
+	const registry = getPrimeConfig().projectRegistry;
+	const assignmentEntries = await Promise.all(
+		sessions.map(
+			async (session) =>
+				[
+					session.id,
+					await registry.projectIdForSession(session.id, bridge.getSession(session.id)?.cwd ?? session.cwd),
+				] as const,
+		),
+	);
+	const assignments = new Map(assignmentEntries);
 	return { bridge, sessions, assignments };
 }
 

--- a/web/server/src/managed-attachments.ts
+++ b/web/server/src/managed-attachments.ts
@@ -100,12 +100,21 @@ export async function validateManagedAttachments(
 	attachments: ReadonlyArray<Pick<UploadedAttachment, "attachmentId">>,
 ): Promise<Map<string, ManagedAttachmentInspection>> {
 	const inspections = new Map<string, ManagedAttachmentInspection>();
-	let totalBytes = 0;
+	const attachmentIds = new Set<string>();
 	for (const attachment of attachments) {
-		if (inspections.has(attachment.attachmentId)) {
+		if (attachmentIds.has(attachment.attachmentId)) {
 			throw new ManagedAttachmentValidationError(`Duplicate attachment: ${attachment.attachmentId}`, 400);
 		}
-		const inspected = await inspectManagedAttachment(session, attachment.attachmentId).catch(() => undefined);
+		attachmentIds.add(attachment.attachmentId);
+	}
+	const inspectedAttachments = await Promise.all(
+		attachments.map((attachment) =>
+			inspectManagedAttachment(session, attachment.attachmentId).catch(() => undefined),
+		),
+	);
+	let totalBytes = 0;
+	for (const [index, attachment] of attachments.entries()) {
+		const inspected = inspectedAttachments[index];
 		if (!inspected) {
 			throw new ManagedAttachmentValidationError(`Unknown attachment: ${attachment.attachmentId}`, 400);
 		}

--- a/web/server/src/managed-attachments.ts
+++ b/web/server/src/managed-attachments.ts
@@ -145,6 +145,14 @@ export async function readManagedAttachment(session: BridgeSession, attachmentId
 	return inspected ? readInspectedManagedAttachment(inspected) : undefined;
 }
 
+export async function deleteManagedAttachment(session: BridgeSession, attachmentId: string): Promise<void> {
+	const root = attachmentRoot(session);
+	const inspected = await inspectManagedAttachment(session, attachmentId).catch(() => undefined);
+	const metadataPath = join(root, `${attachmentId}.json`);
+	if (inspected && contained(root, inspected.dataPath)) await rm(inspected.dataPath, { force: true });
+	if (contained(root, metadataPath)) await rm(metadataPath, { force: true });
+}
+
 export async function deleteManagedAttachments(session: BridgeSession) {
 	await rm(attachmentRoot(session), { recursive: true, force: true });
 }

--- a/web/server/src/prime-bridge.ts
+++ b/web/server/src/prime-bridge.ts
@@ -645,9 +645,7 @@ export class PrimeBridge {
 	}
 
 	async setThinkingLevel(level: ThinkingLevel): Promise<void> {
-		for (const session of this.#sessions.values()) {
-			await session.session.setThinkingLevel(level);
-		}
+		await Promise.all([...this.#sessions.values()].map((session) => session.session.setThinkingLevel(level)));
 	}
 
 	// -----------------------------------------------------------------------
@@ -728,9 +726,7 @@ export class PrimeBridge {
 		// `/reload` reloads the *current* session's world via `session.reload()`.
 		// For the web port we reload every attached session's loader so new
 		// skills/prompts/themes show up on next prompt.
-		for (const session of this.#sessions.values()) {
-			await session.session.reload();
-		}
+		await Promise.all([...this.#sessions.values()].map((session) => session.session.reload()));
 	}
 
 	/** /tree — session-tree navigation via navigateTree (requires entry id). */

--- a/web/server/src/project-registry.ts
+++ b/web/server/src/project-registry.ts
@@ -163,7 +163,7 @@ export class ProjectRegistry {
 	async get(projectId: ProjectId): Promise<ProjectRecord> {
 		await this.#ensureLoaded();
 		const project = this.#projects.get(projectId);
-		if (!project || project.status !== "active") throw new Error("Unknown project");
+		if (project?.status !== "active") throw new Error("Unknown project");
 		return project;
 	}
 

--- a/web/server/src/workspace-browse.ts
+++ b/web/server/src/workspace-browse.ts
@@ -64,15 +64,15 @@ export async function browseWorkspaceDirectories(rawPath: string): Promise<Works
 		};
 	}
 
-	const directories: Array<WorkspaceBrowseEntry> = [];
-	for (const entry of entries) {
-		if (entry.name.startsWith(".")) continue;
-		if (!(await isDirectoryEntry(path, entry))) continue;
-		directories.push({
-			name: entry.name,
-			path: resolve(path, entry.name),
-		});
-	}
+	const directories = (
+		await Promise.all(
+			entries.map(async (entry) => {
+				if (entry.name.startsWith(".")) return undefined;
+				if (!(await isDirectoryEntry(path, entry))) return undefined;
+				return { name: entry.name, path: resolve(path, entry.name) } satisfies WorkspaceBrowseEntry;
+			}),
+		)
+	).filter((entry): entry is WorkspaceBrowseEntry => entry !== undefined);
 	directories.sort((a, b) => a.name.localeCompare(b.name));
 
 	const parent = dirname(path);


### PR DESCRIPTION
## Description

<!-- What does this PR change and why? Link related issues. -->

## Type of change

<!-- Delete the options that do not apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Checklist

- [ ] I read `CONTRIBUTING.md` and `AGENTS.md`
- [ ] `npm run check` passes locally
- [ ] I added or updated tests for the changed behavior
- [ ] I added a `[Unreleased]` entry to each affected package CHANGELOG
- [ ] The PR targets `main` and contains only related changes

## Linked issues

<!-- e.g. Closes #123 -->