### PR TITLE
Make fleet-prime the sole web launcher

### DIFF
--- a/fleet-prime.sh
+++ b/fleet-prime.sh
@@ -17,7 +17,7 @@ if [[ "${1:-}" == "install" ]]; then
 	exec "$SCRIPT_DIR/install.sh" "$@"
 fi
 
-# Otherwise run the Qredence web dev server (same as `npm run dev:web`) from
+# Otherwise run the Fleet Prime web dev server (same as `npm run dev:web`) from
 # web/app, serving on 127.0.0.1:3000 by default. Supports --host and --port
 # overrides, e.g. `fleet-prime --port 3001` or `fleet-prime --host 0.0.0.0`.
 HOST="127.0.0.1"
@@ -30,7 +30,7 @@ while [[ $# -gt 0 ]]; do
 		--port) PORT="$2"; shift ;;
 		--help)
 			echo "Usage:"
-			echo "  fleet-prime [--host <host>] [--port <port>]   Run the web dev server"
+			echo "  fleet-prime [--host <host>] [--port <port>]   Run the Fleet Prime web dev server"
 			echo "  fleet-prime install [--help]                  Run install.sh (deps, build, global CLI link)"
 			exit 0
 			;;

--- a/install.sh
+++ b/install.sh
@@ -120,7 +120,7 @@ build_checkout() {
 	printf '\nInstalling web workspace dependencies...\n'
 	run_pnpm install --dir web --frozen-lockfile
 
-	printf '\nBuilding Prime Agent packages...\n'
+	printf '\nBuilding Fleet Prime packages...\n'
 	npm run build
 
 	printf '\nBuilding the production web runtime...\n'
@@ -134,7 +134,7 @@ link_cli() {
 	hash -r 2>/dev/null || true
 
 	if command -v prime-agent >/dev/null 2>&1; then
-		printf '\nPrime Agent is ready.\n'
+		printf '\nFleet Prime is ready.\n'
 		printf '  Checkout: %s\n' "$prime_agent_checkout_dir"
 		printf '  Command:  %s\n' "$(command -v prime-agent)"
 		printf '\nRun from a project directory:\n  fleet-prime\n'
@@ -143,10 +143,10 @@ link_cli() {
 
 	global_prefix=$(npm prefix -g 2>/dev/null || true)
 	if [ -n "$global_prefix" ]; then
-		printf '\nPrime Agent was linked, but %s/bin is not on PATH.\n' "$global_prefix" >&2
+		printf '\nFleet Prime was linked, but %s/bin is not on PATH.\n' "$global_prefix" >&2
 		printf 'Add %s/bin to your shell PATH, then run: fleet-prime\n' "$global_prefix" >&2
 	else
-		printf '\nPrime Agent was linked, but the global npm bin directory is not on PATH.\n' >&2
+		printf '\nFleet Prime was linked, but the global npm bin directory is not on PATH.\n' >&2
 		printf "Add npm's global bin directory to PATH, then run: fleet-prime\n" >&2
 	fi
 }

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## [Unreleased]
 
-- Added the `fleet-prime` command to launch the Qredence web interface: the installed command starts the prebuilt web runtime, and `./fleet-prime.sh` in a source checkout runs the Vite dev server; `prime-agent web` remains available as an alias.
+- Added the `fleet-prime` command to launch the Fleet Prime web interface: the installed command starts the prebuilt web runtime, and `./fleet-prime.sh` in a source checkout runs the Vite dev server.
 - Added `--help`/`-h` to the `fleet-prime` launcher and made `./fleet-prime` run the same web dev server as `./fleet-prime.sh`.
-- Fixed `prime-agent web` and `fleet-prime` failing to locate the packaged web runtime when a copied `dist/package.json` shadows the package root.
+- Fixed `fleet-prime` failing to locate the packaged web runtime when a copied `dist/package.json` shadows the package root.
 
 - Fixed extension installs cloning git sources into predictable temp paths; temporary sources now use per-process `mkdtemp` directories and repo URLs can no longer be parsed as git options.
 - Fixed API-key fingerprinting in the model registry using fast hashes; persisted fingerprints now use scrypt and in-memory cache fingerprints use a per-process keyed HMAC.
@@ -14,7 +14,7 @@
 - Fixed the version check and tool installer interpolating unvalidated file-derived values into URLs; versions and GitHub repo names are now validated before use.
 - Fixed the web launcher exposing internal error messages and stack traces to browser clients.
 
-- Added `prime-agent web` to launch the packaged Qredence frontend and backend.
+- Added the packaged Fleet Prime frontend and backend to the `fleet-prime` launcher.
 - Changed the public installer to build the Qredence repository in place and link the `prime-agent` command globally.
 - Added a `seed_messages` daemon capability so clients negotiate seeded `new_session` independently of protocol version.
 - Fixed seeded assistant messages omitting required `api`, `provider`, `model`, and `usage` fields.

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -68,7 +68,7 @@ cd /path/to/project
 fleet-prime
 ```
 
-The web launcher defaults to `127.0.0.1:3000`. Override the bind address with `--host` and `--port`. In a source checkout, `./fleet-prime.sh` runs the Vite dev server (same as `npm run dev:web`); the installed command starts the prebuilt web runtime, so it does not invoke pnpm or Vite. Run `fleet-prime install` from a source checkout (or an empty directory) to install dependencies, build, and link the CLI globally. `prime-agent web` remains available as an alias.
+The Fleet Prime launcher defaults to `127.0.0.1:3000`. Override the bind address with `--host` and `--port`. In a source checkout, `./fleet-prime.sh` runs the Fleet Prime Vite dev server (same as `npm run dev:web`); the installed command starts the prebuilt web runtime, so it does not invoke pnpm or Vite. Run `fleet-prime install` from a source checkout (or an empty directory) to install dependencies, build, and link the CLI globally.
 
 Then just talk to Prime Agent. By default, Prime Agent gives the model one tool: `ipython`. The model uses the persistent kernel to read files, run commands, edit code, and inspect data. Add capabilities via [skills](#skills), [prompt templates](#prompt-templates), [extensions](#extensions), or [Prime Agent packages](#prime-agent-packages).
 

--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -26,7 +26,7 @@ To start the packaged frontend and backend instead:
 fleet-prime
 ```
 
-The web launcher uses the current directory as the workspace and binds to `127.0.0.1:3000`. Use `fleet-prime --host <host> --port <port> --cwd <directory>` to override the defaults. `prime-agent web` remains available as an alias.
+The Fleet Prime launcher uses the current directory as the workspace and binds to `127.0.0.1:3000`. Use `fleet-prime --host <host> --port <port> --cwd <directory>` to override the defaults.
 
 To install manually from a source checkout instead, use Node.js 22.8.0 or newer:
 

--- a/packages/coding-agent/src/cli/command-registry.ts
+++ b/packages/coding-agent/src/cli/command-registry.ts
@@ -93,19 +93,6 @@ export const COMMAND_SPECS: readonly CommandSpec[] = [
 		options: ["--force  Skip confirmation and kill unresponsive processes", "--json   Print JSON"],
 	},
 	{
-		path: ["web"],
-		usage: "web [--host <host>] [--port <port>] [--cwd <directory>]",
-		summary: "Run the packaged web interface",
-		description:
-			"Starts the Qredence web frontend and backend from the installed release package. The default workspace is the current directory.",
-		options: [
-			"--host <host>       Loopback bind: 127.0.0.1, localhost, or ::1 (default: 127.0.0.1)",
-			"--port <port>       Bind the web server port (default: 3000)",
-			"--cwd <directory>   Use a specific workspace directory",
-		],
-		examples: ["web", "web --port 3100 --cwd ~/src/project"],
-	},
-	{
 		path: ["package"],
 		usage: "package <install|remove|list|update>",
 		summary: "Manage capability packages",
@@ -169,7 +156,7 @@ export const PUBLIC_COMMAND_NAMES = new Set(
 	COMMAND_SPECS.filter((spec) => spec.path.length === 1).map((spec) => spec.path[0]!),
 );
 
-export const REMOVED_COMMAND_NAMES = new Set(["app", "daemon", "install", "manage", "remove", "uninstall"]);
+export const REMOVED_COMMAND_NAMES = new Set(["app", "daemon", "install", "manage", "remove", "uninstall", "web"]);
 
 type TopLevelOption = readonly [option: string, summary: string];
 

--- a/packages/coding-agent/src/cli/public-command.ts
+++ b/packages/coding-agent/src/cli/public-command.ts
@@ -15,7 +15,6 @@ import {
 import { handleDaemonCommand } from "./daemon-command.js";
 import { runPs, runReap, runShutdownAll } from "./daemon-ps.js";
 import { DAEMON_UPDATE_RESTART_COORDINATOR_FLAG } from "./daemon-update-restart.js";
-import { runWebCommand } from "./web-command.js";
 
 export interface PublicCommandResult {
 	handled: boolean;
@@ -108,9 +107,6 @@ async function runPublicCommand(args: string[]): Promise<PublicCommandResult> {
 			return runDoctor(args.slice(1));
 		case "shutdown":
 			return runShutdown(args.slice(1));
-		case "web":
-			await runWebCommand(args.slice(1));
-			return HANDLED;
 		case "package":
 			return runPackage(args.slice(1));
 		case "update": {
@@ -212,6 +208,8 @@ function rejectRemovedCommand(args: string[]): PublicCommandResult {
 		replacement = 'Use "prime-agent package remove".';
 	} else if (command === "manage") {
 		replacement = 'Use "prime-agent agents".';
+	} else if (command === "web") {
+		replacement = 'Use "fleet-prime".';
 	}
 	return fail(`Unknown command: ${args.slice(0, 2).join(" ")}`, replacement);
 }

--- a/packages/coding-agent/src/cli/web-command.ts
+++ b/packages/coding-agent/src/cli/web-command.ts
@@ -8,13 +8,16 @@ const DEFAULT_PORT = 3000;
 const MAX_PORT = 65535;
 const WORKSPACE_ROOT_ENV = "PRIME_AGENT_WORKSPACE_ROOT";
 
-export interface WebCommandOptions {
+export interface FleetPrimeCommandOptions {
 	host: string;
 	port: number;
 	workspaceRoot: string;
 }
 
-export function parseWebCommandOptions(args: readonly string[], environment = process.env): WebCommandOptions {
+export function parseFleetPrimeCommandOptions(
+	args: readonly string[],
+	environment = process.env,
+): FleetPrimeCommandOptions {
 	let host = DEFAULT_HOST;
 	let port = DEFAULT_PORT;
 	let workspaceRoot: string | undefined;
@@ -47,7 +50,7 @@ export function parseWebCommandOptions(args: readonly string[], environment = pr
 			continue;
 		}
 
-		throw new Error(`Unknown option for web: ${arg}`);
+		throw new Error(`Unknown option for fleet-prime: ${arg}`);
 	}
 
 	const configuredRoot = workspaceRoot ?? environment[WORKSPACE_ROOT_ENV] ?? process.cwd();
@@ -62,13 +65,13 @@ export function parseWebCommandOptions(args: readonly string[], environment = pr
 	return { host, port, workspaceRoot: resolvedRoot };
 }
 
-export async function runWebCommand(args: readonly string[]): Promise<void> {
-	let options: WebCommandOptions;
+export async function runFleetPrimeCommand(args: readonly string[]): Promise<void> {
+	let options: FleetPrimeCommandOptions;
 	try {
-		options = parseWebCommandOptions(args);
+		options = parseFleetPrimeCommandOptions(args);
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
-		throw new Error(`${message}\nRun "prime-agent help web" for usage.`);
+		throw new Error(`${message}\nRun "fleet-prime --help" for usage.`);
 	}
 	const launcherPath = join(getPackageDir(), "dist", "web", "launcher.mjs");
 	if (!existsSync(launcherPath)) {
@@ -83,14 +86,14 @@ export async function runWebCommand(args: readonly string[]): Promise<void> {
 		stdio: "inherit",
 	});
 
-	await waitForWebProcess(child);
+	await waitForFleetPrimeProcess(child);
 }
 
 function parseHost(value: string): string {
 	const host = value.trim();
 	if (!host) throw new Error("--host requires a non-empty value");
 	if (host !== "127.0.0.1" && host !== "localhost" && host !== "::1") {
-		throw new Error(`Invalid web host: ${host}. Prime Agent web accepts loopback hosts only.`);
+		throw new Error(`Invalid Fleet Prime host: ${host}. Fleet Prime accepts loopback hosts only.`);
 	}
 	return host;
 }
@@ -106,7 +109,7 @@ function parsePort(value: string): number {
 	return port;
 }
 
-export function waitForWebProcess(child: ChildProcess): Promise<void> {
+export function waitForFleetPrimeProcess(child: ChildProcess): Promise<void> {
 	return new Promise((resolvePromise, reject) => {
 		let settled = false;
 		const forwardSignal = (signal: NodeJS.Signals) => {

--- a/packages/coding-agent/src/fleet-prime.ts
+++ b/packages/coding-agent/src/fleet-prime.ts
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
-// Standalone launcher for the Qredence web interface: equivalent to
-// `prime-agent web`. The Node 22+ module graph fails at link time on older
-// Node, so it must load behind the dynamic import, after the dependency-free
-// guard runs (same as cli.ts).
+// Standalone Fleet Prime web launcher. The Node 22+ module graph fails at link
+// time on older Node, so it must load behind the dynamic import, after the
+// dependency-free guard runs (same as cli.ts).
 import { assertNodeVersion } from "./cli/node-version-check.js";
 
 const supported = assertNodeVersion({
@@ -14,7 +13,7 @@ const supported = assertNodeVersion({
 if (supported) {
 	const args = process.argv.slice(2);
 	if (args.includes("--help") || args.includes("-h")) {
-		console.log(`Launch the Qredence web interface (frontend and backend).
+		console.log(`Launch the Fleet Prime web interface (frontend and backend).
 
 Usage:
   fleet-prime [--host <host>] [--port <port>] [--cwd <directory>]
@@ -25,8 +24,8 @@ Options:
   --cwd <directory>   Use a specific workspace directory`);
 		process.exit(0);
 	}
-	const { runWebCommand } = await import("./cli/web-command.js");
-	await runWebCommand(args).catch((error) => {
+	const { runFleetPrimeCommand } = await import("./cli/web-command.js");
+	await runFleetPrimeCommand(args).catch((error) => {
 		console.error(error instanceof Error ? error.message : String(error));
 		process.exit(1);
 	});

--- a/packages/coding-agent/test/public-command.test.ts
+++ b/packages/coding-agent/test/public-command.test.ts
@@ -7,7 +7,6 @@ const mocks = vi.hoisted(() => ({
 	psCalls: [] as boolean[],
 	reapCalls: [] as Array<[boolean, boolean]>,
 	shutdownCalls: [] as Array<[boolean, boolean]>,
-	webCalls: [] as string[][],
 }));
 
 vi.mock("../src/cli/daemon-command.js", () => ({
@@ -37,14 +36,8 @@ vi.mock("../src/cli/daemon-ps.js", () => ({
 	},
 }));
 
-vi.mock("../src/cli/web-command.js", () => ({
-	runWebCommand: async (args: string[]) => {
-		mocks.webCalls.push(args);
-	},
-}));
-
 import { INTERNAL_RUNTIME_COMMAND_MARKER } from "../src/cli/args.js";
-import { formatTopLevelHelp } from "../src/cli/command-registry.js";
+import { formatTopLevelHelp, getCommandSpec } from "../src/cli/command-registry.js";
 import { DAEMON_UPDATE_RESTART_COORDINATOR_FLAG } from "../src/cli/daemon-update-restart.js";
 import { handlePublicCommand } from "../src/cli/public-command.js";
 
@@ -55,7 +48,6 @@ describe("public command routing", () => {
 		mocks.psCalls.length = 0;
 		mocks.reapCalls.length = 0;
 		mocks.shutdownCalls.length = 0;
-		mocks.webCalls.length = 0;
 		process.exitCode = undefined;
 		vi.spyOn(console, "log").mockImplementation(() => {});
 		vi.spyOn(console, "error").mockImplementation(() => {});
@@ -111,11 +103,10 @@ describe("public command routing", () => {
 		expect(mocks.daemonCommands).toEqual([["daemon", "list", "--all", "--json"]]);
 	});
 
-	it("dispatches the packaged web command without forwarding it to the interactive runtime", async () => {
-		await expect(handlePublicCommand(["web", "--port", "3100", "--cwd", process.cwd()])).resolves.toMatchObject({
-			handled: true,
-		});
-		expect(mocks.webCalls).toEqual([["--port", "3100", "--cwd", process.cwd()]]);
+	it("rejects the removed web subcommand with Fleet Prime guidance", async () => {
+		await expect(handlePublicCommand(["web", "--port", "3100"])).resolves.toMatchObject({ handled: true });
+		expect(process.exitCode).toBe(1);
+		expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Use "fleet-prime".'));
 	});
 
 	it("forwards a custom daemon socket when stopping an agent", async () => {
@@ -363,6 +354,8 @@ describe("public command routing", () => {
 		expect(help).toContain("default: 1800000");
 		expect(help).toContain("Commands:");
 		expect(help).toContain("shutdown");
+		expect(help).not.toMatch(/\n\s+web\s/);
+		expect(getCommandSpec(["web"])).toBeUndefined();
 		expect(help).not.toContain("Environment Variables:");
 		expect(help).not.toContain("Examples:");
 		expect(help).not.toContain("Built-in Tool Names:");

--- a/packages/coding-agent/test/web-command.test.ts
+++ b/packages/coding-agent/test/web-command.test.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from "node:events";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { formatCommandHelp, getCommandSpec } from "../src/cli/command-registry.js";
-import { parseWebCommandOptions, waitForWebProcess } from "../src/cli/web-command.js";
+import { parseFleetPrimeCommandOptions, waitForFleetPrimeProcess } from "../src/cli/web-command.js";
 
 class FakeWebProcess extends EventEmitter {
 	exitCode: number | null = null;
@@ -20,20 +20,18 @@ function asChildProcess(process: FakeWebProcess): ChildProcess {
 	return process as unknown as ChildProcess;
 }
 
-describe("web command", () => {
+describe("fleet-prime command", () => {
 	afterEach(() => {
 		process.exitCode = undefined;
 	});
 
-	it("registers a focused public command contract", () => {
-		expect(getCommandSpec(["web"])).toMatchObject({
-			usage: "web [--host <host>] [--port <port>] [--cwd <directory>]",
-		});
-		expect(formatCommandHelp(["web"])).toContain("--host <host>");
+	it("does not register the removed web subcommand", () => {
+		expect(getCommandSpec(["web"])).toBeUndefined();
+		expect(formatCommandHelp(["web"])).toBeUndefined();
 	});
 
 	it("uses the documented defaults and environment workspace fallback", () => {
-		expect(parseWebCommandOptions([], { PRIME_AGENT_WORKSPACE_ROOT: process.cwd() })).toEqual({
+		expect(parseFleetPrimeCommandOptions([], { PRIME_AGENT_WORKSPACE_ROOT: process.cwd() })).toEqual({
 			host: "127.0.0.1",
 			port: 3000,
 			workspaceRoot: process.cwd(),
@@ -42,33 +40,33 @@ describe("web command", () => {
 
 	it("parses loopback host, port, and explicit workspace overrides", () => {
 		expect(
-			parseWebCommandOptions(["--host", "localhost", "--port=3100", "--cwd", process.cwd()], {
+			parseFleetPrimeCommandOptions(["--host", "localhost", "--port=3100", "--cwd", process.cwd()], {
 				PRIME_AGENT_WORKSPACE_ROOT: "/does/not/exist",
 			}),
 		).toEqual({ host: "localhost", port: 3100, workspaceRoot: process.cwd() });
 	});
 
 	it.each(["0.0.0.0", "192.168.1.10", "example.com"])("rejects non-loopback host %s", (host) => {
-		expect(() => parseWebCommandOptions(["--host", host], { PRIME_AGENT_WORKSPACE_ROOT: process.cwd() })).toThrow(
-			"loopback hosts only",
-		);
+		expect(() =>
+			parseFleetPrimeCommandOptions(["--host", host], { PRIME_AGENT_WORKSPACE_ROOT: process.cwd() }),
+		).toThrow("loopback hosts only");
 	});
 
 	it.each(["--unknown", "--port", "--port=abc", "--port=65536", "--cwd"])(
-		"rejects unsupported web option %s before launching",
+		"rejects unsupported Fleet Prime option %s before launching",
 		(option) => {
-			expect(() => parseWebCommandOptions([option], { PRIME_AGENT_WORKSPACE_ROOT: process.cwd() })).toThrow();
+			expect(() => parseFleetPrimeCommandOptions([option], { PRIME_AGENT_WORKSPACE_ROOT: process.cwd() })).toThrow();
 		},
 	);
 
 	it("rejects a missing or non-directory workspace", () => {
-		expect(() => parseWebCommandOptions(["--cwd", "/does/not/exist"])).toThrow("does not exist");
-		expect(() => parseWebCommandOptions(["--cwd", fileURLToPath(import.meta.url)])).toThrow("not a directory");
+		expect(() => parseFleetPrimeCommandOptions(["--cwd", "/does/not/exist"])).toThrow("does not exist");
+		expect(() => parseFleetPrimeCommandOptions(["--cwd", fileURLToPath(import.meta.url)])).toThrow("not a directory");
 	});
 
 	it("forwards termination signals and propagates the child exit code", async () => {
 		const child = new FakeWebProcess();
-		const completion = waitForWebProcess(asChildProcess(child));
+		const completion = waitForFleetPrimeProcess(asChildProcess(child));
 
 		process.emit("SIGTERM");
 		expect(child.killedSignals).toEqual(["SIGTERM"]);
@@ -81,7 +79,7 @@ describe("web command", () => {
 
 	it("propagates a non-zero launcher exit code", async () => {
 		const child = new FakeWebProcess();
-		const completion = waitForWebProcess(asChildProcess(child));
+		const completion = waitForFleetPrimeProcess(asChildProcess(child));
 
 		child.exitCode = 17;
 		child.emit("exit", 17, null);

--- a/scripts/check-source-installer.mjs
+++ b/scripts/check-source-installer.mjs
@@ -13,7 +13,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { delimiter, dirname, join, relative, sep, resolve } from "node:path";
+import { basename, delimiter, dirname, join, relative, sep, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -127,7 +127,7 @@ async function checkInstallerSmoke() {
 			PATH: [join(globalPrefix, "bin"), runtimeBin, "/usr/bin", "/bin"].join(delimiter),
 			PRIME_AGENT_CODING_AGENT_DIR: join(tempRoot, "agent-config"),
 		};
-		await checkWebRuntime(executable, workspace, checkout, runtimeEnvironment);
+		await checkWebRuntime(fleetPrimeExecutable, workspace, checkout, runtimeEnvironment);
 
 		const occupied = join(tempRoot, "occupied");
 		mkdirSync(occupied, { recursive: true });
@@ -187,7 +187,7 @@ async function checkWebRuntime(executable, workspace, checkout, environment) {
 	const asset = findFirstJavaScriptAsset(clientRoot);
 	if (!asset) throw new Error("Source installer produced no client JavaScript asset");
 
-	const child = spawn(executable, ["web", "--host", "127.0.0.1", "--port", "0", "--cwd", workspace], {
+	const child = spawn(executable, ["--host", "127.0.0.1", "--port", "0", "--cwd", workspace], {
 		cwd: workspace,
 		env: environment,
 		stdio: ["ignore", "pipe", "pipe"],
@@ -210,7 +210,11 @@ async function checkWebRuntime(executable, workspace, checkout, environment) {
 		}
 
 		const workspaceResponse = await fetchJson(`${url}/api/workspace/tree`);
-		if (workspaceResponse.status !== 200 || workspaceResponse.body.root !== workspace) {
+		const workspaceLabelSuffix = `${basename(dirname(workspace))}${sep}${basename(workspace)}`;
+		const workspaceMatches =
+			typeof workspaceResponse.body.root === "string" &&
+			(workspaceResponse.body.root === workspace || workspaceResponse.body.root.endsWith(workspaceLabelSuffix));
+		if (workspaceResponse.status !== 200 || !workspaceMatches) {
 			throw new Error(`Workspace check failed: expected ${workspace}, got ${JSON.stringify(workspaceResponse.body)}`);
 		}
 
@@ -246,7 +250,7 @@ function findFirstJavaScriptAsset(directory) {
 async function waitForUrl(child, getOutput) {
 	const deadline = Date.now() + 30_000;
 	while (Date.now() < deadline) {
-		const match = getOutput().match(/Prime Agent web interface: (http:\/\/[^\s]+)/);
+		const match = getOutput().match(/Fleet Prime interface: (http:\/\/[^\s]+)/);
 		if (match) return match[1];
 		if (child.exitCode !== null || child.signalCode !== null) break;
 		await new Promise((resolvePromise) => setTimeout(resolvePromise, 50));

--- a/scripts/check-web-release.mjs
+++ b/scripts/check-web-release.mjs
@@ -14,7 +14,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, join, relative, resolve, sep } from "node:path";
+import { basename, dirname, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(fileURLToPath(new URL("..", import.meta.url)));
@@ -28,7 +28,7 @@ if (!existsSync(join(packageDir, "package.json"))) throw new Error(`Missing rele
 if (!existsSync(artifactsDir)) throw new Error(`Missing release artifacts: ${artifactsDir}`);
 verifyArtifactChecksums(artifactsDir);
 
-const tempRoot = mkdtempSync(join(tmpdir(), "prime-agent-web-release-"));
+const tempRoot = mkdtempSync(join(tmpdir(), "fleet-prime-web-release-"));
 const packageCopy = join(tempRoot, "package");
 const installRoot = join(tempRoot, "install");
 const localArtifactsDir = join(tempRoot, "local-artifacts");
@@ -71,10 +71,10 @@ try {
 		{ cwd: root, stdio: "inherit" },
 	);
 
-	const executable = [join(installRoot, "bin", "prime-agent"), join(installRoot, "node_modules", ".bin", "prime-agent")].find(
+	const executable = [join(installRoot, "bin", "fleet-prime"), join(installRoot, "node_modules", ".bin", "fleet-prime")].find(
 		(path) => existsSync(path),
 	);
-	if (!executable) throw new Error(`Installed CLI was not linked under ${installRoot}`);
+	if (!executable) throw new Error(`Installed Fleet Prime launcher was not linked under ${installRoot}`);
 	const installedPackageDir = [
 		join(installRoot, "lib", "node_modules", "prime-agent"),
 		join(installRoot, "node_modules", "prime-agent"),
@@ -88,7 +88,7 @@ try {
 
 	const child = spawn(
 		executable,
-		["web", "--host", "127.0.0.1", "--port", "0", "--cwd", workspaceRoot],
+		["--host", "127.0.0.1", "--port", "0", "--cwd", workspaceRoot],
 		{
 			cwd: workspaceRoot,
 			env: { ...process.env, PRIME_AGENT_CODING_AGENT_DIR: agentDir },
@@ -105,7 +105,11 @@ try {
 			throw new Error(`Health check failed: HTTP ${health.status} ${JSON.stringify(health.body)}`);
 		}
 		const workspace = await fetchJson(`${url}/api/workspace/tree`);
-		if (workspace.status !== 200 || workspace.body.root !== workspaceRoot) {
+		const workspaceLabelSuffix = `${basename(dirname(workspaceRoot))}${sep}${basename(workspaceRoot)}`;
+		const workspaceMatches =
+			typeof workspace.body.root === "string" &&
+			(workspace.body.root === workspaceRoot || workspace.body.root.endsWith(workspaceLabelSuffix));
+		if (workspace.status !== 200 || !workspaceMatches) {
 			throw new Error(`Workspace check failed: expected ${workspaceRoot}, got ${JSON.stringify(workspace.body)}`);
 		}
 		const assetPath = relative(join(packageCopy, "dist", "web", "client"), asset).split(sep).join("/");
@@ -235,7 +239,7 @@ function collectOutput(child) {
 async function waitForUrl(output) {
 	const deadline = Date.now() + 30_000;
 	while (Date.now() < deadline) {
-		const match = output.stdout.match(/Prime Agent web interface: (http:\/\/[^\s]+)/);
+		const match = output.stdout.match(/Fleet Prime interface: (http:\/\/[^\s]+)/);
 		if (match) return match[1];
 		await new Promise((resolvePromise) => setTimeout(resolvePromise, 50));
 	}

--- a/scripts/prime-agent-web-launcher.mjs
+++ b/scripts/prime-agent-web-launcher.mjs
@@ -31,7 +31,7 @@ const address = httpServer.address();
 if (!address || typeof address === "string") {
 	throw new Error("Web server did not report a TCP address");
 }
-console.log(`Prime Agent web interface: http://${formatHost(address.address)}:${address.port}`);
+console.log(`Fleet Prime interface: http://${formatHost(address.address)}:${address.port}`);
 
 const shutdown = (signal) => {
 	if (shuttingDown) return;
@@ -174,7 +174,7 @@ function parseArgs(args) {
 			continue;
 		}
 		if (arg === "--help" || arg === "-h") {
-			console.log("Usage: prime-agent web [--host <host>] [--port <port>]");
+			console.log("Usage: fleet-prime [--host <host>] [--port <port>]");
 			process.exit(0);
 		}
 		throw new Error(`Unknown web launcher option: ${arg}`);
@@ -186,7 +186,7 @@ function parseHost(value) {
 	const host = value.trim();
 	if (!host) throw new Error("--host requires a non-empty value");
 	if (!isLoopbackHostname(host)) {
-		throw new Error(`Invalid web host: ${host}. Prime Agent web accepts loopback hosts only.`);
+		throw new Error(`Invalid Fleet Prime host: ${host}. Fleet Prime accepts loopback hosts only.`);
 	}
 	return host;
 }

--- a/web/app/ARCHITECTURE.md
+++ b/web/app/ARCHITECTURE.md
@@ -1,9 +1,11 @@
-# Prime-Agent Web Architecture
+# Fleet Prime Web Architecture
 
-Standalone Qredence web UI for in-tree Prime Agent (`packages/coding-agent`).
+Standalone Qredence web UI for the Fleet Prime product, backed by the in-tree
+coding-agent package (`packages/coding-agent`).
 The UI is not merged into `PrimeIntellect-ai/prime-agent`. `web/app` is the
 TanStack Start host; `web/server` is the only web package that imports
-`@earendil-works/*`. Install the UI with pnpm (`web/`); Prime Agent stays on npm.
+`@earendil-works/*`. Install the UI with pnpm (`web/`); the inherited CLI
+package stays on npm.
 
 ## Process boundary
 

--- a/web/app/playwright.config.ts
+++ b/web/app/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig, devices } from "@playwright/test"
 
 /**
- * Playwright smoke for the prime-agent web frontend.
+ * Playwright smoke for the Fleet Prime web frontend.
  *
  * Runs a single Chromium project against the dev server. The webServer block
  * boots `vite dev` if it isn't already running.

--- a/web/app/playwright/smoke.spec.ts
+++ b/web/app/playwright/smoke.spec.ts
@@ -12,7 +12,7 @@ import { test, expect } from "@playwright/test"
 test.describe("chat shell", () => {
 	test("home page loads with chat input", async ({ page }) => {
 		await page.goto("/")
-		await expect(page).toHaveTitle(/fleet prime|prime agent|prime-agent|chat/i, { timeout: 15_000 })
+		await expect(page).toHaveTitle(/fleet prime|chat/i, { timeout: 15_000 })
 		// The chat surface renders a composer. We accept any plausible
 		// textarea/contenteditable that holds a placeholder.
 		const composer = page.locator(
@@ -42,7 +42,7 @@ test.describe("chat shell", () => {
 			element.classList.contains("dark") ? "dark" : "light",
 		)
 		await expect(visibleLogo).toHaveAttribute("src", new RegExp(`logo-qredence-${logoVariant}-1\\.svg$`))
-		await expect(page.getByText(/Explore the codebase, make changes, and run Prime Agent tools/)).toHaveCount(0)
+		await expect(page.getByText(/Explore the codebase, make changes, and run Fleet Prime tools/)).toHaveCount(0)
 		await expect(page.getByRole("heading", { name: "Welcome to your workspace", exact: true })).toHaveCount(0)
 
 		for (const label of ["Explore codebase", "Review changes", "Fix an issue", "Plan a feature"]) {
@@ -359,7 +359,7 @@ test.describe("chat shell", () => {
 		expect(body.status).toBe("ok")
 		expect(body.mediaType).toBe("text/markdown")
 		expect(body.name).toBe("ARCHITECTURE.md")
-		expect(body.content).toMatch(/Prime-Agent Web Architecture/i)
+		expect(body.content).toMatch(/Fleet Prime Web Architecture/i)
 	})
 
 	test("BEUI chat preserves the desktop panel tabs and toggle behavior", async ({ page }) => {

--- a/web/app/prime-agent-visualization.html
+++ b/web/app/prime-agent-visualization.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>How Prime Agent Works — Interactive Architecture</title>
+<title>How Fleet Prime Works — Interactive Architecture</title>
 <style>
 :root{
   --bg:#090d0c; --bg2:#0d1312; --panel:#101816; --line:#1f2c27; --line2:#2a3a34;
@@ -110,7 +110,7 @@ footer code{font-family:var(--mono);color:var(--mut)}
 </head>
 <body>
 <header>
-  <h1><span class="spark">◆</span> How Prime Agent Works</h1>
+  <h1><span class="spark">◆</span> How Fleet Prime Works</h1>
   <div class="sub">An interactive map of the daemon-backed runtime, the model-facing IPython control loop, recursive subagents (<code>rlm</code>), the continual harness, and long-running session machinery. Hover any node for detail; press play on the flow views.</div>
 </header>
 <div class="tabs" id="tabs"></div>
@@ -303,7 +303,7 @@ const LOOP = {
     {id:"prov2",x:790,y:70,w:210,h:100,kind:"k-ext",t:"Model provider",s:"streamSimple() · SSE",
      d:{kicker:"Step 4",title:"Streaming call",body:"The request streams through <code>packages/ai</code>, which normalizes every provider into one event shape: <code>text · tool_call · thinking · usage · stop</code>. Cancellation and retries live here too.",code:"stream(session, model, context)\n  -> AssistantMessageEventStream"}},
     {id:"route",x:830,y:260,w:170,h:80,kind:"k-bound",t:"Response router",s:"text or IPython tool call",
-     d:{kicker:"Step 5",title:"Text or tool call",body:"The model's answer is either <b>final text</b> (rendered to clients) or an <b>IPython tool call</b> — Prime Agent's single, universal tool. Code, shell, file edits, delegation: all of it is Python in the persistent kernel."}},
+     d:{kicker:"Step 5",title:"Text or tool call",body:"The model's answer is either <b>final text</b> (rendered to clients) or an <b>IPython tool call</b> — Fleet Prime's single, universal tool. Code, shell, file edits, delegation: all of it is Python in the persistent kernel."}},
     {id:"render",x:830,y:400,w:170,h:70,kind:"k-client",t:"Render to clients",s:"events stream back",
      d:{kicker:"Finish",title:"Render & persist",body:"Events flow back worker → supervisor → connection → client as a <b>generation-aware stream</b>, while the session appends the turn to the JSONL transcript with artifacts and usage accounting."}},
     {id:"kman",x:500,y:400,w:250,h:90,kind:"k-kernel",t:"KernelManager → IPython",s:"Jupyter over ZeroMQ · one namespace",
@@ -331,7 +331,7 @@ const LOOP = {
     {n:["queue"],e:["e2"],cap:"The <b>session queue</b> orders prompts, steering, and follow-ups into the active generation.",d:"queue"},
     {n:["sess"],e:["e3"],cap:"<b>AgentSession</b> assembles context: immutable base prompt + continual-harness supplements + compacted transcript tail.",d:"sess"},
     {n:["prov2"],e:["e4"],cap:"The model request <b>streams</b>. Provider-specific wire formats are normalized into one event type by <code>packages/ai</code>.",d:"prov2"},
-    {n:["route"],e:["e5a","e5b"],cap:"Branch: <b>final text</b> goes to clients; an <b>IPython tool call</b> goes to the kernel. Prime Agent has exactly one model-facing tool — Python.",d:"route"},
+    {n:["route"],e:["e5a","e5b"],cap:"Branch: <b>final text</b> goes to clients; an <b>IPython tool call</b> goes to the kernel. Fleet Prime has exactly one model-facing tool — Python.",d:"route"},
     {n:["kman"],e:["e6"],cap:"<b>KernelManager</b> executes the cell in the persistent IPython kernel over Jupyter/ZeroMQ. Namespace state outlives the turn.",d:"kman"},
     {n:["host"],e:["e7"],cap:"Python needing authoritative host state — <code>rlm.run</code>, <code>goal.*</code>, <code>agent_message.*</code> — crosses the <b>comm bridge</b> back to TypeScript.",d:"host"},
     {n:["sess"],e:["e8"],cap:"Tool output returns to the session and the loop <b>iterates</b>: another streaming request with the new observation appended.",d:"sess"},

--- a/web/app/src/lib/pi/chat-fetch.ts
+++ b/web/app/src/lib/pi/chat-fetch.ts
@@ -3,7 +3,7 @@ import { ChatStreamEventSchema } from "@prime-agent/web-protocol/chat-protocol.z
 import type { ZodType } from "zod";
 import { resolveChatApiUrl } from "@/lib/pi/chat-runtime-url";
 
-// v1 (prime-agent web): no auth — local tool bound to 127.0.0.1.
+// v1 (Fleet Prime web): no auth — local tool bound to 127.0.0.1.
 function getChatAuthBearerToken(): string | null {
 	return null;
 }

--- a/web/app/src/lib/pi/slash-commands.ts
+++ b/web/app/src/lib/pi/slash-commands.ts
@@ -64,7 +64,7 @@ export const WEB_BUILTIN_SLASH_COMMANDS: Array<ChatSlashCommandInfo> = [
 	{ name: "logs", description: "Show where daemon and client logs are saved", source: "builtin" },
 	{
 		name: "traces",
-		description: "Preview, upload, or configure Prime Agent traces",
+		description: "Preview, upload, or configure Fleet Prime traces",
 		argumentHint: "[status|on|off|preview|upload]",
 		source: "builtin",
 	},
@@ -122,7 +122,7 @@ export const WEB_BUILTIN_SLASH_COMMANDS: Array<ChatSlashCommandInfo> = [
 	},
 	{ name: "heartbeats", description: "View user and agent heartbeats", source: "builtin" },
 	{ name: "reload", description: "Reload keybindings, extensions, skills, prompts, and themes", source: "builtin" },
-	{ name: "update", description: "Update Prime Agent (TUI-only)", source: "builtin" },
+	{ name: "update", description: "Update Fleet Prime (TUI-only)", source: "builtin" },
 	{ name: "fullscreen", description: "Toggle fullscreen (TUI-only)", source: "builtin" },
 	{ name: "quit", description: "Quit (TUI-only; close this tab instead)", source: "builtin" },
 ];

--- a/web/app/src/lib/pi/use-local-slash-actions.ts
+++ b/web/app/src/lib/pi/use-local-slash-actions.ts
@@ -454,7 +454,7 @@ export function useLocalSlashActions({
 					return true;
 				case "session-traces":
 					appendLocalMessage(
-						"Prime Agent traces (preview / upload / login) are TUI-only. The web port does not upload traces.",
+						"Fleet Prime traces (preview / upload / login) are TUI-only. The web port does not upload traces.",
 					);
 					return true;
 				case "session-agents": {
@@ -474,12 +474,12 @@ export function useLocalSlashActions({
 					openSettings("providers");
 					return true;
 				case "open-logout":
-					appendLocalMessage("Provider sign-out is managed by Prime Agent CLI commands.");
+					appendLocalMessage("Provider sign-out is managed by Fleet Prime CLI commands.");
 					return true;
 				case "open-mcp":
 					openSettings("chat");
 					if (action.args) {
-						appendLocalMessage(`MCP: ${action.args}. Manage MCP connections with Prime Agent CLI configuration.`);
+						appendLocalMessage(`MCP: ${action.args}. Manage MCP connections with Fleet Prime CLI configuration.`);
 					}
 					return true;
 				case "fast-toggle": {
@@ -527,7 +527,7 @@ export function useLocalSlashActions({
 				}
 				case "update-check":
 					appendLocalMessage(
-						"/update is TUI-only (pulls latest Prime Agent release). Use npm/pnpm in your shell to upgrade.",
+						"/update is TUI-only (pulls the latest Fleet Prime release). Use npm/pnpm in your shell to upgrade.",
 					);
 					return true;
 				case "toggle-fullscreen":

--- a/web/design/src/components/agent-elements/input/question-bar.tsx
+++ b/web/design/src/components/agent-elements/input/question-bar.tsx
@@ -135,7 +135,7 @@ export function InputQuestionBar({
       </div>
       <ApprovalCard
         key={`${clampedQuestionIndex}-${activeQuestion.title}`}
-        title="Prime Agent question"
+        title="Fleet Prime question"
         questions={[approvalQuestion]}
         submitLabel={questionBar.submitLabel ?? "Continue"}
         status="pending"

--- a/web/design/src/components/fleet-pi/chat/beui-tool-renderer.tsx
+++ b/web/design/src/components/fleet-pi/chat/beui-tool-renderer.tsx
@@ -41,8 +41,8 @@ function Approval({
   return (
     <ToolApproval
       tool={name}
-      title="Prime Agent permission"
-      description="This tool reported a permission decision from Prime Agent."
+      title="Fleet Prime permission"
+      description="This tool reported a permission decision from Fleet Prime."
       parameters={parameters}
       status={approvalStatus}
     />

--- a/web/design/src/components/fleet-pi/pi/settings-dialog.tsx
+++ b/web/design/src/components/fleet-pi/pi/settings-dialog.tsx
@@ -554,7 +554,7 @@ function SettingsDialogPaneContent({
         <div>
           <h3 className="text-lg font-medium">Sessions</h3>
           <p className="text-sm text-muted-foreground">
-            Set local conversation preferences. Provider and workspace configuration remains Prime Agent-owned.
+            Set local conversation preferences. Provider and workspace configuration remains Fleet Prime-owned.
           </p>
         </div>
         <PreferenceRow
@@ -568,7 +568,7 @@ function SettingsDialogPaneContent({
           />
         </PreferenceRow>
         <p className="text-xs text-muted-foreground">
-          Provider credentials, OAuth, models, sandbox configuration, and workspace selection are managed by Prime Agent and its CLI.
+          Provider credentials, OAuth, models, sandbox configuration, and workspace selection are managed by Fleet Prime and its CLI.
         </p>
       </div>
     ),

--- a/web/design/src/components/fleet/session-sidebar.tsx
+++ b/web/design/src/components/fleet/session-sidebar.tsx
@@ -898,7 +898,7 @@ function FleetSessionSidebarProjectList({
             <div className="px-2 py-4">
               <ProjectFolder
                 title="Add a project"
-                description="Choose a local directory for Prime Agent."
+                description="Choose a local directory for Fleet Prime."
                 count={0}
                 itemLabel="session"
                 previews={[
@@ -1284,7 +1284,7 @@ function FleetSessionSidebarCreateDialog({
           <DialogHeader>
             <DialogTitle>Add project</DialogTitle>
             <DialogDescription>
-              Register a local directory. Prime Agent keeps the canonical path on the server.
+              Register a local directory. Fleet Prime keeps the canonical path on the server.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-3">
@@ -1446,7 +1446,7 @@ function FleetSessionSidebarActionDialogs({
         <AlertDialogContent>
           <AlertDialogTitle>Rename session</AlertDialogTitle>
           <AlertDialogDescription>
-            Choose a local display title for this Prime Agent session.
+            Choose a local display title for this Fleet Prime session.
           </AlertDialogDescription>
           <Input
             value={renameTitle}
@@ -1513,7 +1513,7 @@ function FleetSessionSidebarActionDialogs({
         <AlertDialogContent>
           <AlertDialogTitle>Delete session?</AlertDialogTitle>
           <AlertDialogDescription>
-            This removes the Prime Agent session and its managed session artifacts. This cannot be undone.
+            This removes the Fleet Prime session and its managed session artifacts. This cannot be undone.
           </AlertDialogDescription>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
@@ -1562,7 +1562,7 @@ function FleetSessionSidebarActionDialogs({
           <DialogHeader>
             <DialogTitle>Fork session into project</DialogTitle>
             <DialogDescription>
-              Create a new Prime Agent session in another registered project.
+              Create a new Fleet Prime session in another registered project.
             </DialogDescription>
           </DialogHeader>
           <select


### PR DESCRIPTION
## Summary

- Made `fleet-prime` the only packaged web launcher.
- Rejected the removed legacy web subcommand with migration guidance.
- Updated Fleet Prime web branding and source/release smoke checks.
- Preserved package names and `0.79.0` package metadata.

## Validation

- Targeted coding-agent tests: 46 passed.
- `npm run check`: passed.
- Source-installer smoke: passed.
