### PR TITLE
fix: align inherited Prime Agent version with v0.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prime-agent",
-	"version": "0.79.0",
+	"version": "0.7.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prime-agent",
-			"version": "0.79.0",
+			"version": "0.7.3",
 			"license": "MIT",
 			"workspaces": [
 				"packages/*",
@@ -16,7 +16,7 @@
 				"packages/coding-agent/examples/extensions/sandbox"
 			],
 			"dependencies": {
-				"@earendil-works/pi-coding-agent": "^0.79.0",
+				"@earendil-works/pi-coding-agent": "^0.7.3",
 				"get-east-asian-width": "^1.6.0"
 			},
 			"devDependencies": {
@@ -5738,10 +5738,10 @@
 		},
 		"packages/agent": {
 			"name": "@earendil-works/pi-agent-core",
-			"version": "0.79.0",
+			"version": "0.7.3",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.79.0",
+				"@earendil-works/pi-ai": "^0.7.3",
 				"typebox": "^1.1.24"
 			},
 			"devDependencies": {
@@ -5768,7 +5768,7 @@
 		},
 		"packages/ai": {
 			"name": "@earendil-works/pi-ai",
-			"version": "0.79.0",
+			"version": "0.7.3",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.91.1",
@@ -5822,14 +5822,14 @@
 		},
 		"packages/coding-agent": {
 			"name": "@earendil-works/pi-coding-agent",
-			"version": "0.79.0",
+			"version": "0.7.3",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
 				"@agentclientprotocol/sdk": "^1.3.0",
-				"@earendil-works/pi-agent-core": "^0.79.0",
-				"@earendil-works/pi-ai": "^0.79.0",
-				"@earendil-works/pi-tui": "^0.79.0",
+				"@earendil-works/pi-agent-core": "^0.7.3",
+				"@earendil-works/pi-ai": "^0.7.3",
+				"@earendil-works/pi-tui": "^0.7.3",
 				"@silvia-odwyer/photon-node": "^0.3.4",
 				"chalk": "^5.5.0",
 				"cli-highlight": "^2.1.11",
@@ -5880,25 +5880,25 @@
 		},
 		"packages/coding-agent/examples/extensions/custom-provider-anthropic": {
 			"name": "pi-extension-custom-provider-anthropic",
-			"version": "0.79.0",
+			"version": "0.7.3",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.52.0"
 			}
 		},
 		"packages/coding-agent/examples/extensions/custom-provider-gitlab-duo": {
 			"name": "pi-extension-custom-provider-gitlab-duo",
-			"version": "0.79.0"
+			"version": "0.7.3"
 		},
 		"packages/coding-agent/examples/extensions/sandbox": {
 			"name": "pi-extension-sandbox",
-			"version": "0.79.0",
+			"version": "0.7.3",
 			"dependencies": {
 				"@anthropic-ai/sandbox-runtime": "^0.0.55"
 			}
 		},
 		"packages/coding-agent/examples/extensions/with-deps": {
 			"name": "pi-extension-with-deps",
-			"version": "0.79.0",
+			"version": "0.7.3",
 			"dependencies": {
 				"ms": "^2.1.3"
 			},
@@ -5940,7 +5940,7 @@
 		},
 		"packages/tui": {
 			"name": "@earendil-works/pi-tui",
-			"version": "0.79.0",
+			"version": "0.7.3",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -61,9 +61,9 @@
 	"engines": {
 		"node": ">=22.8.0"
 	},
-	"version": "0.79.0",
+	"version": "0.7.3",
 	"dependencies": {
-		"@earendil-works/pi-coding-agent": "^0.79.0",
+		"@earendil-works/pi-coding-agent": "^0.7.3",
 		"get-east-asian-width": "^1.6.0"
 	},
 	"overrides": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-agent-core",
-	"version": "0.79.0",
+	"version": "0.7.3",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -17,7 +17,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@earendil-works/pi-ai": "^0.79.0",
+		"@earendil-works/pi-ai": "^0.7.3",
 		"typebox": "^1.1.24"
 	},
 	"keywords": [

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-ai",
-	"version": "0.79.0",
+	"version": "0.7.3",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/examples/extensions/custom-provider-anthropic/package-lock.json
+++ b/packages/coding-agent/examples/extensions/custom-provider-anthropic/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-extension-custom-provider",
-  "version": "0.79.0",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-extension-custom-provider",
-      "version": "0.79.0",
+      "version": "0.7.3",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0"
       }

--- a/packages/coding-agent/examples/extensions/custom-provider-anthropic/package.json
+++ b/packages/coding-agent/examples/extensions/custom-provider-anthropic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-extension-custom-provider-anthropic",
   "private": true,
-  "version": "0.79.0",
+  "version": "0.7.3",
   "type": "module",
   "scripts": {
     "clean": "echo 'nothing to clean'",

--- a/packages/coding-agent/examples/extensions/custom-provider-gitlab-duo/package.json
+++ b/packages/coding-agent/examples/extensions/custom-provider-gitlab-duo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-extension-custom-provider-gitlab-duo",
   "private": true,
-  "version": "0.79.0",
+  "version": "0.7.3",
   "type": "module",
   "scripts": {
     "clean": "echo 'nothing to clean'",

--- a/packages/coding-agent/examples/extensions/sandbox/package-lock.json
+++ b/packages/coding-agent/examples/extensions/sandbox/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-extension-sandbox",
-	"version": "0.79.0",
+	"version": "0.7.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-extension-sandbox",
-			"version": "0.79.0",
+			"version": "0.7.3",
 			"dependencies": {
 				"@anthropic-ai/sandbox-runtime": "^0.0.55"
 			}

--- a/packages/coding-agent/examples/extensions/sandbox/package.json
+++ b/packages/coding-agent/examples/extensions/sandbox/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pi-extension-sandbox",
 	"private": true,
-	"version": "0.79.0",
+	"version": "0.7.3",
 	"type": "module",
 	"scripts": {
 		"clean": "echo 'nothing to clean'",

--- a/packages/coding-agent/examples/extensions/with-deps/package-lock.json
+++ b/packages/coding-agent/examples/extensions/with-deps/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-extension-with-deps",
-  "version": "0.79.0",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-extension-with-deps",
-      "version": "0.79.0",
+      "version": "0.7.3",
       "dependencies": {
         "ms": "^2.1.3"
       },

--- a/packages/coding-agent/examples/extensions/with-deps/package.json
+++ b/packages/coding-agent/examples/extensions/with-deps/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-extension-with-deps",
   "private": true,
-  "version": "0.79.0",
+  "version": "0.7.3",
   "type": "module",
   "scripts": {
     "clean": "echo 'nothing to clean'",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-coding-agent",
-	"version": "0.79.0",
+	"version": "0.7.3",
 	"description": "Coding agent CLI with IPython-backed tools and session management",
 	"type": "module",
 	"piConfig": {
@@ -50,9 +50,9 @@
 	},
 	"dependencies": {
 		"@agentclientprotocol/sdk": "^1.3.0",
-		"@earendil-works/pi-agent-core": "^0.79.0",
-		"@earendil-works/pi-ai": "^0.79.0",
-		"@earendil-works/pi-tui": "^0.79.0",
+		"@earendil-works/pi-agent-core": "^0.7.3",
+		"@earendil-works/pi-ai": "^0.7.3",
+		"@earendil-works/pi-tui": "^0.7.3",
 		"@silvia-odwyer/photon-node": "^0.3.4",
 		"chalk": "^5.5.0",
 		"cli-highlight": "^2.1.11",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@earendil-works/pi-tui",
-	"version": "0.79.0",
+	"version": "0.7.3",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Aligned the inherited Prime Agent package metadata and internal dependency ranges with upstream `v0.7.3`.
- Updated the root lockfile and extension fixtures to the same inherited version.
- Kept Fleet Prime's product release version separate at `v0.2.0`.

## Validation

- `npm run check`
