### PR TITLE
ci(dependabot): scope bot away from vendored engine

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,13 @@
 # Dependency update PRs wait out the same 7-day cooldown that .npmrc's
 # min-release-age enforces locally. Security-advisory PRs are exempt
 # from cooldown by design, so CVE fixes still arrive promptly.
+#
+# Vendored engine directories (packages/*, prime-agent-runtime) must never
+# get dependency PRs: they are verbatim upstream copies pinned by the root
+# UPSTREAM manifest, and check:upstream fails CI on any drift. Engine
+# dependency updates arrive via `node scripts/sync-upstream.mjs --apply`.
+# The per-package entries below use open-pull-requests-limit: 0, which
+# disables version-update PRs for those directories.
 version: 2
 updates:
   - package-ecosystem: npm
@@ -19,16 +26,34 @@ updates:
       default-days: 7
     open-pull-requests-limit: 5
 
-  - package-ecosystem: uv
-    directory: /prime-agent-runtime
-    schedule:
-      interval: weekly
-    cooldown:
-      default-days: 7
-
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     cooldown:
       default-days: 7
+
+  # Vendored upstream — never bump here; updates arrive via upstream sync.
+  - package-ecosystem: npm
+    directory: /packages/ai
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: npm
+    directory: /packages/agent
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: npm
+    directory: /packages/tui
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: npm
+    directory: /packages/coding-agent
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## Summary

`packages/*` and `prime-agent-runtime/` are now verbatim upstream copies (v0.8.0), so Dependabot must stop proposing dependency PRs for them.

- Remove the `uv` update entry for `/prime-agent-runtime` (vendored; deps arrive via upstream sync)
- Add `open-pull-requests-limit: 0` entries for `/packages/{ai,agent,tui,coding-agent}` so version-update PRs cannot target vendored manifests
- Keep root/npm, web/npm, and github-actions entries unchanged
- Security updates remain on repo-wide: any CVE PR touching vendored manifests fails `check:upstream` in CI and should be closed in favor of an upstream sync

The 7-day cooldown and `no-changelog` conventions are unchanged.
