### PR TITLE
ci(dependabot): ignore engine-managed deps in root npm config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,15 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 5
+    ignore:
+      # Engine-managed dependencies: declared in vendored packages/* manifests,
+      # resolved through the root lockfile, updated only via sync-upstream.mjs.
+      # Root-level version PRs for them fail check:upstream by design.
+      - dependency-name: "@anthropic-ai/sdk"
+      - dependency-name: "@google/genai"
+      - dependency-name: "@mistralai/mistralai"
+      - dependency-name: "chalk"
+      - dependency-name: "esbuild"
 
   - package-ecosystem: npm
     directory: /web


### PR DESCRIPTION
## Summary

Dependabot's root `directory: /` npm entry keeps opening version-update PRs for dependencies that are declared only inside vendored `packages/*` manifests (chalk, `@anthropic-ai/sdk`, `@mistralai/mistralai`, `@google/genai`, esbuild) but resolved through the root `package-lock.json`. The per-directory `open-pull-requests-limit: 0` guards cannot catch these because the PR originates from the root config, and every such PR fails `check:upstream` by design (PRs #54-58 today).

Adds an explicit `ignore` list to the root npm entry for those five engine-managed names so the PRs stop recurring. Engine updates continue to arrive exclusively via `node scripts/sync-upstream.mjs --apply`.

Also closed #54-#58 as covered by upstream sync; no security advisories are attached to any of them.

## Validation

- YAML parses cleanly (`yaml@2.9.0`)
- `npm run check` passes via pre-commit hook (upstream verify, biome, tsgo, installer, browser-smoke, rendering, web typecheck)
