### PR TITLE
fix(web): Preserve provider models and OpenUI actions

### DIFF
--- a/web/app/src/lib/pi/review-regressions.test.tsx
+++ b/web/app/src/lib/pi/review-regressions.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render } from "@testing-library/react";
+import type { ChatMessage } from "@prime-agent/web-protocol/chat-types";
+import { describe, expect, it, vi } from "vitest";
+import { ArtifactsPanelContent } from "@prime-agent/web-design/components/fleet-pi/pi/artifacts-panel";
+import { FleetPiAgentChat } from "@prime-agent/web-design/components/fleet-pi/chat/fleet-pi-agent-chat";
+
+vi.mock("@prime-agent/web-design/components/openui/inline-renderer", () => ({
+	GenerativeTextRenderer: ({ onOpenUIAction }: { onOpenUIAction?: (message: string) => void }) => (
+		<button type="button" onClick={() => onOpenUIAction?.("continue_conversation")}>Trigger OpenUI action</button>
+	),
+}));
+
+const inputBar = {
+	modelKey: undefined,
+	models: [],
+	onModelChange: vi.fn(),
+};
+
+function settledReasoningMessage(): ChatMessage {
+	return {
+		id: "assistant-1",
+		role: "assistant",
+		parts: [
+			{
+				type: "tool-FleetReasoning",
+				state: "output-available",
+				input: {
+					runId: "run-1",
+					phase: "complete",
+					steps: [{ title: "Inspecting", body: "Checked the workspace." }],
+					visibleSteps: 1,
+					streaming: false,
+					startedAt: 1,
+					restingLabel: "Completed",
+				},
+			},
+			{ type: "text", text: "Done." },
+		],
+	};
+}
+
+describe("review regressions", () => {
+	it("keeps a completed reasoning presentation visible", () => {
+		const { getByLabelText } = render(
+			<FleetPiAgentChat
+				inputBar={inputBar}
+				messages={[settledReasoningMessage()]}
+				onSend={vi.fn()}
+				onStop={vi.fn()}
+				status="ready"
+			/>,
+		);
+
+		expect(getByLabelText("Safe reasoning progress")).toBeTruthy();
+	});
+
+	it("forwards actions from reopened artifact OpenUI blocks", () => {
+		const onOpenUIAction = vi.fn();
+		const messages: Array<ChatMessage> = [
+			{
+				id: "assistant-1",
+				role: "assistant",
+				parts: [{ type: "text", text: "```openui\nroot = Card\n```" }],
+			},
+		];
+
+		const { getByRole } = render(
+			<ArtifactsPanelContent
+				error={null}
+				loadWorkspaceFile={vi.fn()}
+				loading={false}
+				messages={messages}
+				onOpenUIAction={onOpenUIAction}
+				onSelectedPathChange={vi.fn()}
+				selectedPath={null}
+				status="ready"
+				workspace={null}
+			/>,
+		);
+
+		fireEvent.click(getByRole("button", { name: /Card/ }));
+		fireEvent.click(getByRole("button", { name: "Trigger OpenUI action" }));
+		 expect(onOpenUIAction).toHaveBeenCalledWith("continue_conversation");
+	});
+});

--- a/web/app/src/lib/pi/use-chat-workspace-data.ts
+++ b/web/app/src/lib/pi/use-chat-workspace-data.ts
@@ -464,6 +464,7 @@ export function useChatWorkspaceData() {
 		isLoadingProviders,
 		isUpdatingProvider: isUpdatingProvider || isRemovingProvider,
 		loadWorkspaceFile: loadProjectWorkspaceFile,
+		messages,
 		modelKey,
 		models,
 		modelCatalog,

--- a/web/app/src/lib/pi/use-right-panel-context-value.ts
+++ b/web/app/src/lib/pi/use-right-panel-context-value.ts
@@ -20,7 +20,7 @@ import type {
 	WorkspaceFileResponse,
 	WorkspaceTreeResponse,
 } from "@prime-agent/web-protocol/chat-protocol";
-import type { ChatStatus } from "@prime-agent/web-protocol/chat-types";
+import type { ChatMessage, ChatStatus } from "@prime-agent/web-protocol/chat-types";
 import { useMemo } from "react";
 
 type UseRightPanelContextValueArgs = {
@@ -29,6 +29,7 @@ type UseRightPanelContextValueArgs = {
 	isLoadingProviders?: boolean;
 	isUpdatingProvider?: boolean;
 	loadWorkspaceFile: (path: string) => Promise<WorkspaceFileResponse>;
+	messages: Array<ChatMessage>;
 	modelKey?: string;
 	models: Array<ChatModelOption>;
 	modelCatalog?: Array<ChatModelOption>;
@@ -72,6 +73,7 @@ export function useRightPanelContextValue({
 	isLoadingProviders,
 	isUpdatingProvider,
 	loadWorkspaceFile,
+	messages,
 	modelKey,
 	models,
 	modelCatalog,
@@ -105,6 +107,7 @@ export function useRightPanelContextValue({
 	const chatPanelData = useMemo<ChatPanelDataContextValue>(
 		() => ({
 			activityLabel,
+			messages,
 			models,
 			planLabel,
 			queue,
@@ -119,6 +122,7 @@ export function useRightPanelContextValue({
 		}),
 		[
 			activityLabel,
+			messages,
 			models,
 			planLabel,
 			queue,

--- a/web/app/src/routes/index.tsx
+++ b/web/app/src/routes/index.tsx
@@ -146,6 +146,7 @@ function ChatWorkspaceShell() {
       />
       <RightPanelProvider
         chatPanelData={chatPanelData}
+        onOpenUIAction={handleOpenUIAction}
         settingsActions={settingsActions}
         workspaceTree={workspaceTreeContext}
       >

--- a/web/design/src/components/agents/prompt-input.tsx
+++ b/web/design/src/components/agents/prompt-input.tsx
@@ -168,7 +168,7 @@ export function PromptInput({
     <form
       onSubmit={submit}
       className={cn(
-        "relative w-full rounded-[14px] border border-border/70 bg-background p-2 shadow-sm transition-[border-color,box-shadow] focus-within:border-foreground/25 focus-within:ring-1 focus-within:ring-ring/20",
+        "relative w-full rounded-[14px] border border-border/70 bg-sidebar p-2 text-[color:var(--foreground)] shadow-sm transition-[border-color,box-shadow] focus-within:border-foreground/25 focus-within:ring-1 focus-within:ring-ring/20",
         disabled && "opacity-60",
         className,
       )}
@@ -190,7 +190,7 @@ export function PromptInput({
         {...textareaProps}
         onChange={(event) => setValue(event.target.value)}
         onKeyDown={handleKeyDown}
-        className="scrollbar-hide block w-full resize-none overflow-y-auto bg-transparent px-2 pt-1.5 text-sm leading-6 text-foreground outline-none placeholder:text-muted-foreground/55"
+        className="scrollbar-hide block w-full resize-none overflow-y-auto bg-transparent px-2 pt-1.5 text-sm leading-6 text-foreground outline-none placeholder:text-foreground/55"
       />
 
       <div className="mt-1 flex min-h-8 items-center gap-1">
@@ -203,7 +203,7 @@ export function PromptInput({
                 size="icon"
                 disabled={disabled || loading}
                 aria-label="Add to prompt"
-                className="size-8 rounded-full"
+                className="size-8 rounded-full text-foreground/70 hover:text-foreground"
               >
                 <m.span
                   aria-hidden="true"
@@ -234,7 +234,7 @@ export function PromptInput({
                   className="flex w-full items-start gap-2.5 rounded-lg px-2.5 py-2 text-left outline-none transition-colors hover:bg-muted focus-visible:bg-muted disabled:pointer-events-none disabled:opacity-50"
                 >
                   {action.icon ? (
-                    <span className="mt-0.5 grid size-5 shrink-0 place-items-center text-muted-foreground [&_svg]:size-4">
+                    <span className="mt-0.5 grid size-5 shrink-0 place-items-center text-foreground/70 [&_svg]:size-4">
                       {action.icon}
                     </span>
                   ) : null}
@@ -243,7 +243,7 @@ export function PromptInput({
                       {action.label}
                     </span>
                     {action.description ? (
-                      <span className="mt-0.5 block text-xs leading-4 text-muted-foreground">
+                      <span className="mt-0.5 block text-xs leading-4 text-foreground/60">
                         {action.description}
                       </span>
                     ) : null}
@@ -264,11 +264,11 @@ export function PromptInput({
             <AnimatedSelectTrigger className="h-8 w-auto max-w-52 rounded-xl border-0 bg-transparent px-2 py-0 text-xs hover:bg-muted focus-visible:ring-2">
               <span className="flex min-w-0 items-center gap-1.5">
                 {currentModel?.icon ? (
-                  <span className="grid size-4 shrink-0 place-items-center text-muted-foreground [&_svg]:size-3.5">
+                  <span className="grid size-4 shrink-0 place-items-center text-foreground/70 [&_svg]:size-3.5">
                     {currentModel.icon}
                   </span>
                 ) : null}
-                <span className="truncate text-muted-foreground">
+                <span className="truncate text-foreground/70">
                   {currentModel?.label ?? "Choose model"}
                 </span>
               </span>

--- a/web/design/src/components/elements/fleet-reasoning-panel.tsx
+++ b/web/design/src/components/elements/fleet-reasoning-panel.tsx
@@ -16,16 +16,24 @@ import { cn } from "@prime-agent/web-design/lib/utils";
 export function FleetReasoningPanel({
   presentation,
   className,
+  streamingOverride,
 }: {
   presentation: ChatReasoningPresentation;
   className?: string;
+  /** Live turn state from the caller; corrects parts reconciled before trailing `streaming:false` frames arrive. */
+  streamingOverride?: boolean;
 }) {
   const [userOpen, setUserOpen] = useState<boolean | undefined>(undefined);
-  const open = userOpen ?? presentation.streaming;
+  const streaming = streamingOverride ?? presentation.streaming;
+  const open = userOpen ?? streaming;
   const steps = useMemo(
     () => presentation.steps.map((step) => ({ title: step.title, body: step.body })),
     [presentation.steps],
   );
+  /* Nothing to display once the run settles and no steps were produced —
+   * an empty "Completed" card is worse than no card. While streaming the
+   * step-agnostic loader keeps the section meaningful. */
+  if (!streaming && steps.length === 0) return null;
   const visibleSteps = Math.min(Math.max(0, presentation.visibleSteps), steps.length);
   const activeStep = steps.at(visibleSteps - 1);
   const activeLabel = activeStep?.title ?? phaseLabel(presentation.phase);
@@ -40,7 +48,7 @@ export function FleetReasoningPanel({
         className,
       )}
     >
-      {presentation.streaming ? (
+      {streaming ? (
         <div className="mb-1.5 flex flex-col gap-1.5 border-b border-border/45 pb-2.5">
           {activeStep?.body ? (
             <>
@@ -62,7 +70,7 @@ export function FleetReasoningPanel({
       <ReasoningPanel
         steps={steps}
         visibleSteps={visibleSteps}
-        streaming={presentation.streaming}
+        streaming={streaming}
         streamingLabel="Preparing response"
         open={open}
         onOpenChange={setUserOpen}

--- a/web/design/src/components/elements/prompt-suggestions.tsx
+++ b/web/design/src/components/elements/prompt-suggestions.tsx
@@ -33,7 +33,7 @@ export function PromptSuggestions({
       className={cn(
         list
           ? "flex w-full max-w-sm flex-col gap-2"
-          : "flex max-w-md flex-wrap justify-center gap-2",
+          : "flex w-full max-w-xl flex-wrap justify-center gap-1",
         className,
       )}
 

--- a/web/design/src/components/fleet-pi/chat/fleet-pi-agent-chat.tsx
+++ b/web/design/src/components/fleet-pi/chat/fleet-pi-agent-chat.tsx
@@ -286,6 +286,7 @@ function AssistantMessage({
             {reasoningPresentation ? (
               <FleetReasoningPanel
                 presentation={reasoningPresentation}
+                streamingOverride={turnStreaming}
                 className="mb-2"
               />
             ) : null}

--- a/web/design/src/components/fleet-pi/layout/right-panel-context.tsx
+++ b/web/design/src/components/fleet-pi/layout/right-panel-context.tsx
@@ -6,7 +6,9 @@ import type { RightPanelContentProps } from "./right-panel-registry"
 export type ChatPanelDataContextValue = Pick<
   RightPanelContentProps,
   | "activityLabel"
+  | "messages"
   | "models"
+  | "onOpenUIAction"
   | "planLabel"
   | "queue"
   | "refreshResources"
@@ -66,18 +68,20 @@ const SettingsActionsContext =
 export function RightPanelProvider({
   chatPanelData,
   children,
+  onOpenUIAction,
   settingsActions,
   workspaceTree,
 }: {
   chatPanelData: ChatPanelDataContextValue
   children: ReactNode
+  onOpenUIAction?: (message: string) => void
   settingsActions: SettingsActionsContextValue
   workspaceTree: WorkspaceTreeContextValue
 }) {
   return (
     <SettingsActionsContext.Provider value={settingsActions}>
       <WorkspaceTreeContext.Provider value={workspaceTree}>
-        <ChatPanelDataContext.Provider value={chatPanelData}>
+        <ChatPanelDataContext.Provider value={{ ...chatPanelData, onOpenUIAction }}>
           {children}
         </ChatPanelDataContext.Provider>
       </WorkspaceTreeContext.Provider>

--- a/web/design/src/components/fleet-pi/layout/right-panel-registry.tsx
+++ b/web/design/src/components/fleet-pi/layout/right-panel-registry.tsx
@@ -4,7 +4,7 @@ import { ArtifactsPanelContent } from "../pi/artifacts-panel"
 import { ResourcesPanelContent } from "../pi/resources-panel"
 import { WorkspacePanelContent } from "../pi/workspace-panel"
 import type { ElementType, ReactNode } from "react"
-import type { ChatStatus } from "@prime-agent/web-protocol/chat-types"
+import type { ChatMessage, ChatStatus } from "@prime-agent/web-protocol/chat-types"
 import type { RightPanel, ThemePreference } from "../../../lib/canvas-utils"
 import type {
   ChatPiSettingsUpdate,
@@ -26,9 +26,12 @@ import type { ChatModelOption } from "../../../lib/pi/chat-helpers"
 export type ActiveRightPanel = Exclude<RightPanel, null>
 
 export type RightPanelContentProps = {
-  activityLabel?: string
-  isLoadingProviders?: boolean
-  isUpdatingProvider?: boolean
+	activityLabel?: string
+	isLoadingProviders?: boolean
+	isUpdatingProvider?: boolean
+	onOpenUIAction?: (message: string) => void
+	/** Current session messages — the artifacts panel derives generative-UI entries from them. */
+  messages: Array<ChatMessage>
   models: Array<ChatModelOption>
   /** Full registry catalog for Settings model curation (unfiltered). */
   modelCatalog?: Array<ChatModelOption>
@@ -129,8 +132,11 @@ export const RIGHT_PANEL_REGISTRY: Record<
         error={props.workspaceError}
         loadWorkspaceFile={props.loadWorkspaceFile}
         loading={props.workspaceLoading}
+        messages={props.messages}
+        onOpenUIAction={props.onOpenUIAction}
         onSelectedPathChange={props.setSelectedWorkspacePath}
         selectedPath={props.selectedWorkspacePath}
+        status={props.status}
         workspace={props.workspaceTree}
       />
     ),

--- a/web/design/src/components/fleet-pi/pi/artifacts-panel.tsx
+++ b/web/design/src/components/fleet-pi/pi/artifacts-panel.tsx
@@ -1,42 +1,153 @@
+import { ChevronRight, LayoutTemplate } from "lucide-react"
+import { useMemo, useState } from "react"
+import type { ChatMessage, ChatStatus } from "@prime-agent/web-protocol/chat-types"
+
+import { GenerativeTextRenderer } from "../../openui/inline-renderer"
+import { Button } from "../../button"
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../../collapsible"
+import { UiErrorBoundary } from "../ui-error-boundary"
 import { WorkspacePanelContent } from "./workspace-panel"
-import { getArtifactsScopePath } from "./artifacts-utils"
+import { collectSessionOpenUIBlocks, getArtifactsScopePath } from "./artifacts-utils"
+import { findWorkspaceNode } from "./shared"
+import type { SessionOpenUIBlock } from "./artifacts-utils"
 import type { WorkspacePanelContentProps } from "./workspace-panel"
 
-export function ArtifactsPanelContent({
-  error,
-  loadWorkspaceFile,
-  loading,
-  onSelectedPathChange,
-  selectedPath,
-  workspace,
-}: Pick<
-  WorkspacePanelContentProps,
-  | "error"
-  | "loadWorkspaceFile"
-  | "loading"
-  | "onSelectedPathChange"
-  | "selectedPath"
-  | "workspace"
->) {
-  const scopePath = workspace
-    ? getArtifactsScopePath(workspace.root)
-    : undefined
+type ArtifactsPanelContentProps = Pick<
+	WorkspacePanelContentProps,
+	| "error"
+	| "loadWorkspaceFile"
+	| "loading"
+	| "onSelectedPathChange"
+	| "selectedPath"
+	| "workspace"
+> & {
+	messages: Array<ChatMessage>
+	onOpenUIAction?: (message: string) => void
+	status: ChatStatus
+}
 
-  return (
-    <WorkspacePanelContent
-      emptyDescription="No artifacts folder was found under agent-workspace yet."
-      emptyTitle="Artifacts unavailable"
-      error={error}
-      loadWorkspaceFile={loadWorkspaceFile}
-      loading={loading}
-      onSelectedPathChange={onSelectedPathChange}
-      previewEmptyDescription="Choose a report, dataset, trace, or diagram to preview."
-      previewEmptyTitle="Select an artifact"
-      scopeLabel="artifacts"
-      scopePath={scopePath}
-      selectedPath={selectedPath}
-      treeTestId="artifacts-tree"
-      workspace={workspace}
-    />
-  )
+function GenerativeUiBlockRow({
+	block,
+	expanded,
+	isStreaming,
+	onOpenUIAction,
+	onToggle,
+}: {
+	block: SessionOpenUIBlock
+	expanded: boolean
+	isStreaming: boolean
+	onOpenUIAction?: (message: string) => void
+	onToggle: () => void
+}) {
+	return (
+		<Collapsible open={expanded} onOpenChange={onToggle}>
+			<CollapsibleTrigger
+				render={
+					<Button
+						variant="ghost"
+						size="sm"
+						className="group w-full justify-start gap-1.5 text-left text-label font-normal text-foreground/65 transition-none hover:bg-foreground/5 hover:text-foreground/80"
+					/>
+				}
+			>
+				<ChevronRight className="size-3 shrink-0 text-foreground/35 transition-transform group-data-panel-open:rotate-90" />
+				<LayoutTemplate className="size-3.5 shrink-0 text-foreground/35" />
+				<span className="min-w-0 flex-1 truncate" title={block.component}>
+					{block.component}
+				</span>
+				<span className="shrink-0 text-[10px] text-foreground/40">#{block.ordinal}</span>
+			</CollapsibleTrigger>
+			<CollapsibleContent>
+				<div className="mb-1 mt-0.5 flex min-w-0 flex-col overflow-hidden rounded-md border border-border/60 bg-background px-2.5 py-2">
+					<UiErrorBoundary resetKeys={[block.content]}>
+						<GenerativeTextRenderer
+							content={block.content}
+							isStreaming={isStreaming}
+							messageId={block.blockId}
+							onOpenUIAction={onOpenUIAction}
+						/>
+					</UiErrorBoundary>
+				</div>
+			</CollapsibleContent>
+		</Collapsible>
+	)
+}
+
+export function ArtifactsPanelContent({
+	error,
+	loadWorkspaceFile,
+	loading,
+	messages,
+	onOpenUIAction,
+	onSelectedPathChange,
+	selectedPath,
+	status,
+	workspace,
+}: ArtifactsPanelContentProps) {
+	const scopePath = workspace ? getArtifactsScopePath(workspace.root) : undefined
+	const blocks = useMemo(() => collectSessionOpenUIBlocks(messages), [messages])
+	const hasArtifactFiles = useMemo(() => {
+		if (!workspace || !scopePath) return false
+		const root = findWorkspaceNode(workspace.nodes, scopePath)
+		return Boolean(root?.children?.length)
+	}, [scopePath, workspace])
+	const [expandedBlockId, setExpandedBlockId] = useState<string | null>(null)
+	const latestStreaming = status === "streaming" ? blocks.at(-1)?.blockId : undefined
+
+	return (
+		<div className="flex h-full min-h-0 flex-col gap-2 overflow-hidden">
+			<div className="flex min-h-0 flex-col">
+				<div className="mb-2 flex min-w-0 items-center gap-2 rounded-sm bg-foreground/5 px-2 py-1.5">
+					<LayoutTemplate className="size-3.5 shrink-0 text-foreground/45" />
+					<span className="min-w-0 flex-1 truncate text-label font-medium text-foreground/70">
+						Generative UI
+					</span>
+					<span className="shrink-0 text-[10px] text-foreground/40">
+						{blocks.length > 0 ? `${blocks.length}` : "none yet"}
+					</span>
+				</div>
+				{blocks.length === 0 ? (
+					<p className="px-2 pb-1 text-[11px] leading-4 text-foreground/40">
+						OpenUI interfaces the agent generates in this session appear here, and can be
+						re-opened without scrolling the conversation. Files written to
+						agent-workspace/artifacts show below once the agent creates them.
+					</p>
+				) : (
+					<div className="flex min-h-0 flex-col gap-0.5 overflow-y-auto">
+						{blocks.map((block) => (
+							<GenerativeUiBlockRow
+								key={block.blockId}
+								block={block}
+							expanded={block.blockId === expandedBlockId}
+								isStreaming={block.blockId === latestStreaming}
+								onOpenUIAction={onOpenUIAction}
+								onToggle={() =>
+									setExpandedBlockId((current) =>
+										current === block.blockId ? null : block.blockId,
+									)
+								}
+							/>
+						))}
+					</div>
+				)}
+			</div>
+			{hasArtifactFiles && (
+				<div className="min-h-0 flex-1">
+					<WorkspacePanelContent
+						error={error}
+						loadWorkspaceFile={loadWorkspaceFile}
+						loading={loading}
+						onSelectedPathChange={onSelectedPathChange}
+						previewEmptyDescription="Choose a report, dataset, trace, or diagram to preview."
+						previewEmptyTitle="Select an artifact"
+						scopeLabel="artifacts"
+						scopePath={scopePath}
+						selectedPath={selectedPath}
+						treeTestId="artifacts-tree"
+						workspace={workspace}
+					/>
+				</div>
+			)}
+		</div>
+	)
 }

--- a/web/design/src/components/fleet-pi/pi/artifacts-utils.ts
+++ b/web/design/src/components/fleet-pi/pi/artifacts-utils.ts
@@ -1,6 +1,52 @@
+import type { ChatMessage } from "@prime-agent/web-protocol/chat-types";
+import { segmentOpenUIContent } from "../../openui/openui-utils";
+
 const ARTIFACTS_SCOPE_SUFFIX = "artifacts";
 
 /** Relative tree path of the artifacts folder. Matches workspace node paths. */
 export function getArtifactsScopePath(_root?: string) {
 	return ARTIFACTS_SCOPE_SUFFIX;
+}
+
+export type SessionOpenUIBlock = {
+	/** Stable id: `${messageId}:${segmentId}` — matches chat-rendered block ids. */
+	blockId: string;
+	/** DSL source of the block (without the markdown fence). */
+	content: string;
+	component: string;
+	/** 1-based position across the session's assistant messages. */
+	ordinal: number;
+};
+
+const ROOT_COMPONENT_PATTERN = /^root\s*=\s*([A-Za-z][A-Za-z0-9]*)/;
+const FIRST_STRING_LITERAL_PATTERN = /"((?:\\.|[^"\\]){1,80})"/;
+
+/** Human label for a block: card/heading titles if present, else the root component. */
+export function openUIBlockLabel(content: string): string {
+	return FIRST_STRING_LITERAL_PATTERN.exec(content)?.[1] ?? ROOT_COMPONENT_PATTERN.exec(content)?.[1] ?? "Interface";
+}
+
+/**
+ * Extract generative-UI blocks (openui DSL segments) from session messages,
+ * in chronological order. Shared between the chat renderer and the artifacts
+ * panel so both see the exact same blocks for a session.
+ */
+export function collectSessionOpenUIBlocks(messages: ReadonlyArray<ChatMessage>): Array<SessionOpenUIBlock> {
+	const blocks: Array<SessionOpenUIBlock> = [];
+	for (const message of messages) {
+		if (message.role !== "assistant") continue;
+		for (const part of message.parts) {
+			if (part.type !== "text" || typeof part.text !== "string") continue;
+			for (const segment of segmentOpenUIContent(part.text)) {
+				if (segment.type !== "openui") continue;
+				blocks.push({
+					blockId: `${message.id}:${segment.id}`,
+					content: segment.content,
+					component: openUIBlockLabel(segment.content),
+					ordinal: blocks.length + 1,
+				});
+			}
+		}
+	}
+	return blocks;
 }

--- a/web/design/src/components/fleet-pi/pi/config-panel/sections/add-models-dialog.tsx
+++ b/web/design/src/components/fleet-pi/pi/config-panel/sections/add-models-dialog.tsx
@@ -25,12 +25,16 @@ import type { ConfigModelInfo } from "../shared/types"
 
 export type AddModelsDialogProps = {
   configuredProviderIds: ReadonlySet<string>
+  /** Providers whose models.json base URL allows live model discovery. */
+  discoverableProviderIds?: ReadonlySet<string>
   discoveringProviderId: string | null
   enabledModels: ChatPiSettings["enabledModels"] | undefined
   modelOptions: Array<ConfigModelInfo>
   onAddModels: (models: Array<ConfigModelInfo>) => void
   onDiscoverProvider: (providerId: string) => Promise<void>
   onOpenChange: (open: boolean) => void
+  /** Preferred labels for custom/OCC instance ids (display names). */
+  providerLabel?: (providerId: string) => string
 }
 
 function searchableModelText(model: ConfigModelInfo) {
@@ -41,12 +45,14 @@ function searchableModelText(model: ConfigModelInfo) {
 
 export function AddModelsDialog({
   configuredProviderIds,
+  discoverableProviderIds,
   discoveringProviderId,
   enabledModels,
   modelOptions,
   onAddModels,
   onDiscoverProvider,
   onOpenChange,
+  providerLabel = formatProviderLabel,
 }: AddModelsDialogProps) {
   const [filter, setFilter] = useState("")
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set())
@@ -71,10 +77,24 @@ export function AddModelsDialog({
   }, [candidateModels])
 
   const discoverableProviders = useMemo(() => {
-    return Array.from(configuredProviderIds).sort((a, b) =>
-      formatProviderLabel(a).localeCompare(formatProviderLabel(b))
-    )
-  }, [configuredProviderIds])
+    // Only providers with a recorded base URL can serve GET {baseUrl}/models;
+    // built-ins come from the engine's static registry instead.
+    const ids = discoverableProviderIds ?? configuredProviderIds
+    return Array.from(ids)
+      .filter((id) => configuredProviderIds.has(id))
+      .sort((a, b) => providerLabel(a).localeCompare(providerLabel(b)))
+  }, [configuredProviderIds, discoverableProviderIds])
+
+  /** Enabled-model count per provider, for the "N active" group labels. */
+  const activeCountByProvider = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const model of modelOptions) {
+      if (isModelEnabled(model, enabledModels)) {
+        counts.set(model.provider, (counts.get(model.provider) ?? 0) + 1)
+      }
+    }
+    return counts
+  }, [enabledModels, modelOptions])
 
   const toggleSelected = (model: ConfigModelInfo) => {
     setSelectedKeys((current) => {
@@ -106,6 +126,7 @@ export function AddModelsDialog({
         <div className="flex flex-wrap gap-1.5">
           {discoverableProviders.map((providerId) => {
             const discovering = discoveringProviderId === providerId
+            const activeCount = activeCountByProvider.get(providerId) ?? 0
             return (
               <Button
                 key={providerId}
@@ -122,7 +143,12 @@ export function AddModelsDialog({
                 ) : (
                   <RefreshCw data-icon="inline-start" />
                 )}
-                {formatProviderLabel(providerId)}
+                {providerLabel(providerId)}
+                {activeCount > 0 ? (
+                  <span className="tabular-nums text-muted-foreground">
+                    · {activeCount} active
+                  </span>
+                ) : null}
               </Button>
             )
           })}
@@ -152,7 +178,12 @@ export function AddModelsDialog({
               {groupedCandidates.map(([provider, models]) => (
                 <div key={provider} className="flex flex-col gap-1">
                   <div className="px-2 text-[11px] font-medium tracking-wide text-muted-foreground uppercase">
-                    {formatProviderLabel(provider)}
+                    {providerLabel(provider)}
+                    {(activeCountByProvider.get(provider) ?? 0) > 0 ? (
+                      <span className="ml-1 font-normal normal-case tabular-nums">
+                        · {activeCountByProvider.get(provider)} active
+                      </span>
+                    ) : null}
                   </div>
                   {models.map((model) => {
                     const checked = selectedKeys.has(model.id)

--- a/web/design/src/components/fleet-pi/pi/config-panel/sections/model-defaults-section.tsx
+++ b/web/design/src/components/fleet-pi/pi/config-panel/sections/model-defaults-section.tsx
@@ -1,4 +1,4 @@
-import { Plus, Search, Trash2 } from "lucide-react"
+import { Plus, Search, Star, Trash2 } from "lucide-react"
 import { useMemo, useState } from "react"
 import { Button } from "../../../../button"
 import {
@@ -32,6 +32,7 @@ export function ModelDefaultsSection({
   onDiscoverProvider,
   onModelFilterChange,
   onRemoveModel,
+  onSetDefaultModel,
   onRevert,
   onSave,
   providers,
@@ -47,9 +48,10 @@ export function ModelDefaultsSection({
   onDiscoverProvider: (providerId: string) => Promise<void>
   onModelFilterChange: (value: string) => void
   onRemoveModel: (model: ConfigModelInfo) => void
+  onSetDefaultModel?: (model: ConfigModelInfo) => void
   onRevert: () => void
   onSave: () => void
-  providers: Array<{ id: string; isConfigured: boolean }>
+  providers: Array<{ id: string; isConfigured: boolean; discoverable?: boolean; name?: string; displayName?: string }>
   saving: boolean
   settingsLoading: boolean
 }) {
@@ -75,6 +77,35 @@ export function ModelDefaultsSection({
     }
     return ids
   }, [draft?.enabledModels, modelOptions, providers])
+
+  const discoverableProviderIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const provider of providers) {
+      if (provider.discoverable === true && configuredProviderIds.has(provider.id)) {
+        ids.add(provider.id)
+      }
+    }
+    return ids
+  }, [configuredProviderIds, providers])
+
+  const isDefaultModel = useMemo(() => {
+    return (model: ConfigModelInfo) =>
+      !!draft?.defaultProvider &&
+      !!draft?.defaultModel &&
+      model.provider === draft.defaultProvider &&
+      model.modelId === draft.defaultModel
+  }, [draft?.defaultModel, draft?.defaultProvider])
+
+  /** Preferred labels for custom/OCC instances, falling back to the catalog. */
+  const providerLabel = useMemo(() => {
+    const labels = new Map<string, string>()
+    for (const provider of providers) {
+      if (provider.displayName || provider.name) {
+        labels.set(provider.id, provider.displayName ?? provider.name ?? provider.id)
+      }
+    }
+    return (providerId: string) => labels.get(providerId) ?? formatProviderLabel(providerId)
+  }, [providers])
 
   const listedModels = useMemo(() => {
     return modelOptions.filter((model) => {
@@ -191,30 +222,53 @@ export function ModelDefaultsSection({
           groupedListed.map(([provider, models]) => (
             <div key={provider} className="flex flex-col gap-1.5">
               <div className="px-1 text-xs font-medium text-muted-foreground">
-                {formatProviderLabel(provider)}
+                {providerLabel(provider)}
               </div>
               {models.map((model) => (
                 <ItemRow
                   key={model.id}
                   icon={<ProviderBrandIcon provider={model.provider} />}
                   title={model.name}
-                  subtitle={`${formatProviderLabel(model.provider)} · ${model.modelId}`}
+                  subtitle={`${providerLabel(model.provider)} · ${model.modelId}`}
                   trailing={
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      className={cn(
-                        HIT_AREA_EXPAND_DENSE_CLASS,
-                        "h-7 px-2 text-xs text-muted-foreground transition-[background-color,color,transform] duration-150 hover:text-destructive active:scale-[0.96]"
-                      )}
-                      disabled={disabled}
-                      aria-label={`Remove ${model.name}`}
-                      onClick={() => onRemoveModel(model)}
-                    >
-                      <Trash2 data-icon="inline-start" />
-                      Remove
-                    </Button>
+                    <div className="flex items-center">
+                      {isDefaultModel(model) ? (
+                        <span className="px-2 text-xs font-medium text-muted-foreground">
+                          Default
+                        </span>
+                      ) : onSetDefaultModel ? (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className={cn(
+                            HIT_AREA_EXPAND_DENSE_CLASS,
+                            "h-7 px-2 text-xs text-muted-foreground transition-[background-color,color,transform] duration-150 active:scale-[0.96]"
+                          )}
+                          disabled={disabled}
+                          aria-label={`Set ${model.name} as default`}
+                          onClick={() => onSetDefaultModel(model)}
+                        >
+                          <Star data-icon="inline-start" />
+                          Set default
+                        </Button>
+                      ) : null}
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className={cn(
+                          HIT_AREA_EXPAND_DENSE_CLASS,
+                          "h-7 px-2 text-xs text-muted-foreground transition-[background-color,color,transform] duration-150 hover:text-destructive active:scale-[0.96]"
+                        )}
+                        disabled={disabled}
+                        aria-label={`Remove ${model.name}`}
+                        onClick={() => onRemoveModel(model)}
+                      >
+                        <Trash2 data-icon="inline-start" />
+                        Remove
+                      </Button>
+                    </div>
                   }
                 />
               ))}
@@ -226,12 +280,14 @@ export function ModelDefaultsSection({
       {addOpen ? (
         <AddModelsDialog
           configuredProviderIds={configuredProviderIds}
+          discoverableProviderIds={discoverableProviderIds}
           discoveringProviderId={discoveringProviderId}
           enabledModels={draft?.enabledModels}
           modelOptions={modelOptions}
           onAddModels={onAddModels}
           onDiscoverProvider={onDiscoverProvider}
           onOpenChange={setAddOpen}
+          providerLabel={providerLabel}
         />
       ) : null}
     </SettingsPane>

--- a/web/design/src/components/fleet-pi/pi/config-panel/sections/provider-credentials-editor.tsx
+++ b/web/design/src/components/fleet-pi/pi/config-panel/sections/provider-credentials-editor.tsx
@@ -264,7 +264,7 @@ export function AddProviderEditorPanel({
 
       <ProviderCredentialFields
         attemptedSave={attemptedSave}
-        api={provider.api ?? api}
+        api={api}
         apiKey={apiKey}
         baseUrl={baseUrl}
         modelId={modelId}

--- a/web/design/src/components/fleet-pi/pi/config-panel/sections/use-provider-credentials-controller.ts
+++ b/web/design/src/components/fleet-pi/pi/config-panel/sections/use-provider-credentials-controller.ts
@@ -143,7 +143,8 @@ export function useProviderCredentialsController({
 		setEditingIsNewOccInstance(opts?.newOccInstance === true);
 		resetEditor();
 		const existing = providers.find((provider) => provider.id === providerId);
-		setDisplayName(existing?.displayName ?? "");
+		setBaseUrl(existing?.baseUrl ?? "");
+		setDisplayName(existing?.displayName ?? (isCustomProviderId(providerId) ? (existing?.name ?? "") : ""));
 		setApi(existing?.api ?? "openai-completions");
 		setModels((existing?.modelIds ?? []).join(", "));
 		setModelId(existing?.modelIds?.[0] ?? "");

--- a/web/design/src/components/fleet-pi/pi/right-panel-launcher.tsx
+++ b/web/design/src/components/fleet-pi/pi/right-panel-launcher.tsx
@@ -10,7 +10,7 @@ import {
   useWorkspaceTreeContext,
 } from "../layout/right-panel-context"
 import { HIT_AREA_EXPAND_CLASS, PANEL_OVERLAY_CLASS } from "../styles/tokens"
-import { getArtifactsScopePath } from "./artifacts-utils"
+import { collectSessionOpenUIBlocks, getArtifactsScopePath } from "./artifacts-utils"
 import {
   countWorkspaceFiles,
   findWorkspaceNode,
@@ -24,7 +24,7 @@ import type {
 } from "@prime-agent/web-protocol/chat-protocol"
 /** Reads panel state from RightPanelProvider — no prop threading from route. */
 export function RightPanelLauncherFromContext() {
-  const { rightPanel, setRightPanel, resources } = useChatPanelDataContext()
+  const { messages, rightPanel, setRightPanel, resources } = useChatPanelDataContext()
   const { workspaceTree } = useWorkspaceTreeContext()
 
   return (
@@ -32,6 +32,7 @@ export function RightPanelLauncherFromContext() {
       activePanel={rightPanel}
       onPanelChange={setRightPanel}
       resources={resources}
+      sessionBlocks={collectSessionOpenUIBlocks(messages).length}
       workspace={workspaceTree}
     />
   )
@@ -41,11 +42,14 @@ export function RightPanelLauncher({
   activePanel,
   onPanelChange,
   resources,
+  sessionBlocks = 0,
   workspace,
 }: {
   activePanel: RightPanel
   onPanelChange: (panel: RightPanel) => void
   resources: ChatResourcesResponse | null
+  /** Generative-UI blocks in the current session — counted alongside workspace files. */
+  sessionBlocks?: number
   workspace: WorkspaceTreeResponse | null
 }) {
   const totalResources = getResourceGroups(resources, workspace).reduce(
@@ -53,16 +57,21 @@ export function RightPanelLauncher({
     0
   )
   const totalArtifacts = useMemo(() => {
-    if (!workspace) return undefined
+    const files = (() => {
+      if (!workspace) return 0
 
-    const artifactsRoot = findWorkspaceNode(
-      workspace.nodes,
-      getArtifactsScopePath(workspace.root)
-    )
-    if (!artifactsRoot?.children?.length) return undefined
+      const artifactsRoot = findWorkspaceNode(
+        workspace.nodes,
+        getArtifactsScopePath(workspace.root)
+      )
+      if (!artifactsRoot?.children?.length) return 0
 
-    return countWorkspaceFiles(artifactsRoot.children)
-  }, [workspace])
+      return countWorkspaceFiles(artifactsRoot.children)
+    })()
+
+    const total = files + sessionBlocks
+    return total > 0 ? total : undefined
+  }, [sessionBlocks, workspace])
 
   const tabs = useMemo(
     () => [

--- a/web/design/src/components/fleet-pi/pi/settings-dialog.tsx
+++ b/web/design/src/components/fleet-pi/pi/settings-dialog.tsx
@@ -148,6 +148,7 @@ function useSettingsForm() {
     modelDirty,
     addModels,
     removeModel,
+    setDefaultModel,
     discoverProvider,
     discoveringProviderId,
     commitModelSettings,
@@ -251,6 +252,7 @@ function useSettingsForm() {
     handlePackageRowsChange,
     addModels,
     removeModel,
+    setDefaultModel,
     discoverProvider,
     discoveringProviderId,
     saveSection,
@@ -391,6 +393,7 @@ function SettingsDialogPaneContent({
     handlePackageRowsChange,
     addModels,
     removeModel,
+    setDefaultModel,
     discoverProvider,
     discoveringProviderId,
     saveSection,
@@ -520,6 +523,7 @@ function SettingsDialogPaneContent({
         onDiscoverProvider={discoverProvider}
         onModelFilterChange={setModelFilter}
         onRemoveModel={removeModel}
+        onSetDefaultModel={setDefaultModel}
         providers={providers}
         onRevert={revertModelDraft}
         onSave={() => draft && saveSection("models", modelSettings(draft))}

--- a/web/design/src/components/fleet-pi/pi/settings/use-model-defaults-form.ts
+++ b/web/design/src/components/fleet-pi/pi/settings/use-model-defaults-form.ts
@@ -170,6 +170,16 @@ export function useModelDefaultsForm({
 		setModelEnabled(model, false);
 	};
 
+	/** Promote an enabled model to the session default (engine settings.json). */
+	const setDefaultModel = (model: ConfigModelInfo) => {
+		if (!draft) return;
+		void commitModelSettings({
+			...draft,
+			defaultProvider: model.provider,
+			defaultModel: model.modelId,
+		});
+	};
+
 	const discoverProvider = async (providerId: string) => {
 		if (!onDiscoverModels) return;
 		setDiscoveringProviderId(providerId);
@@ -205,6 +215,7 @@ export function useModelDefaultsForm({
 		modelDirty,
 		addModels,
 		removeModel,
+		setDefaultModel,
 		discoverProvider,
 		discoveringProviderId,
 		commitModelSettings,

--- a/web/protocol/src/chat-protocol.ts
+++ b/web/protocol/src/chat-protocol.ts
@@ -321,10 +321,14 @@ export type ChatProviderInfo = {
 	providerFamily?: string;
 	/** OCC family only: user-supplied display label for the instance. */
 	displayName?: string;
-	/** Native Pi API family for a custom provider (absent for catalog rows). */
+	/** Custom provider only: native Pi API family for a custom provider (absent for catalog rows). */
 	api?: PiCustomProviderApi;
+	/** Custom provider/OCC only: non-secret base URL used by the Settings editor. */
+	baseUrl?: string;
 	/** Custom provider only: model ids registered for this provider. */
 	modelIds?: Array<string>;
+	/** Custom provider/OCC only: models can be discovered from the recorded base URL. */
+	discoverable?: boolean;
 };
 
 export type ChatProviderUpdateRequest = {

--- a/web/protocol/src/schemas/catalog.ts
+++ b/web/protocol/src/schemas/catalog.ts
@@ -126,7 +126,9 @@ export const ChatProviderInfoSchema = z
 		providerFamily: z.string().optional(),
 		displayName: z.string().optional(),
 		api: z.enum(["openai-completions", "openai-responses", "anthropic-messages", "google-genai"]).optional(),
+		baseUrl: z.string().optional(),
 		modelIds: z.array(z.string().max(4096)).max(64).optional(),
+		discoverable: z.boolean().optional(),
 	})
 	.openapi({ description: "Chat provider info" });
 

--- a/web/server/src/__tests__/chat-models-discover.test.ts
+++ b/web/server/src/__tests__/chat-models-discover.test.ts
@@ -1,0 +1,106 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { upsertCustomProvider } from "../custom-provider-store";
+
+const mocks = vi.hoisted(() => ({
+	config: {
+		agentDir: "",
+		modelRegistry: {
+			getApiKeyForProvider: vi.fn(),
+		},
+		reloadAuth: vi.fn(),
+	},
+}));
+
+vi.mock("../prime-config", () => ({ getPrimeConfig: () => mocks.config }));
+
+import { handleChatModelsDiscoverPost, openAiModelsUrl } from "../handlers/chat-models-discover";
+
+describe("chat model discovery", () => {
+	let agentDir: string;
+
+	beforeEach(() => {
+		agentDir = mkdtempSync(join(tmpdir(), "chat-model-discover-"));
+		mocks.config.agentDir = agentDir;
+		mocks.config.modelRegistry.getApiKeyForProvider.mockResolvedValue("secret-key");
+		mocks.config.reloadAuth.mockReset();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				new Response(JSON.stringify({ data: [{ id: "new-model" }] }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				}),
+			),
+		);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		rmSync(agentDir, { recursive: true, force: true });
+	});
+
+	it.each([
+		["https://api.example.test", "https://api.example.test/v1/models"],
+		["https://api.example.test/", "https://api.example.test/v1/models"],
+		["https://api.example.test/v1", "https://api.example.test/v1/models"],
+		["https://api.example.test/v1/", "https://api.example.test/v1/models"],
+		["https://api.example.test/openai/v1", "https://api.example.test/openai/v1/models"],
+	])("normalizes %s to %s", (baseUrl, expected) => {
+		expect(openAiModelsUrl(baseUrl).toString()).toBe(expected);
+	});
+
+	it("persists discovered IDs and refreshes the engine registry", async () => {
+		upsertCustomProvider(join(agentDir, "models.json"), "custom+lab", {
+			baseUrl: "https://api.example.test/v1",
+			api: "openai-completions",
+			apiKey: "CUSTOM_LAB_API_KEY",
+			models: [{ id: "existing-model", reasoning: true }],
+		});
+
+		const response = await handleChatModelsDiscoverPost(
+			new Request("http://localhost/api/chat/models/discover", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ providerId: "custom+lab" }),
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+			new URL("https://api.example.test/v1/models"),
+			expect.objectContaining({ headers: { Authorization: "Bearer secret-key" } }),
+		);
+		const stored = JSON.parse(readFileSync(join(agentDir, "models.json"), "utf-8")) as {
+			providers: Record<string, { models: Array<Record<string, unknown>> }>;
+		};
+		expect(stored.providers["custom+lab"].models).toEqual([
+			{ id: "existing-model", reasoning: true },
+			{ id: "new-model" },
+		]);
+		expect(mocks.config.reloadAuth).toHaveBeenCalledOnce();
+	});
+
+	it("does not advertise or call OpenAI discovery for Google providers", async () => {
+		upsertCustomProvider(join(agentDir, "models.json"), "custom+google", {
+			baseUrl: "https://generativelanguage.example.test",
+			api: "google-genai",
+			apiKey: "CUSTOM_GOOGLE_API_KEY",
+			models: [{ id: "gemini" }],
+		});
+
+		const response = await handleChatModelsDiscoverPost(
+			new Request("http://localhost/api/chat/models/discover", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ providerId: "custom+google" }),
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ providerId: "custom+google", models: [] });
+		expect(fetch).not.toHaveBeenCalled();
+	});
+});

--- a/web/server/src/__tests__/chat-providers-handler.test.ts
+++ b/web/server/src/__tests__/chat-providers-handler.test.ts
@@ -1,0 +1,450 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getProviders as getBuiltinProviders } from "@earendil-works/pi-ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+	const keys = new Map<string, string>();
+	const config = {
+		agentDir: "",
+		authStorage: {
+			set: (providerId: string, credential: { type: string; key: string }) => keys.set(providerId, credential.key),
+			remove: (providerId: string) => keys.delete(providerId),
+		},
+		modelRegistry: {
+			getProviderAuthStatus: (providerId: string) => ({ configured: keys.has(providerId) }),
+		},
+		reloadAuth: () => undefined,
+	};
+	return { keys, config };
+});
+
+vi.mock("../prime-config", () => ({ getPrimeConfig: () => mocks.config }));
+
+import { handleChatProvidersDelete, handleChatProvidersGet, handleChatProvidersPost } from "../handlers/chat-providers";
+
+function readModelsJson(dir: string): { providers?: Record<string, Record<string, unknown>> } {
+	return JSON.parse(readFileSync(join(dir, "models.json"), "utf-8"));
+}
+
+describe("chat providers custom/OCC write path", () => {
+	let agentDir: string;
+
+	beforeEach(() => {
+		agentDir = mkdtempSync(join(tmpdir(), "chat-providers-"));
+		mocks.config.agentDir = agentDir;
+		mocks.keys.clear();
+	});
+
+	afterEach(() => {
+		rmSync(agentDir, { recursive: true, force: true });
+	});
+
+	it("GET synthesizes the default OCC row", async () => {
+		const response = await handleChatProvidersGet(new Request("http://localhost/api/chat/providers"));
+		const body = (await response.json()) as { providers: Array<Record<string, unknown>> };
+		const occ = body.providers.find((p) => p.id === "openai-chat-completions");
+		expect(occ).toMatchObject({
+			isConfigured: false,
+			envVarName: "OPENAI_CHAT_COMPLETIONS_API_KEY",
+			providerFamily: "openai-chat-completions",
+		});
+	});
+
+	it("creates a custom provider: models.json entry + auth key + listed as configured", async () => {
+		const response = await handleChatProvidersPost(
+			new Request("http://localhost/api/chat/providers", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					providerId: "custom",
+					createOccInstance: true,
+					displayName: "My Lab",
+					apiKey: "sk-lab",
+					baseUrl: "https://api.mylab.test",
+					api: "openai-responses",
+					models: ["lab-1", "lab-2"],
+				}),
+			}),
+		);
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as { providers: Array<Record<string, unknown>> };
+		const row = body.providers.find((p) => p.id === "custom+my-lab");
+		expect(row).toMatchObject({
+			name: "My Lab",
+			isConfigured: true,
+			providerFamily: "custom",
+			api: "openai-responses",
+			modelIds: ["lab-1", "lab-2"],
+			discoverable: true,
+			envVarName: "CUSTOM_MY_LAB_API_KEY",
+		});
+
+		const stored = readModelsJson(agentDir);
+		expect(stored.providers?.["custom+my-lab"]).toMatchObject({
+			name: "My Lab",
+			baseUrl: "https://api.mylab.test",
+			api: "openai-responses",
+			apiKey: "CUSTOM_MY_LAB_API_KEY",
+			models: [{ id: "lab-1" }, { id: "lab-2" }],
+		});
+		expect(mocks.keys.get("custom+my-lab")).toBe("sk-lab");
+
+		// Second creation with the same name allocates a suffixed id.
+		const second = await handleChatProvidersPost(
+			new Request("http://localhost/api/chat/providers", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					providerId: "custom",
+					createOccInstance: true,
+					displayName: "My Lab",
+					apiKey: "sk-lab-2",
+					baseUrl: "https://api2.mylab.test",
+					models: ["x"],
+				}),
+			}),
+		);
+		const secondBody = (await second.json()) as { providers: Array<Record<string, unknown>> };
+		expect(secondBody.providers.some((p) => p.id === "custom+my-lab-2")).toBe(true);
+	});
+
+	it("creates a named OCC instance from the generic slot", async () => {
+		const response = await handleChatProvidersPost(
+			new Request("http://localhost/api/chat/providers", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					providerId: "openai-chat-completions",
+					createOccInstance: true,
+					displayName: "Zen Router",
+					apiKey: "sk-zen",
+					baseUrl: "https://zen.test/v1",
+					modelId: "zen-large",
+				}),
+			}),
+		);
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as { providers: Array<Record<string, unknown>> };
+		const row = body.providers.find((p) => p.id === "openai-chat-completions+zen-router");
+		expect(row).toMatchObject({
+			name: "Zen Router",
+			displayName: "Zen Router",
+			isConfigured: true,
+			providerFamily: "openai-chat-completions",
+			api: "openai-completions",
+			modelIds: ["zen-large"],
+			discoverable: true,
+			envVarName: "OPENAI_CHAT_COMPLETIONS_ZEN_ROUTER_API_KEY",
+		});
+
+		const stored = readModelsJson(agentDir);
+		expect(stored.providers?.["openai-chat-completions+zen-router"]).toMatchObject({
+			name: "Zen Router",
+			baseUrl: "https://zen.test/v1",
+			api: "openai-completions",
+			models: [{ id: "zen-large" }],
+		});
+	});
+
+	it("stores the engine Google API identifier and hides non-OpenAI discovery", async () => {
+		const response = await handleChatProvidersPost(
+			new Request("http://localhost/api/chat/providers", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					providerId: "custom",
+					createOccInstance: true,
+					displayName: "Gemini Lab",
+					apiKey: "google-key",
+					baseUrl: "https://gemini.test",
+					api: "google-genai",
+					models: ["gemini-custom"],
+				}),
+			}),
+		);
+		expect(response.status).toBe(200);
+
+		const stored = readModelsJson(agentDir);
+		expect(stored.providers?.["custom+gemini-lab"]).toMatchObject({
+			api: "google-generative-ai",
+		});
+		const body = (await response.json()) as { providers: Array<Record<string, unknown>> };
+		const row = body.providers.find((provider) => provider.id === "custom+gemini-lab");
+		expect(row).toMatchObject({ api: "google-genai", discoverable: false });
+	});
+
+	it("configures the default OCC slot without dropping the synth row", async () => {
+		const response = await handleChatProvidersPost(
+			new Request("http://localhost/api/chat/providers", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					providerId: "openai-chat-completions",
+					apiKey: "sk-occ",
+					baseUrl: "https://occ.test/v1",
+					modelId: "occ-model",
+				}),
+			}),
+		);
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as { providers: Array<Record<string, unknown>> };
+		const row = body.providers.find((p) => p.id === "openai-chat-completions");
+		expect(row).toMatchObject({
+			isConfigured: true,
+			modelIds: ["occ-model"],
+			discoverable: true,
+			envVarName: "OPENAI_CHAT_COMPLETIONS_API_KEY",
+		});
+	});
+
+	it("updates an existing custom provider without losing fields", async () => {
+		await handleChatProvidersPost(
+			new Request("http://localhost/api/chat/providers", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					providerId: "custom",
+					createOccInstance: true,
+					displayName: "Lab",
+					apiKey: "sk-1",
+					baseUrl: "https://v1.lab.test",
+					models: ["m1"],
+				}),
+			}),
+		);
+		const update = await handleChatProvidersPost(
+			new Request("http://localhost/api/chat/providers", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					providerId: "custom+lab",
+					displayName: "Lab",
+					apiKey: "sk-2",
+					baseUrl: "https://v2.lab.test",
+					models: ["m1", "m2"],
+				}),
+			}),
+		);
+		expect(update.status).toBe(200);
+		const stored = readModelsJson(agentDir);
+		expect(stored.providers?.["custom+lab"]).toMatchObject({
+			baseUrl: "https://v2.lab.test",
+			models: [{ id: "m1" }, { id: "m2" }],
+		});
+		expect(mocks.keys.get("custom+lab")).toBe("sk-2");
+	});
+
+	it("falls back to stored managed-provider fields when update fields are blank", async () => {
+		await handleChatProvidersPost(
+			new Request("http://localhost/api/chat/providers", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					providerId: "custom",
+					createOccInstance: true,
+					displayName: "Stored Lab",
+					apiKey: "sk-1",
+					baseUrl: "https://stored.test/v1",
+					models: ["stored-model"],
+				}),
+			}),
+		);
+
+		const response = await handleChatProvidersPost(
+			new Request("http://localhost/api/chat/providers", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					providerId: "custom+stored-lab",
+					apiKey: "sk-2",
+					baseUrl: "",
+					displayName: "",
+				}),
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		expect(readModelsJson(agentDir).providers?.["custom+stored-lab"]).toMatchObject({
+			name: "Stored Lab",
+			baseUrl: "https://stored.test/v1",
+			models: [{ id: "stored-model" }],
+		});
+	});
+
+	it("rejects invalid custom payloads with 400, not 500", async () => {
+		// Missing displayName for a new instance.
+		let response = await handleChatProvidersPost(
+			new Request("http://localhost/api/chat/providers", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					providerId: "custom",
+					createOccInstance: true,
+					apiKey: "sk",
+					baseUrl: "https://x.test",
+					models: ["m"],
+				}),
+			}),
+		);
+		expect(response.status).toBe(400);
+
+		// Non-URL baseUrl.
+		response = await handleChatProvidersPost(
+			new Request("http://localhost/api/chat/providers", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					providerId: "custom",
+					createOccInstance: true,
+					displayName: "Bad",
+					apiKey: "sk",
+					baseUrl: "not-a-url",
+					models: ["m"],
+				}),
+			}),
+		);
+		expect(response.status).toBe(400);
+
+		// No models for a custom provider.
+		response = await handleChatProvidersPost(
+			new Request("http://localhost/api/chat/providers", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					providerId: "custom",
+					createOccInstance: true,
+					displayName: "Empty",
+					apiKey: "sk",
+					baseUrl: "https://x.test",
+				}),
+			}),
+		);
+		expect(response.status).toBe(400);
+	});
+
+	it("DELETE removes models.json entry and credential for managed providers", async () => {
+		await handleChatProvidersPost(
+			new Request("http://localhost/api/chat/providers", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					providerId: "custom",
+					createOccInstance: true,
+					displayName: "Gone",
+					apiKey: "sk-gone",
+					baseUrl: "https://gone.test",
+					models: ["g"],
+				}),
+			}),
+		);
+		const response = await handleChatProvidersDelete(
+			new Request("http://localhost/api/chat/providers", {
+				method: "DELETE",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ providerId: "custom+gone" }),
+			}),
+		);
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as { providers: Array<Record<string, unknown>> };
+		expect(body.providers.some((p) => p.id === "custom+gone")).toBe(false);
+		expect(readModelsJson(agentDir).providers?.["custom+gone"]).toBeUndefined();
+		expect(mocks.keys.has("custom+gone")).toBe(false);
+	});
+
+	it("catalog providers keep the key-only path", async () => {
+		const response = await handleChatProvidersPost(
+			new Request("http://localhost/api/chat/providers", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ providerId: "deepseek", apiKey: "sk-ds" }),
+			}),
+		);
+		expect(response.status).toBe(200);
+		expect(() => readModelsJson(agentDir)).toThrow();
+		expect(mocks.keys.get("deepseek")).toBe("sk-ds");
+	});
+});
+
+describe("native builtin provider coverage", () => {
+	let agentDir: string;
+
+	beforeEach(() => {
+		agentDir = mkdtempSync(join(tmpdir(), "chat-providers-"));
+		mocks.config.agentDir = agentDir;
+		mocks.keys.clear();
+	});
+
+	afterEach(() => {
+		rmSync(agentDir, { recursive: true, force: true });
+	});
+
+	it("lists every engine builtin exactly once with a name and a hint policy", async () => {
+		const response = await handleChatProvidersGet(new Request("http://localhost/api/chat/providers"));
+		const body = (await response.json()) as { providers: Array<Record<string, unknown>> };
+
+		const byId = new Map<string, Record<string, unknown>>();
+		for (const row of body.providers) {
+			const id = row.id as string;
+			expect(byId.has(id), `duplicate provider row for ${id}`).toBe(false);
+			byId.set(id, row);
+		}
+
+		// Ids that legitimately carry no env-var hint (OAuth-only credentials).
+		const noHintAllowed = new Set(["github-copilot", "openai-codex"]);
+
+		for (const providerId of getBuiltinProviders()) {
+			const row = byId.get(providerId);
+			expect(row, `builtin ${providerId} missing from providers list`).toBeDefined();
+			expect(typeof row?.name === "string" && row.name.length > 0, `builtin ${providerId} has no display name`).toBe(
+				true,
+			);
+			if (!noHintAllowed.has(providerId)) {
+				expect(
+					typeof row?.envVarName === "string" && row.envVarName.length > 0,
+					`builtin ${providerId} has no env-var hint`,
+				).toBe(true);
+			}
+		}
+	});
+
+	it("gives anthropic and amazon-bedrock the env hints the engine honors", async () => {
+		const response = await handleChatProvidersGet(new Request("http://localhost/api/chat/providers"));
+		const body = (await response.json()) as { providers: Array<Record<string, unknown>> };
+		const byId = new Map(body.providers.map((row) => [row.id as string, row]));
+
+		expect(byId.get("anthropic")?.envVarName).toBe("ANTHROPIC_API_KEY");
+		expect(byId.get("amazon-bedrock")?.envVarName).toBe("AWS_BEARER_TOKEN_BEDROCK");
+		expect(byId.get("openrouter")?.envVarName).toBe("OPENROUTER_API_KEY");
+	});
+
+	it("round-trips an API key for key-auth builtins without touching models.json", async () => {
+		for (const providerId of ["openai", "openrouter", "anthropic", "amazon-bedrock"]) {
+			const post = await handleChatProvidersPost(
+				new Request("http://localhost/api/chat/providers", {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({ providerId, apiKey: `sk-${providerId}` }),
+				}),
+			);
+			expect(post.status, `POST ${providerId}`).toBe(200);
+			const postBody = (await post.json()) as { providers: Array<Record<string, unknown>> };
+			expect(postBody.providers.find((p) => p.id === providerId)?.isConfigured).toBe(true);
+
+			const del = await handleChatProvidersDelete(
+				new Request("http://localhost/api/chat/providers", {
+					method: "DELETE",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({ providerId }),
+				}),
+			);
+			expect(del.status, `DELETE ${providerId}`).toBe(200);
+			const delBody = (await del.json()) as { providers: Array<Record<string, unknown>> };
+			expect(delBody.providers.find((p) => p.id === providerId)?.isConfigured).toBe(false);
+		}
+
+		// The builtin path must never create models.json.
+		expect(() => readModelsJson(agentDir)).toThrow();
+	});
+});

--- a/web/server/src/__tests__/custom-provider-store.test.ts
+++ b/web/server/src/__tests__/custom-provider-store.test.ts
@@ -1,0 +1,215 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	envVarNameForManagedProvider,
+	isDiscoverableEntry,
+	listCustomProviders,
+	removeCustomProvider,
+	upsertCustomProvider,
+} from "../custom-provider-store";
+
+describe("custom-provider-store", () => {
+	let dir: string;
+	let modelsJsonPath: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "custom-provider-store-"));
+		modelsJsonPath = join(dir, "models.json");
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("creates models.json with the provider entry", async () => {
+		await upsertCustomProvider(modelsJsonPath, "custom+acme", {
+			name: "Acme",
+			baseUrl: "https://api.acme.test",
+			api: "openai-completions",
+			apiKey: "CUSTOM_ACME_API_KEY",
+			models: [{ id: "acme-1" }, { id: "acme-2" }],
+		});
+
+		const providers = await listCustomProviders(modelsJsonPath);
+		expect(providers["custom+acme"]).toMatchObject({
+			name: "Acme",
+			baseUrl: "https://api.acme.test",
+			api: "openai-completions",
+			apiKey: "CUSTOM_ACME_API_KEY",
+			models: [{ id: "acme-1" }, { id: "acme-2" }],
+		});
+	});
+
+	it("preserves other entries and unmanaged fields on upsert", async () => {
+		await upsertCustomProvider(modelsJsonPath, "custom+keep", {
+			baseUrl: "https://keep.test",
+			api: "openai-completions",
+			apiKey: "KEEP_KEY",
+			models: [{ id: "m" }],
+		});
+		// Simulate a hand-maintained field on the managed entry and an unrelated entry.
+		const raw = JSON.parse(readFileSync(modelsJsonPath, "utf-8")) as {
+			providers: Record<string, Record<string, unknown>>;
+		};
+		raw.providers["custom+keep"].compat = { supportsStore: false };
+		raw.providers["custom+keep"].models = [
+			{ id: "m", reasoning: true, cost: { input: 1 }, headers: { "x-test": "keep" } },
+		];
+		raw.providers["custom+other"] = { baseUrl: "https://other.test", models: [{ id: "o" }] };
+		rewriteModelsJson(raw);
+
+		await upsertCustomProvider(modelsJsonPath, "custom+keep", {
+			name: "Keep v2",
+			baseUrl: "https://keep2.test",
+			api: "openai-responses",
+			apiKey: "KEEP_KEY",
+			models: [{ id: "m2" }],
+		});
+
+		const providers = await listCustomProviders(modelsJsonPath);
+		expect(providers["custom+keep"]).toMatchObject({
+			name: "Keep v2",
+			baseUrl: "https://keep2.test",
+			api: "openai-responses",
+			compat: { supportsStore: false },
+			models: [{ id: "m2" }],
+		});
+		expect(providers["custom+other"]).toMatchObject({ baseUrl: "https://other.test" });
+	});
+
+	it("preserves JSONC providers and model metadata while updating", async () => {
+		writeFileSync(
+			modelsJsonPath,
+			`{
+				// Hand-maintained models.json comments must not cause data loss.
+				"providers": {
+					"custom+keep": {
+						"baseUrl": "https://keep.test",
+						"api": "openai-completions",
+						"apiKey": "KEEP_KEY",
+						"models": [{ "id": "m", "reasoning": true, "cost": { "input": 1 }, }],
+					},
+				},
+			}
+			`,
+			"utf-8",
+		);
+
+		await upsertCustomProvider(modelsJsonPath, "custom+keep", {
+			baseUrl: "https://keep-v2.test",
+			api: "openai-completions",
+			apiKey: "KEEP_KEY",
+			models: [{ id: "m" }],
+		});
+
+		const provider = (await listCustomProviders(modelsJsonPath))["custom+keep"];
+		expect(provider).toMatchObject({ baseUrl: "https://keep-v2.test" });
+		expect(provider.models).toEqual([{ id: "m", reasoning: true, cost: { input: 1 } }]);
+	});
+
+	it("refuses to overwrite an unparseable models.json", () => {
+		const original = "{ this is not valid JSONC";
+		writeFileSync(modelsJsonPath, original, "utf-8");
+
+		expect(() =>
+			upsertCustomProvider(modelsJsonPath, "custom+new", {
+				baseUrl: "https://new.test",
+				api: "openai-completions",
+				apiKey: "NEW_KEY",
+				models: [{ id: "new" }],
+			}),
+		).toThrow(/Refusing to update models\.json/);
+		expect(readFileSync(modelsJsonPath, "utf-8")).toBe(original);
+	});
+
+	it("removes only the targeted entry", async () => {
+		await upsertCustomProvider(modelsJsonPath, "custom+a", {
+			baseUrl: "https://a.test",
+			api: "openai-completions",
+			apiKey: "A_KEY",
+			models: [{ id: "a" }],
+		});
+		await upsertCustomProvider(modelsJsonPath, "custom+b", {
+			baseUrl: "https://b.test",
+			api: "openai-completions",
+			apiKey: "B_KEY",
+			models: [{ id: "b" }],
+		});
+
+		await removeCustomProvider(modelsJsonPath, "custom+a");
+
+		const providers = await listCustomProviders(modelsJsonPath);
+		expect(providers["custom+a"]).toBeUndefined();
+		expect(providers["custom+b"]).toBeDefined();
+	});
+
+	it("remove is a no-op for unknown ids", async () => {
+		await removeCustomProvider(modelsJsonPath, "custom+missing");
+		expect(await listCustomProviders(modelsJsonPath)).toEqual({});
+	});
+
+	it("derives stable env var names for managed providers", () => {
+		expect(envVarNameForManagedProvider("openai-chat-completions")).toBe("OPENAI_CHAT_COMPLETIONS_API_KEY");
+		expect(envVarNameForManagedProvider("openai-chat-completions+zen")).toBe("OPENAI_CHAT_COMPLETIONS_ZEN_API_KEY");
+		expect(envVarNameForManagedProvider("custom+my-lab")).toBe("CUSTOM_MY_LAB_API_KEY");
+	});
+
+	it("flags discoverable entries by http(s) baseUrl", () => {
+		expect(isDiscoverableEntry({ baseUrl: "https://api.acme.test" })).toBe(true);
+		expect(isDiscoverableEntry({ baseUrl: "http://localhost:8080" })).toBe(true);
+		expect(isDiscoverableEntry({ baseUrl: "file:///x" })).toBe(false);
+		expect(isDiscoverableEntry({})).toBe(false);
+		expect(isDiscoverableEntry(undefined)).toBe(false);
+	});
+
+	it("round-trips through a real engine ModelRegistry and AuthStorage", async () => {
+		const providerId = "custom+acme";
+		await upsertCustomProvider(modelsJsonPath, providerId, {
+			name: "Acme",
+			baseUrl: "https://api.acme.test",
+			api: "openai-completions",
+			apiKey: "CUSTOM_ACME_API_KEY",
+			models: [{ id: "acme-1", name: "Acme One" }],
+		});
+
+		const authStorage = AuthStorage.create(join(dir, "auth.json"));
+		authStorage.set(providerId, { type: "api_key", key: "secret-key" });
+		const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+		registry.refresh();
+
+		expect(registry.getError()).toBeUndefined();
+		const model = registry.getAll().find((m) => m.provider === providerId && m.id === "acme-1");
+		expect(model).toBeDefined();
+		expect(model?.name).toBe("Acme One");
+		expect(model?.baseUrl).toBe("https://api.acme.test");
+		expect(registry.getProviderAuthStatus(providerId).configured).toBe(true);
+		expect(await registry.getApiKeyForProvider(providerId)).toBe("secret-key");
+	});
+
+	it("engine reports a load error when a required field is missing", async () => {
+		await upsertCustomProvider(modelsJsonPath, "custom+broken", {
+			baseUrl: "https://broken.test",
+			api: "openai-completions",
+			apiKey: "BROKEN_KEY",
+			models: [{ id: "b" }],
+		});
+		const raw = JSON.parse(readFileSync(modelsJsonPath, "utf-8")) as {
+			providers: Record<string, Record<string, unknown>>;
+		};
+		delete raw.providers["custom+broken"].apiKey;
+		rewriteModelsJson(raw);
+
+		const registry = ModelRegistry.create(AuthStorage.create(join(dir, "auth.json")), modelsJsonPath);
+		registry.refresh();
+
+		expect(registry.getError()).toContain("apiKey");
+	});
+
+	function rewriteModelsJson(raw: unknown) {
+		rmSync(modelsJsonPath, { force: true });
+		writeFileSync(modelsJsonPath, `${JSON.stringify(raw, null, "\t")}\n`, "utf-8");
+	}
+});

--- a/web/server/src/custom-provider-store.ts
+++ b/web/server/src/custom-provider-store.ts
@@ -1,0 +1,180 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import type { PiCustomProviderApi } from "@prime-agent/web-protocol/chat-protocol";
+import {
+	isOccFamilyApi,
+	isOccProviderId,
+	isPiCustomProviderApi,
+	OPENAI_CHAT_COMPLETIONS_PROVIDER_ID,
+} from "@prime-agent/web-protocol/provider-catalog";
+
+/**
+ * Shape of one custom-provider entry in prime-agent's `models.json`
+ * (engine `ModelsConfig.providers[id]`). Unknown fields (compat,
+ * modelOverrides, headers, …) are preserved verbatim on upsert.
+ */
+export type StoredCustomProvider = {
+	name?: string;
+	baseUrl?: string;
+	api?: string;
+	/** Engine convention: env var name, `!command`, or (rarely) a literal key. */
+	apiKey?: string;
+	models?: Array<{ id: string; name?: string; [key: string]: unknown }>;
+	[key: string]: unknown;
+};
+
+type ModelsJson = {
+	providers?: Record<string, StoredCustomProvider>;
+	[key: string]: unknown;
+};
+
+export type CustomProviderWriteInput = {
+	name?: string;
+	baseUrl: string;
+	api: PiCustomProviderApi;
+	/** Stored as the env-var reference name; the secret itself lives in auth.json. */
+	apiKey: string;
+	models: Array<{ id: string; name?: string; [key: string]: unknown }>;
+};
+
+/** Convert the Settings API-family value to the engine's models.json value. */
+export function storedApiForCustomProvider(api: PiCustomProviderApi): string {
+	return api === "google-genai" ? "google-generative-ai" : api;
+}
+
+/** Convert a stored engine API-family value back to the Settings API value. */
+export function uiApiForCustomProvider(value: unknown): PiCustomProviderApi | undefined {
+	if (value === "google-generative-ai") return "google-genai";
+	return isPiCustomProviderApi(value) ? value : undefined;
+}
+
+/** Env-var name recorded in models.json for a provider managed via the UI. */
+export function envVarNameForManagedProvider(providerId: string): string {
+	if (providerId === OPENAI_CHAT_COMPLETIONS_PROVIDER_ID) {
+		return "OPENAI_CHAT_COMPLETIONS_API_KEY";
+	}
+	const slug = providerId
+		.slice(providerId.indexOf("+") + 1)
+		.toUpperCase()
+		.replace(/[^A-Z0-9]+/g, "_");
+	return isOccProviderId(providerId) ? `OPENAI_CHAT_COMPLETIONS_${slug}_API_KEY` : `CUSTOM_${slug}_API_KEY`;
+}
+
+export function readModelsJson(filePath: string): ModelsJson {
+	try {
+		if (!existsSync(filePath)) return {};
+		return parseModelsJson(readFileSync(filePath, "utf-8"));
+	} catch {
+		// A corrupt models.json is surfaced through the engine's loader error;
+		// the store must not amplify it into the providers API.
+		return {};
+	}
+}
+
+/** Strip `//` line comments and trailing commas from JSON, leaving strings untouched. */
+function stripJsonComments(input: string): string {
+	return input
+		.replace(/"(?:\\.|[^"\\])*"|\/\/[^\n]*/g, (match) => (match[0] === '"' ? match : ""))
+		.replace(/"(?:\\.|[^"\\])*"|,(\s*[}\]])/g, (match, tail) => tail ?? (match[0] === '"' ? match : ""));
+}
+
+function parseModelsJson(raw: string): ModelsJson {
+	const parsed = JSON.parse(stripJsonComments(raw)) as unknown;
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		throw new Error("models.json must contain an object");
+	}
+	return parsed as ModelsJson;
+}
+
+function readModelsJsonForWrite(filePath: string): ModelsJson {
+	if (!existsSync(filePath)) return {};
+	try {
+		return parseModelsJson(readFileSync(filePath, "utf-8"));
+	} catch (error) {
+		throw new Error(
+			`Refusing to update models.json because it could not be parsed: ${error instanceof Error ? error.message : error}`,
+		);
+	}
+}
+
+function mergeModelDefinitions(
+	existing: Array<{ id: string; [key: string]: unknown }> | undefined,
+	incoming: Array<{ id: string; [key: string]: unknown }>,
+): Array<{ id: string; [key: string]: unknown }> {
+	const existingById = new Map((existing ?? []).map((model) => [model.id, model]));
+	const seen = new Set<string>();
+	return incoming.flatMap((model) => {
+		if (seen.has(model.id)) return [];
+		seen.add(model.id);
+		return [{ ...existingById.get(model.id), ...model }];
+	});
+}
+
+export function listCustomProviders(filePath: string): Record<string, StoredCustomProvider> {
+	const data = readModelsJson(filePath);
+	return data.providers ?? {};
+}
+
+function writeModelsJson(filePath: string, data: ModelsJson): void {
+	mkdirSync(dirname(filePath), { recursive: true, mode: 0o700 });
+	const serialized = `${JSON.stringify(data, null, "\t")}\n`;
+	const tmpPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+	writeFileSync(tmpPath, serialized, "utf-8");
+	renameSync(tmpPath, filePath);
+}
+
+/**
+ * Insert or update a custom-provider entry, preserving fields the UI does not
+ * manage (compat, modelOverrides, headers) and entries for other providers.
+ */
+export function upsertCustomProvider(filePath: string, providerId: string, input: CustomProviderWriteInput): void {
+	const data = readModelsJsonForWrite(filePath);
+	const providers = { ...(data.providers ?? {}) };
+	const existing = providers[providerId] ?? {};
+	providers[providerId] = {
+		...existing,
+		name: input.name ?? existing.name,
+		baseUrl: input.baseUrl,
+		api: storedApiForCustomProvider(input.api),
+		apiKey: input.apiKey,
+		models: mergeModelDefinitions(existing.models, input.models),
+	};
+	writeModelsJson(filePath, { ...data, providers });
+}
+
+/** Add discovered model IDs while preserving every existing model definition. */
+export function addCustomProviderModelIds(filePath: string, providerId: string, modelIds: Array<string>): void {
+	const data = readModelsJsonForWrite(filePath);
+	const providers = { ...(data.providers ?? {}) };
+	const existing = providers[providerId];
+	if (!existing) return;
+	providers[providerId] = {
+		...existing,
+		models: mergeModelDefinitions(existing.models, [...(existing.models ?? []), ...modelIds.map((id) => ({ id }))]),
+	};
+	writeModelsJson(filePath, { ...data, providers });
+}
+
+export function removeCustomProvider(filePath: string, providerId: string): void {
+	const data = readModelsJsonForWrite(filePath);
+	const providers = data.providers;
+	if (!providers || !(providerId in providers)) return;
+	const next = { ...providers };
+	delete next[providerId];
+	writeModelsJson(filePath, { ...data, providers: next });
+}
+
+/** True when the provider entry points at an HTTP(S) endpoint we can discover models from. */
+export function isDiscoverableEntry(entry: StoredCustomProvider | undefined): boolean {
+	const baseUrl = entry?.baseUrl;
+	if (!baseUrl) return false;
+	const api = uiApiForCustomProvider(entry?.api);
+	if (api && !isOccFamilyApi(api)) return false;
+	if (entry?.api && !api) return false;
+	try {
+		const parsed = new URL(baseUrl);
+		return parsed.protocol === "https:" || parsed.protocol === "http:";
+	} catch {
+		return false;
+	}
+}

--- a/web/server/src/handlers/chat-models-discover.ts
+++ b/web/server/src/handlers/chat-models-discover.ts
@@ -1,6 +1,20 @@
 import { ChatModelsDiscoverRequestSchema } from "@prime-agent/web-protocol/chat-protocol.zod";
+import { isOccFamilyApi } from "@prime-agent/web-protocol/provider-catalog";
+import { addCustomProviderModelIds, listCustomProviders, uiApiForCustomProvider } from "../custom-provider-store";
 import { getPrimeConfig } from "../prime-config";
 import { wrapApiHandler } from "../wrap-api-handler";
+
+export function openAiModelsUrl(baseUrl: string): URL {
+	const parsed = new URL(baseUrl);
+	if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+		throw new Error("model discovery requires an http(s) URL");
+	}
+	const path = parsed.pathname.replace(/\/+$/, "");
+	parsed.pathname = path.endsWith("/v1") ? `${path}/models` : `${path}/v1/models`;
+	parsed.search = "";
+	parsed.hash = "";
+	return parsed;
+}
 
 export function handleChatModelsDiscoverPost(request: Request): Promise<Response> {
 	return wrapApiHandler(async () => {
@@ -16,12 +30,16 @@ export function handleChatModelsDiscoverPost(request: Request): Promise<Response
 		}
 
 		const provider = body.providerId;
-		const customProviders = (
-			config.modelRegistry as unknown as {
-				customProviderModels?: Record<string, { baseUrl?: string; models?: Array<string> }>;
-			}
-		).customProviderModels;
-		const baseUrl = customProviders?.[provider]?.baseUrl;
+		const custom = listCustomProviders(`${config.agentDir}/models.json`);
+		const entry = custom[provider];
+		const api = uiApiForCustomProvider(entry?.api);
+		if ((entry?.api && !api) || (api && !isOccFamilyApi(api))) {
+			return Response.json({
+				providerId: provider,
+				models: [],
+			});
+		}
+		const baseUrl = entry?.baseUrl;
 		if (!baseUrl) {
 			return Response.json({
 				providerId: provider,
@@ -30,17 +48,11 @@ export function handleChatModelsDiscoverPost(request: Request): Promise<Response
 		}
 
 		try {
-			const parsedBaseUrl = new URL(baseUrl);
-			if (parsedBaseUrl.protocol !== "https:" && parsedBaseUrl.protocol !== "http:") {
-				return Response.json({
-					providerId: provider,
-					models: [],
-				});
-			}
+			const modelsUrl = openAiModelsUrl(baseUrl);
 			// Stored provider credentials are sent to the user-configured provider
 			// endpoint; this is the model discovery auth flow.
 			// codeql[js/file-access-to-http]
-			const response = await fetch(`${parsedBaseUrl.toString().replace(/\/$/, "")}/v1/models`, {
+			const response = await fetch(modelsUrl, {
 				headers: { Authorization: `Bearer ${apiKey}` },
 				signal: AbortSignal.timeout(10_000),
 			});
@@ -64,6 +76,14 @@ export function handleChatModelsDiscoverPost(request: Request): Promise<Response
 				defaultThinkingLevel: "off" as const,
 				thinkingLevels: ["off"] as const,
 			}));
+			if (models.length > 0) {
+				addCustomProviderModelIds(
+					`${config.agentDir}/models.json`,
+					provider,
+					models.map((model) => model.id),
+				);
+				config.reloadAuth();
+			}
 			return Response.json({ providerId: provider, models });
 		} catch {
 			return Response.json({ providerId: provider, models: [] });

--- a/web/server/src/handlers/chat-providers.ts
+++ b/web/server/src/handlers/chat-providers.ts
@@ -1,11 +1,31 @@
-import { existsSync, readFileSync } from "node:fs";
 import { getProviders } from "@earendil-works/pi-ai";
 import { getOAuthProviders } from "@earendil-works/pi-ai/oauth";
+import type { ChatProviderInfo } from "@prime-agent/web-protocol/chat-protocol";
 import {
 	ChatProviderRemoveRequestSchema,
 	ChatProviderUpdateRequestSchema,
 } from "@prime-agent/web-protocol/chat-protocol.zod";
-import { KNOWN_PROVIDERS } from "@prime-agent/web-protocol/provider-catalog";
+import {
+	allocateProviderId,
+	isCustomProviderId,
+	isNamedOccInstanceId,
+	isOccProviderId,
+	isPiCustomProviderApi,
+	KNOWN_PROVIDERS,
+	normalizeCustomProviderInstance,
+	OPENAI_CHAT_COMPLETIONS_PROVIDER_ID,
+	toCustomProviderId,
+	toInstanceSlug,
+	toOccInstanceId,
+} from "@prime-agent/web-protocol/provider-catalog";
+import {
+	envVarNameForManagedProvider,
+	isDiscoverableEntry,
+	listCustomProviders,
+	removeCustomProvider,
+	uiApiForCustomProvider,
+	upsertCustomProvider,
+} from "../custom-provider-store";
 import { getPrimeConfig } from "../prime-config";
 import { PRIME_PROVIDER_ENV_MAP } from "../prime-provider-env-map";
 import { wrapApiHandler } from "../wrap-api-handler";
@@ -46,16 +66,27 @@ const BUILT_IN_PROVIDER_DISPLAY_NAMES: Record<string, string> = {
 	"github-copilot": "GitHub Copilot",
 };
 
-type CustomProviderEntry = {
-	name?: string;
-	baseUrl?: string;
-	apiKey?: string;
-	models?: Array<{ id: string }>;
+const KNOWN_PROVIDER_BY_ID = new Map(KNOWN_PROVIDERS.map((provider) => [provider.id, provider]));
+
+/**
+ * Builtin credential env-var hints that live outside pi-ai's `envMap` mirror:
+ * anthropic's key is special-cased in `packages/ai/src/env-api-keys.ts`
+ * (after `ANTHROPIC_OAUTH_TOKEN`), and Bedrock accepts a static bearer token.
+ * These extend the mirror, they do not fork it — see `PRIME_PROVIDER_ENV_MAP`.
+ */
+const EXTRA_BUILTIN_ENV_HINTS: Record<string, string> = {
+	anthropic: "ANTHROPIC_API_KEY",
+	"amazon-bedrock": "AWS_BEARER_TOKEN_BEDROCK",
 };
 
-type CustomProvidersMap = Record<string, CustomProviderEntry>;
+/** Env-var hint shown next to the credential field for a builtin provider. */
+function envHintForBuiltin(providerId: string): string {
+	return PRIME_PROVIDER_ENV_MAP[providerId] ?? EXTRA_BUILTIN_ENV_HINTS[providerId] ?? "";
+}
 
-const KNOWN_PROVIDER_BY_ID = new Map(KNOWN_PROVIDERS.map((provider) => [provider.id, provider]));
+function badRequest(message: string): never {
+	throw Object.assign(new Error(message), { status: 400 });
+}
 
 export function resolveProviderAuthFields(
 	providerId: string,
@@ -72,45 +103,54 @@ export function resolveProviderAuthFields(
 	};
 }
 
-function readCustomProviders(modelsJsonPath: string): CustomProvidersMap {
-	try {
-		if (!existsSync(modelsJsonPath)) return {};
-		const raw = readFileSync(modelsJsonPath, "utf-8");
-		const parsed = JSON.parse(raw) as { providers?: CustomProvidersMap };
-		return parsed.providers ?? {};
-	} catch {
-		return {};
-	}
-}
-
-function buildProviders() {
+function buildProviders(): Array<ChatProviderInfo> {
 	const config = getPrimeConfig();
 	const oauthIds = new Set(getOAuthProviders().map((p) => p.id));
 
-	const custom = readCustomProviders(`${config.agentDir}/models.json`);
+	const custom = listCustomProviders(`${config.agentDir}/models.json`);
 	const builtinIds = new Set<string>(getProviders());
 	const allIds = new Set<string>([...builtinIds, ...Object.keys(custom)]);
+	// The generic OpenAI Chat Completions slot is always offered, even before a
+	// models.json entry exists, so its "add named instance" flow stays visible.
+	allIds.add(OPENAI_CHAT_COMPLETIONS_PROVIDER_ID);
 
-	return Array.from(allIds)
+	return [...allIds]
 		.map((id) => {
 			const isCustom = !builtinIds.has(id);
-			const customEntry = custom[id];
+			const customEntry = isCustom ? custom[id] : undefined;
 			const status = config.modelRegistry.getProviderAuthStatus(id);
-			const name = isCustom ? (customEntry?.name ?? id) : (BUILT_IN_PROVIDER_DISPLAY_NAMES[id] ?? id);
-			const envVarName = isCustom ? (customEntry?.apiKey ?? "") : (PRIME_PROVIDER_ENV_MAP[id] ?? "");
+			const catalogEntry = KNOWN_PROVIDER_BY_ID.get(id);
+			const name = isCustom
+				? (customEntry?.name ?? catalogEntry?.name ?? id)
+				: (BUILT_IN_PROVIDER_DISPLAY_NAMES[id] ?? catalogEntry?.name ?? id);
+			const envVarName = isCustom ? (customEntry?.apiKey ?? catalogEntry?.envVarName ?? "") : envHintForBuiltin(id);
 			const authFields = resolveProviderAuthFields(id, envVarName, oauthIds);
-			return {
+
+			const row: ChatProviderInfo = {
 				id,
 				name,
 				envVarName,
 				...authFields,
 				isConfigured: status.configured,
 			};
+
+			if (isOccProviderId(id) || isCustomProviderId(id)) {
+				row.providerFamily = isOccProviderId(id) ? OPENAI_CHAT_COMPLETIONS_PROVIDER_ID : "custom";
+				if (customEntry?.name && (isNamedOccInstanceId(id) || isCustomProviderId(id))) {
+					row.displayName = customEntry.name;
+				}
+				const customApi = uiApiForCustomProvider(customEntry?.api);
+				if (customApi) row.api = customApi;
+				if (customEntry?.baseUrl) row.baseUrl = customEntry.baseUrl;
+				row.modelIds = (customEntry?.models ?? []).map((model) => model.id);
+				row.discoverable = isDiscoverableEntry(customEntry);
+			}
+			return row;
 		})
 		.sort((a, b) => a.name.localeCompare(b.name));
 }
 
-export function listChatProviders() {
+export function listChatProviders(): Array<ChatProviderInfo> {
 	return buildProviders();
 }
 
@@ -120,12 +160,97 @@ export function handleChatProvidersGet(_request: Request): Promise<Response> {
 	});
 }
 
+function requireBaseUrl(baseUrl: string | undefined, providerId: string): string {
+	const trimmed = baseUrl?.trim() ?? "";
+	if (!trimmed) {
+		badRequest(`baseUrl is required for ${providerId}`);
+	}
+	try {
+		const parsed = new URL(trimmed);
+		if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+			badRequest(`baseUrl must be an http(s) URL for ${providerId}`);
+		}
+	} catch (error) {
+		if (error && typeof error === "object" && "status" in error) throw error;
+		badRequest(`baseUrl must be an http(s) URL for ${providerId}`);
+	}
+	return trimmed;
+}
+
 export function handleChatProvidersPost(request: Request): Promise<Response> {
 	return wrapApiHandler(async () => {
 		const raw = await request.json().catch(() => ({}));
 		const body = ChatProviderUpdateRequestSchema.parse(raw);
 		const config = getPrimeConfig();
-		config.authStorage.set(body.providerId, {
+		const modelsJsonPath = `${config.agentDir}/models.json`;
+
+		const isNewCustom = body.providerId === "custom";
+		const isNewOccInstance =
+			body.providerId === OPENAI_CHAT_COMPLETIONS_PROVIDER_ID && body.createOccInstance === true;
+		const isManagedProvider = isNewCustom || isCustomProviderId(body.providerId) || isOccProviderId(body.providerId);
+		const isDefaultOccSlot = body.providerId === OPENAI_CHAT_COMPLETIONS_PROVIDER_ID && !isNewOccInstance;
+
+		if (!isManagedProvider) {
+			// Plain catalog provider: credentials only, no models.json involvement.
+			config.authStorage.set(body.providerId, {
+				type: "api_key",
+				key: body.apiKey,
+			});
+			config.reloadAuth();
+			return Response.json({
+				success: true,
+				providers: buildProviders(),
+			});
+		}
+
+		// Custom provider / OCC family: register (or update) the provider in
+		// prime-agent's models.json, then store the key under the final id.
+		let providerId = body.providerId;
+		if (isNewCustom || isNewOccInstance) {
+			const displayName = body.displayName?.trim() ?? "";
+			if (!displayName) {
+				badRequest("displayName is required when creating a new provider instance");
+			}
+			const existingIds = new Set<string>([...getProviders(), ...Object.keys(listCustomProviders(modelsJsonPath))]);
+			providerId = allocateProviderId(
+				toInstanceSlug(displayName),
+				existingIds,
+				isNewCustom ? toCustomProviderId : toOccInstanceId,
+			);
+		}
+
+		const existingEntry = listCustomProviders(modelsJsonPath)[providerId];
+		const api =
+			body.api ??
+			(uiApiForCustomProvider(existingEntry?.api)
+				? uiApiForCustomProvider(existingEntry?.api)
+				: "openai-completions");
+		if (!isPiCustomProviderApi(api)) {
+			badRequest(`unsupported api "${api}" for ${providerId}`);
+		}
+		const baseUrl = requireBaseUrl(body.baseUrl?.trim() || existingEntry?.baseUrl, providerId);
+		const { modelIds } = normalizeCustomProviderInstance({
+			modelId: body.modelId ?? existingEntry?.models?.[0]?.id,
+			api,
+			modelIds: body.models ?? existingEntry?.models?.map((model) => model.id),
+		});
+		if (modelIds.length === 0) {
+			badRequest(
+				isDefaultOccSlot
+					? `modelId is required for ${providerId}`
+					: `at least one model id is required for ${providerId}`,
+			);
+		}
+
+		const displayName = body.displayName?.trim() || existingEntry?.name;
+		upsertCustomProvider(modelsJsonPath, providerId, {
+			...(displayName ? { name: displayName } : {}),
+			baseUrl,
+			api,
+			apiKey: envVarNameForManagedProvider(providerId),
+			models: modelIds.map((id) => ({ id })),
+		});
+		config.authStorage.set(providerId, {
 			type: "api_key",
 			key: body.apiKey,
 		});
@@ -142,6 +267,13 @@ export function handleChatProvidersDelete(request: Request): Promise<Response> {
 		const raw = await request.json().catch(() => ({}));
 		const body = ChatProviderRemoveRequestSchema.parse(raw);
 		const config = getPrimeConfig();
+
+		if (isCustomProviderId(body.providerId) || isOccProviderId(body.providerId)) {
+			// Removing the registration for a UI-managed provider must not leave a
+			// stale models.json entry behind (the default OCC slot stays listed via
+			// the synthesized row even after removal).
+			removeCustomProvider(`${config.agentDir}/models.json`, body.providerId);
+		}
 		config.authStorage.remove(body.providerId);
 		config.reloadAuth();
 		return Response.json({


### PR DESCRIPTION
## Summary

- preserve JSONC provider registry content, model metadata, and engine-compatible Google API identifiers
- normalize and persist OpenAI-compatible discovery results while restricting unsupported API families
- preserve provider edit state and keep settled reasoning and reopened OpenUI actions functional

## Validation

- `npm run check`
- `pnpm exec vitest run` in `web/server` (22 files, 168 tests)
- `pnpm exec vitest run` in `web/app` (16 files, 64 tests)
