### PR TITLE
ci(circleci): gate workflows on trigger type for scheduled runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,6 +230,9 @@ jobs:
 
 workflows:
   ci:
+    when:
+      not:
+        equal: [schedule, << pipeline.trigger.type >>]
     jobs:
       - build-check
       - test:
@@ -316,12 +319,7 @@ workflows:
             - test-web
 
   nightly-process-stress:
-    triggers:
-      - schedule:
-          cron: "0 9 * * *"
-          filters:
-            branches:
-              only:
-                - main
+    when:
+      equal: [schedule, << pipeline.trigger.type >>]
     jobs:
       - process-stress


### PR DESCRIPTION
## Summary
- Replace deprecated in-config `triggers: schedule` block with workflow-level `when` conditions based on `<< pipeline.trigger.type >>`.
- Gating the `ci` workflow to non-scheduled runs, and `nightly-process-stress` to scheduled runs.
- Enables native GitHub App scheduled triggers on CircleCI.

## Validation
- `circleci___validate_config` passed (valid CircleCI 2.1 config).
- `npm run check` passed.