### PR TITLE
feat(release): publish @qredence/fleet to npm via trusted publishing

### DIFF
--- a/.github/workflows/release-fleet.yml
+++ b/.github/workflows/release-fleet.yml
@@ -1,10 +1,12 @@
 name: Release Fleet Prime
 
 # Fleet release model (see AGENTS.md "Releasing"):
-#   build -> build:web:release -> release:pack -> tag.
+#   build -> build:web:release -> release:pack -> tag -> npm publish.
 # The upstream Prime Agent engine is consumed as a checksum-pinned stock
 # tarball (PRIME_AGENT_RUNTIME.json). This workflow never publishes or
-# rebuilds Prime Agent itself; it packs and releases @qredence/fleet-prime.
+# rebuilds Prime Agent itself; it packs, releases, and publishes
+# @qredence/fleet to npm via trusted publishing (see
+# docs/guides/releasing.md for the one-time bootstrap).
 
 on:
   push:
@@ -52,10 +54,13 @@ jobs:
           echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
 
   build:
-    name: Build, pack, and smoke test
+    name: Build, pack, smoke test, and publish
     needs: release-context
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
+      id-token: write # OIDC for npm trusted publishing
     env:
       RELEASE_VERSION: ${{ needs.release-context.outputs.version }}
     steps:
@@ -71,10 +76,11 @@ jobs:
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        uses: actions/setup-node@820762786026740c76336085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: pnpm
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install system dependencies
         run: |
@@ -100,15 +106,23 @@ jobs:
         run: |
           mkdir -p dist-release
           pnpm --dir packages/fleet-prime pack --pack-destination "$GITHUB_WORKSPACE/dist-release"
-          test -f "dist-release/qredence-fleet-prime-${RELEASE_VERSION}.tgz"
+          test -f "dist-release/qredence-fleet-${RELEASE_VERSION}.tgz"
 
       - name: Smoke test packed artifact
-        run: node scripts/check-web-release.mjs --package "dist-release/qredence-fleet-prime-${RELEASE_VERSION}.tgz"
+        run: node scripts/check-web-release.mjs --package "dist-release/qredence-fleet-${RELEASE_VERSION}.tgz"
+
+      # Trusted publishing needs npm >= 11.5.1; the Node 22 bundle ships npm 10.
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Publish to npm
+        run: npm publish --provenance
+        working-directory: packages/fleet-prime
 
       - name: Generate checksum
         run: |
           cd dist-release
-          sha256sum "qredence-fleet-prime-${RELEASE_VERSION}.tgz" > SHA256SUMS
+          sha256sum "qredence-fleet-${RELEASE_VERSION}.tgz" > SHA256SUMS
           cat SHA256SUMS
 
       - name: Upload release artifact
@@ -116,7 +130,7 @@ jobs:
         with:
           name: fleet-prime-${{ env.RELEASE_VERSION }}
           path: |
-            dist-release/qredence-fleet-prime-${{ env.RELEASE_VERSION }}.tgz
+            dist-release/qredence-fleet-${{ env.RELEASE_VERSION }}.tgz
             dist-release/SHA256SUMS
           if-no-files-found: error
 
@@ -152,8 +166,10 @@ jobs:
             echo ""
             echo "Artifacts:"
             echo ""
-            echo "- qredence-fleet-prime-${RELEASE_VERSION}.tgz: packed @qredence/fleet-prime launcher package"
+            echo "- qredence-fleet-${RELEASE_VERSION}.tgz: packed @qredence/fleet launcher package"
             echo "- SHA256SUMS: checksum for the packed tarball"
+            echo ""
+            echo "The package is also published to npm as @qredence/fleet with provenance attestations."
             echo ""
             echo "The upstream Prime Agent runtime is consumed as the stock tarball pinned in PRIME_AGENT_RUNTIME.json."
             echo "Verify the checksum before installing the artifact."

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 node_modules/
 dist/
 /dist-release/
-qredence-fleet-prime-*.tgz
+qredence-fleet-*.tgz
 *.log
 .DS_Store
 *.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -22,7 +22,13 @@ https://github.com/user-attachments/assets/7df3d0ea-8c73-40a4-9bd3-f1c0445a9ea8
 
 ## Install
 
-Clone the repository and run the Fleet Prime installer command. It installs the pinned upstream Prime Agent runtime, the web dependencies, builds Fleet Prime, and links `fleet-agent`.
+Install the npm package (Node.js 22.8.0 or later):
+
+```bash
+npm install -g @qredence/fleet
+```
+
+Or install from source. Clone the repository and run the Fleet Prime installer command. It installs the pinned upstream Prime Agent runtime, the web dependencies, builds Fleet Prime, and links `fleet-agent`.
 
 ```bash
 git clone https://github.com/Qredence/fleet-prime-agent.git

--- a/docs/guides/releasing.md
+++ b/docs/guides/releasing.md
@@ -2,11 +2,56 @@
 
 Read this before cutting a Fleet release.
 
-The upstream engine version is pinned in `PRIME_AGENT_RUNTIME.json`; upgrades
-are explicit dependency updates with checksum and adapter verification.
+The upstream engine version is pinned in
+`PRIME_AGENT_RUNTIME.json`; upgrades are explicit dependency updates with
+checksum and adapter verification.
 
-Fleet release (web product + packed CLI artifact):
+Fleet release (web product + packed CLI artifact + npm publish):
 
 1. Upgrade the runtime pin if needed, then run `pnpm install` and `pnpm run check`.
 2. Build and pack: `pnpm run build:web:release && pnpm run release:pack`.
-3. Tag this repository; do not publish Prime Agent itself from Fleet.
+3. Tag this repository; the release workflow builds, smoke-tests, and publishes
+   `@qredence/fleet`. Do not publish Prime Agent itself from Fleet.
+
+## npm publishing
+
+Pushing a `v*` tag (or dispatching the release workflow) publishes
+`@qredence/fleet` to npmjs.com from the release workflow using
+npm trusted publishing (OIDC, no stored tokens). The publish runs from
+`packages/fleet-prime` after the packed tarball passes the web release smoke
+test. The upstream Prime Agent engine is never republished by Fleet; the
+published package installs it as the checksum-pinned tarball dependency from
+`PRIME_AGENT_RUNTIME.json`.
+
+Trusted publishing requires `id-token: write` on a GitHub-hosted runner, an
+npm CLI of at least 11.5.1 (the workflow upgrades npm itself), and a
+`repository.url` in `packages/fleet-prime/package.json` that matches this
+GitHub repository exactly.
+
+### One-time bootstrap
+
+The first version of a new package cannot be published via trusted
+publishing: npm's trusted-publisher settings require the package to already
+exist.
+
+1. Ensure the `@qredence` organization exists on npmjs.com and your account is
+   an owner, then sign in on this machine with `npm login` (npm reports
+   missing publish permission as `E404`).
+2. Build locally and publish the initial version once with 2FA:
+
+   ```bash
+   pnpm run build:web:release
+   npm publish ./packages/fleet-prime --access public
+   ```
+
+3. Configure the trusted publisher at
+   `https://www.npmjs.com/package/@qredence/fleet/access`:
+   GitHub Actions, organization `Qredence`, repository `fleet-prime-agent`,
+   workflow filename `release-fleet.yml`, allowed action `npm publish`.
+4. Later tagged releases publish through OIDC with no stored tokens.
+
+### Hardening (recommended)
+
+After the trusted publisher works, restrict the package on npmjs.com
+(Settings → Publishing access → "Require two-factor authentication and
+disallow tokens") so only the trusted publisher can publish.

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
 	"type": "module",
 	"packageManager": "pnpm@11.15.1",
 	"bin": {
-		"fleet-agent": "./packages/fleet-prime/bin/fleet-prime.mjs",
-		"fleet-prime": "./packages/fleet-prime/bin/fleet-prime.mjs"
+		"fleet-agent": "packages/fleet-prime/bin/fleet-prime.mjs",
+		"fleet-prime": "packages/fleet-prime/bin/fleet-prime.mjs"
 	},
 	"scripts": {
 		"build": "pnpm run build:web:release",

--- a/packages/fleet-prime/LICENSE
+++ b/packages/fleet-prime/LICENSE
@@ -1,0 +1,23 @@
+MIT License
+
+Copyright (c) 2025 Mario Zechner
+Copyright (c) 2026 Prime Intellect
+Copyright (c) 2026 Qredence
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/fleet-prime/README.md
+++ b/packages/fleet-prime/README.md
@@ -1,0 +1,41 @@
+# @qredence/fleet
+
+Fleet Prime Agent is Qredence's persistent local workspace for coding and
+research with AI: a multi-project web chat built on the upstream
+[Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent) engine. The
+engine is installed as a checksum-pinned dependency and never modified; Fleet
+adds the web interface, workspace navigation, streaming tool cards, and
+managed IPython kernels.
+
+## Install
+
+Requires Node.js 22.8.0 or later. Python 3.10 or later is needed for the
+managed IPython kernel.
+
+```bash
+npm install -g @qredence/fleet
+```
+
+## Use
+
+Run the launcher from the project directory you want the agent to work in:
+
+```bash
+cd /path/to/your/project
+fleet-agent
+```
+
+Open the local URL the launcher prints. On first use, add a provider in
+**Settings → Providers** (or run `/login`) and choose a model in the composer.
+`fleet-prime` is an alias for the same launcher, and `fleet-agent agent`
+exposes the upstream Prime Agent CLI.
+
+## Learn more
+
+- [Fleet Prime Agent repository](https://github.com/Qredence/fleet-prime-agent)
+- [Prime Agent engine documentation](https://github.com/PrimeIntellect-ai/prime-agent#readme)
+
+## License
+
+MIT — see [LICENSE](LICENSE). The upstream Prime Agent engine keeps its own
+license; this package consumes it as a pinned dependency.

--- a/packages/fleet-prime/package.json
+++ b/packages/fleet-prime/package.json
@@ -1,16 +1,39 @@
 {
-  "name": "@qredence/fleet-prime",
+  "name": "@qredence/fleet",
   "version": "0.1.0",
-  "private": true,
+  "description": "Fleet Prime: local web interface and launcher for the pinned Prime Agent runtime",
+  "license": "MIT",
   "type": "module",
+  "homepage": "https://github.com/Qredence/fleet-prime-agent#readme",
+  "bugs": "https://github.com/Qredence/fleet-prime-agent/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Qredence/fleet-prime-agent.git",
+    "directory": "packages/fleet-prime"
+  },
+  "keywords": [
+    "ai",
+    "agent",
+    "coding-agent",
+    "cli",
+    "prime-agent",
+    "web-ui",
+    "workspace"
+  ],
   "bin": {
-    "fleet-agent": "./bin/fleet-prime.mjs",
-    "fleet-prime": "./bin/fleet-prime.mjs"
+    "fleet-agent": "bin/fleet-prime.mjs",
+    "fleet-prime": "bin/fleet-prime.mjs"
   },
   "files": [
     "bin",
     "dist"
   ],
+  "engines": {
+    "node": ">=22.8.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@earendil-works/pi-agent-core": "https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/releases/v0.8.1/prime-agent-core-0.8.1.tgz",
     "@earendil-works/pi-ai": "https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/releases/v0.8.1/prime-agent-ai-0.8.1.tgz",

--- a/scripts/check-web-release.mjs
+++ b/scripts/check-web-release.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-// Smoke-tests a packed @qredence/fleet-prime release tarball: installs it into a
+// Smoke-tests a packed @qredence/fleet release tarball: installs it into a
 // temporary npm prefix, boots the bundled web runtime, and verifies the HTTP
 // surface (/, /api/health, /api/workspace/tree, one client asset).
 
@@ -16,7 +16,7 @@ const STARTUP_TIMEOUT_MS = 60000;
 const FETCH_TIMEOUT_MS = 5000;
 
 function printUsage() {
-	console.log("Usage: node scripts/check-web-release.mjs [--package path/to/qredence-fleet-prime-*.tgz]");
+	console.log("Usage: node scripts/check-web-release.mjs [--package path/to/qredence-fleet-*.tgz]");
 	console.log("");
 	console.log("Without --package, packs packages/fleet-prime into a temporary directory first.");
 	console.log("Requires a built web runtime: pnpm run build:web:release");
@@ -50,7 +50,7 @@ function parseArgs(argv) {
 
 function findExistingTarball() {
 	const candidates = readdirSync(root)
-		.filter((entry) => entry.startsWith("qredence-fleet-prime-") && entry.endsWith(".tgz"))
+		.filter((entry) => entry.startsWith("qredence-fleet-") && entry.endsWith(".tgz"))
 		.sort();
 	if (candidates.length === 0) return undefined;
 	return join(root, candidates[candidates.length - 1]);
@@ -66,10 +66,10 @@ function packToTemp(tempDir) {
 		stdio: "inherit",
 	});
 	const packed = readdirSync(tempDir)
-		.filter((entry) => entry.startsWith("qredence-fleet-prime-") && entry.endsWith(".tgz"))
+		.filter((entry) => entry.startsWith("qredence-fleet-") && entry.endsWith(".tgz"))
 		.sort();
 	if (packed.length === 0) {
-		throw new Error("pnpm pack did not produce a qredence-fleet-prime tarball");
+		throw new Error("pnpm pack did not produce a qredence-fleet tarball");
 	}
 	return join(tempDir, packed[packed.length - 1]);
 }
@@ -99,7 +99,7 @@ function installTarball(tarball, prefix) {
 		encoding: "utf8",
 		env: { ...process.env, NPM_CONFIG_PREFIX: prefix, npm_config_prefix: prefix },
 	}).trim();
-	const installedPackage = join(globalRoot, "@qredence", "fleet-prime");
+	const installedPackage = join(globalRoot, "@qredence", "fleet");
 	if (!existsSync(installedPackage)) {
 		throw new Error(`Expected installed package at ${installedPackage}`);
 	}

--- a/scripts/check-web-release.mjs
+++ b/scripts/check-web-release.mjs
@@ -15,6 +15,9 @@ const fleetPrimeDir = join(root, "packages", "fleet-prime");
 const STARTUP_TIMEOUT_MS = 60000;
 const FETCH_TIMEOUT_MS = 5000;
 
+/**
+ * Prints command usage and the prerequisite for running the web release smoke test.
+ */
 function printUsage() {
 	console.log("Usage: node scripts/check-web-release.mjs [--package path/to/qredence-fleet-*.tgz]");
 	console.log("");
@@ -48,6 +51,10 @@ function parseArgs(argv) {
 	return { packagePath };
 }
 
+/**
+ * Finds the latest matching Fleet package tarball in the project root.
+ * @returns {string|undefined} The path to the latest matching tarball, or `undefined` when none exists.
+ */
 function findExistingTarball() {
 	const candidates = readdirSync(root)
 		.filter((entry) => entry.startsWith("qredence-fleet-") && entry.endsWith(".tgz"))
@@ -56,6 +63,12 @@ function findExistingTarball() {
 	return join(root, candidates[candidates.length - 1]);
 }
 
+/**
+ * Packs the fleet package into a temporary directory.
+ * @param {string} tempDir - Directory where the package tarball is created.
+ * @returns {string} The path to the created package tarball.
+ * @throws {Error} If the web launcher is missing or packing does not produce a tarball.
+ */
 function packToTemp(tempDir) {
 	const launcher = join(fleetPrimeDir, "dist", "web", "launcher.mjs");
 	if (!existsSync(launcher)) {
@@ -90,6 +103,13 @@ function findClientJsAsset(clientDir) {
 	return undefined;
 }
 
+/**
+ * Installs a release tarball into a temporary global npm prefix.
+ * @param {string} tarball - The path to the package tarball.
+ * @param {string} prefix - The npm installation prefix.
+ * @return {string} The path to the installed package.
+ * @throws {Error} If installation fails or the package is missing from the prefix.
+ */
 function installTarball(tarball, prefix) {
 	execFileSync("npm", ["install", "--global", "--no-fund", "--no-audit", tarball], {
 		stdio: "inherit",


### PR DESCRIPTION
## Summary

Publishes the Fleet product to the public npm registry as **@qredence/fleet**, automated through the existing tag-driven release workflow via npm trusted publishing (OIDC, no stored tokens).

## What's in it

**Package identity**
- `packages/fleet-prime` renamed from `@qredence/fleet-prime` (private, pack-only) to `@qredence/fleet` (public, publishable)
- Publish metadata: `engines` (Node >= 22.8.0), `repository`, keywords, `publishConfig.access`
- New package-facing README and LICENSE (npm ships them from the package directory)
- Bin paths in npm-normalized form (no `./` prefix); bins stay `fleet-agent` / `fleet-prime`
- Runtime deps unchanged: the pinned Prime Agent engine arrives as a checksum-pinned dependency and is never republished

**Release pipeline**
- `release-prime-agent.yml` renamed to `release-fleet.yml`
- Publish step after the tarball smoke test: `npm install -g npm@latest` (trusted publishing needs npm >= 11.5.1) and `npm publish --provenance` from `packages/fleet-prime`
- Build job gets `id-token: write`; setup-node points at the npm registry
- Tarball is now `qredence-fleet-<version>.tgz`; smoke test, workflow, and gitignore track the new name

**Docs**
- `docs/guides/releasing.md`: npm publishing section, one-time bootstrap (manual first publish + trusted-publisher config), hardening recommendation
- Root README: `npm install -g @qredence/fleet` as the primary install path

## One-time bootstrap after merge (repo owner)

1. `npm login`, then `npm publish ./packages/fleet-prime --access public` (first publish of a new package cannot use OIDC)
2. Configure the trusted publisher at `https://www.npmjs.com/package/@qredence/fleet/access`: org `Qredence`, repo `fleet-prime-agent`, workflow `release-fleet.yml`, allow `npm publish`
3. First tagged release: `v0.2.0` (do not tag `v0.1.0`; the manual publish covers it)

## Validation

- `pnpm run check`
- `node scripts/check-web-release.mjs` (pack, global install as `@qredence/fleet`, boot, HTTP checks)
- `npm publish --dry-run`: warning-free, 864 files
