### PR TITLE
fix(release): title GitHub releases 'Fleet Prime v<version>'

### DIFF
--- a/scripts/publish-github-release.mjs
+++ b/scripts/publish-github-release.mjs
@@ -93,7 +93,7 @@ async function findOrCreateRelease(token, version, owner, repo, sha) {
 		body: JSON.stringify({
 			tag_name: tag,
 			target_commitish: sha,
-			name: tag,
+			name: `Fleet Prime v${version}`,
 			body: releaseNotes(version),
 			prerelease: version.includes("-"),
 		}),


### PR DESCRIPTION
Follows the Fleet Prime v0.2.0–v0.4.0 convention so pipeline-created releases stop as bare tag names (v0.5.0 was renamed by hand). One-line change in scripts/publish-github-release.mjs.