### PR TITLE
chore(release): version @qredence/fleet 0.5.5

### DIFF
--- a/.changeset/bright-wolves-build.md
+++ b/.changeset/bright-wolves-build.md
@@ -1,5 +1,0 @@
----
-"@qredence/fleet": patch
----
-
-Adds first-class read-only subagent conversation tabs with resilient live and snapshot transcript handling.

--- a/.changeset/giant-baths-pump.md
+++ b/.changeset/giant-baths-pump.md
@@ -1,5 +1,0 @@
----
-"@qredence/fleet": patch
----
-
-adding changeset

--- a/packages/fleet-web/CHANGELOG.md
+++ b/packages/fleet-web/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.5.5
+
+### Patch Changes
+
+- 6f6db1c: Adds first-class read-only subagent conversation tabs with resilient live and snapshot transcript handling.
+- 2a1e883: adding changeset
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/fleet-web/package.json
+++ b/packages/fleet-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qredence/fleet",
-  "version": "0.5.1",
+  "version": "0.5.5",
   "description": "Fleet Prime: local web interface and launcher for the pinned Prime Agent runtime",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Description
This pull request updates the `@qredence/fleet` package to version `0.5.5` and documents recent changes. The main improvement is the introduction of first-class read-only subagent conversation tabs, enhancing transcript handling. The changes also include changelog updates and version bumps.

Release and feature updates:

* Updated `@qredence/fleet` to version `0.5.5` in `package.json` to reflect new changes.
* Added changelog entries in `CHANGELOG.md` for version `0.5.5`, detailing the addition of read-only subagent conversation tabs with resilient live and snapshot transcript handling, and the addition of a changeset.

Cleanup:

* Removed obsolete changeset files `.changeset/bright-wolves-build.md` and `.changeset/giant-baths-pump.md` as their changes are now reflected in the changelog. [[1]](diffhunk://#diff-fbbcc4efbfe40400e7ebe5530af6f96059659ae8276b18cb107a2eb013a4d533L1-L5) [[2]](diffhunk://#diff-27f8d86374fb132f4c2fbe83556c82c1a76775827db8ab1d8dee8cfebf18c99aL1-L5)