### PR TITLE
perf(web): shrink welcome eager graph, defer heavy UI, add vitals telemetry

### DIFF
--- a/.changeset/tidy-pandas-shake.md
+++ b/.changeset/tidy-pandas-shake.md
@@ -1,0 +1,5 @@
+---
+"@qredence/fleet": patch
+---
+
+Shrinks the welcome-route eager JavaScript bundle (~7%) by lazy-loading chat panels, timelines, and pickers behind skeleton fallbacks, isolates composer keystrokes from transcript re-renders, and adds zero-dependency LCP/INP/CLS telemetry plus a bundle-budget snapshot for CI.

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview",
     "typecheck": "tsgo --noEmit",
     "test": "vitest run",
+    "bench": "vitest bench --config vitest.bench.config.ts",
     "test:watch": "vitest",
     "test:e2e": "playwright test"
   },

--- a/web/app/playwright/perf-smoke.spec.ts
+++ b/web/app/playwright/perf-smoke.spec.ts
@@ -50,13 +50,11 @@ test.describe("performance smoke", () => {
 		const composer = page.locator('textarea, [contenteditable="true"], [data-chat-input]')
 		await expect(composer.first()).toBeVisible({ timeout: 15_000 })
 
-		const lcp = await page.evaluate(
+		const lcpPromise = page.evaluate(
 			() =>
 				new Promise<number>((resolve) => {
 					let latest = -1
 					let observer: PerformanceObserver
-					let quietPeriod: number | undefined
-					let timeout: number | undefined
 					let settled = false
 					const updateLatest = (entries: PerformanceEntryList) => {
 						const entry = entries[entries.length - 1]
@@ -66,25 +64,32 @@ test.describe("performance smoke", () => {
 						if (settled) return
 						settled = true
 						updateLatest(observer.takeRecords())
-						if (quietPeriod !== undefined) window.clearTimeout(quietPeriod)
-						if (timeout !== undefined) window.clearTimeout(timeout)
 						observer.disconnect()
+						for (const eventName of interactionEvents) {
+							window.removeEventListener(eventName, finishOnInteraction, true)
+						}
 						document.removeEventListener("visibilitychange", finishOnVisibilityChange)
+						window.removeEventListener("pagehide", finish)
 						resolve(latest)
 					}
+					const finishOnInteraction = () => finish()
 					const finishOnVisibilityChange = () => {
 						if (document.visibilityState === "hidden") finish()
 					}
+					const interactionEvents = ["pointerdown", "keydown", "touchstart"] as const
 					observer = new PerformanceObserver((list) => {
 						updateLatest(list.getEntries())
-						if (quietPeriod !== undefined) window.clearTimeout(quietPeriod)
-						quietPeriod = window.setTimeout(finish, 250)
 					})
 					observer.observe({ type: "largest-contentful-paint", buffered: true })
+					for (const eventName of interactionEvents) {
+						window.addEventListener(eventName, finishOnInteraction, true)
+					}
 					document.addEventListener("visibilitychange", finishOnVisibilityChange)
-					timeout = window.setTimeout(finish, 10_000)
+					window.addEventListener("pagehide", finish)
 				}),
 		)
+		await composer.first().click()
+		const lcp = await lcpPromise
 
 		expect(lcp).toBeGreaterThanOrEqual(0)
 		expect(lcp).toBeLessThan(4_000)

--- a/web/app/playwright/perf-smoke.spec.ts
+++ b/web/app/playwright/perf-smoke.spec.ts
@@ -55,11 +55,12 @@ test.describe("performance smoke", () => {
 				new Promise<number>((resolve) => {
 					const timeout = setTimeout(() => resolve(-1), 10_000)
 					new PerformanceObserver((list, observer) => {
-						for (const entry of list.getEntries()) {
+						const entries = list.getEntries()
+						const entry = entries[entries.length - 1]
+						if (entry) {
 							clearTimeout(timeout)
 							observer.disconnect()
 							resolve(entry.startTime)
-							return
 						}
 					}).observe({ type: "largest-contentful-paint", buffered: true })
 				}),

--- a/web/app/playwright/perf-smoke.spec.ts
+++ b/web/app/playwright/perf-smoke.spec.ts
@@ -53,16 +53,36 @@ test.describe("performance smoke", () => {
 		const lcp = await page.evaluate(
 			() =>
 				new Promise<number>((resolve) => {
-					const timeout = setTimeout(() => resolve(-1), 10_000)
-					new PerformanceObserver((list, observer) => {
-						const entries = list.getEntries()
+					let latest = -1
+					let observer: PerformanceObserver
+					let quietPeriod: number | undefined
+					let timeout: number | undefined
+					let settled = false
+					const updateLatest = (entries: PerformanceEntryList) => {
 						const entry = entries[entries.length - 1]
-						if (entry) {
-							clearTimeout(timeout)
-							observer.disconnect()
-							resolve(entry.startTime)
-						}
-					}).observe({ type: "largest-contentful-paint", buffered: true })
+						if (entry) latest = entry.startTime
+					}
+					const finish = () => {
+						if (settled) return
+						settled = true
+						updateLatest(observer.takeRecords())
+						if (quietPeriod !== undefined) window.clearTimeout(quietPeriod)
+						if (timeout !== undefined) window.clearTimeout(timeout)
+						observer.disconnect()
+						document.removeEventListener("visibilitychange", finishOnVisibilityChange)
+						resolve(latest)
+					}
+					const finishOnVisibilityChange = () => {
+						if (document.visibilityState === "hidden") finish()
+					}
+					observer = new PerformanceObserver((list) => {
+						updateLatest(list.getEntries())
+						if (quietPeriod !== undefined) window.clearTimeout(quietPeriod)
+						quietPeriod = window.setTimeout(finish, 250)
+					})
+					observer.observe({ type: "largest-contentful-paint", buffered: true })
+					document.addEventListener("visibilitychange", finishOnVisibilityChange)
+					timeout = window.setTimeout(finish, 10_000)
 				}),
 		)
 

--- a/web/app/playwright/perf-smoke.spec.ts
+++ b/web/app/playwright/perf-smoke.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from "@playwright/test"
+
+// Perf smoke: runtime mirror of web/app/scripts/check-bundle-budget.mjs.
+//
+// While the budget script audits the static import graph at build time, this
+// spec asserts the same invariant at runtime: loading `/` must not fetch the
+// heavy deferred chunks (panels, OpenUI renderer, charts, syntax
+// highlighting), and first paint must land within an LCP budget.
+const FORBIDDEN_CHUNK_PATTERNS = [
+	/openui-renderer/i,
+	/settings-dialog/i,
+	/markdown-code/i,
+	/artifacts-panel/i,
+	/resources-panel/i,
+	/session-insights-panel/i,
+	/workspace-panel/i,
+	/fleet-tool-timeline/i,
+	/fleet-subagent-list/i,
+	/fleet-reasoning-panel/i,
+	/prompt-suggestions/i,
+	/fleet-message-queue/i,
+	/agent-activity/i,
+	/model-selector-list/i,
+	/command-/i,
+]
+
+test.describe("performance smoke", () => {
+	test("welcome load fetches no deferred chunks", async ({ page }) => {
+		const forbidden: Array<string> = []
+		page.on("response", (response) => {
+			const url = response.url()
+			if (!url.endsWith(".js")) return
+			const file = url.split("/").pop() ?? url
+			if (FORBIDDEN_CHUNK_PATTERNS.some((pattern) => pattern.test(file))) {
+				forbidden.push(file)
+			}
+		})
+
+		await page.goto("/")
+		const composer = page.locator('textarea, [contenteditable="true"], [data-chat-input]')
+		await expect(composer.first()).toBeVisible({ timeout: 15_000 })
+		// Let any eager follow-up fetches settle.
+		await page.waitForTimeout(2_000)
+
+		expect(forbidden).toEqual([])
+	})
+
+	test("welcome LCP stays within budget", async ({ page }) => {
+		await page.goto("/")
+		const composer = page.locator('textarea, [contenteditable="true"], [data-chat-input]')
+		await expect(composer.first()).toBeVisible({ timeout: 15_000 })
+
+		const lcp = await page.evaluate(
+			() =>
+				new Promise<number>((resolve) => {
+					const timeout = setTimeout(() => resolve(-1), 10_000)
+					new PerformanceObserver((list, observer) => {
+						for (const entry of list.getEntries()) {
+							clearTimeout(timeout)
+							observer.disconnect()
+							resolve(entry.startTime)
+							return
+						}
+					}).observe({ type: "largest-contentful-paint", buffered: true })
+				}),
+		)
+
+		expect(lcp).toBeGreaterThanOrEqual(0)
+		expect(lcp).toBeLessThan(4_000)
+	})
+})

--- a/web/app/scripts/check-bundle-budget.mjs
+++ b/web/app/scripts/check-bundle-budget.mjs
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync } from "node:fs"
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs"
 import { basename, join, resolve } from "node:path"
 import { gzipSync } from "node:zlib"
 
@@ -57,8 +57,8 @@ for (const file of eagerFiles) {
     violations.push(`${file} must not be in the welcome route eager graph`)
   }
   const source = readFileSync(join(assetsDirectory, file), "utf8")
-  if (/\brecharts\b|createHighlighter|from["']shiki["']/.test(source)) {
-    violations.push(`${file} eagerly contains Recharts or Shiki implementation code`)
+  if (/\brecharts\b|createHighlighter|from["']shiki["']|streamdown|lottie-react|\bcmdk\b/.test(source)) {
+    violations.push(`${file} eagerly contains Recharts, Shiki, Streamdown, Lottie, or cmdk implementation code`)
   }
 }
 
@@ -71,3 +71,23 @@ if (violations.length > 0) {
     `Bundle contract passed (${eagerFiles.size} eager files, ${eagerGzipBytes} bytes gzip, ${(reduction * 100).toFixed(1)}% route-entry reduction).`,
   )
 }
+
+// Machine-readable snapshot for CI artifact storage (bundle-over-time
+// tracking with no new service). Written on pass AND fail.
+writeFileSync(
+  resolve(assetsDirectory, "..", "bundle-budget.json"),
+  JSON.stringify(
+    {
+      timestamp: new Date().toISOString(),
+      routeEntry: routeEntries[0],
+      routeEntryGzipBytes,
+      routeEntryReduction: reduction,
+      eagerFiles: eagerFiles.size,
+      eagerGzipBytes,
+      passed: violations.length === 0,
+      violations,
+    },
+    null,
+    2,
+  ) + "\n",
+)

--- a/web/app/scripts/check-bundle-budget.mjs
+++ b/web/app/scripts/check-bundle-budget.mjs
@@ -57,7 +57,7 @@ for (const file of eagerFiles) {
     violations.push(`${file} must not be in the welcome route eager graph`)
   }
   const source = readFileSync(join(assetsDirectory, file), "utf8")
-  if (/\brecharts\b|createHighlighter|from["']shiki["']|streamdown|lottie-react|\bcmdk\b/.test(source)) {
+  if (/\brecharts\b|createHighlighter|from\s*["']shiki["']|streamdown|lottie-react|\bcmdk\b/.test(source)) {
     violations.push(`${file} eagerly contains Recharts, Shiki, Streamdown, Lottie, or cmdk implementation code`)
   }
 }

--- a/web/app/src/lib/analytics-stub.test.ts
+++ b/web/app/src/lib/analytics-stub.test.ts
@@ -35,15 +35,29 @@ function entry(values: Partial<PerformanceEntry> & Record<string, unknown>): Per
 
 describe("initAnalytics web vitals", () => {
 	let debug: ReturnType<typeof vi.spyOn>;
+	let addEventListener: ReturnType<typeof vi.spyOn>;
+	let interactionCountDescriptor: PropertyDescriptor | undefined;
 
 	beforeEach(() => {
 		FakePerformanceObserver.instances = [];
 		vi.stubGlobal("PerformanceObserver", FakePerformanceObserver);
 		debug = vi.spyOn(console, "debug").mockImplementation(() => {});
+		addEventListener = vi.spyOn(window, "addEventListener");
+		interactionCountDescriptor = Object.getOwnPropertyDescriptor(performance, "interactionCount");
 		delete (window as unknown as { __fleetVitalsInit?: boolean }).__fleetVitalsInit;
 	});
 
 	afterEach(() => {
+		for (const [type, listener, options] of addEventListener.mock.calls) {
+			if (type === "pageshow") {
+				window.removeEventListener(type, listener as EventListener, options);
+			}
+		}
+		if (interactionCountDescriptor) {
+			Object.defineProperty(performance, "interactionCount", interactionCountDescriptor);
+		} else {
+			Reflect.deleteProperty(performance, "interactionCount");
+		}
 		delete (window as unknown as { __fleetVitalsInit?: boolean }).__fleetVitalsInit;
 		vi.restoreAllMocks();
 		vi.unstubAllGlobals();
@@ -73,5 +87,41 @@ describe("initAnalytics web vitals", () => {
 		window.dispatchEvent(new Event("pagehide"));
 
 		expect(debug.mock.calls).toEqual([["[vitals] LCP: 300"], ["[vitals] CLS: 2"], ["[vitals] INP: 120"]]);
+	});
+
+	it("uses the INP p98 estimate for interaction-heavy pages", () => {
+		Object.defineProperty(performance, "interactionCount", { configurable: true, value: 100 });
+		initAnalytics();
+
+		const inp = FakePerformanceObserver.instances[2];
+		inp.emit(Array.from({ length: 100 }, (_, index) => entry({ interactionId: index + 1, duration: index + 1 })));
+		window.dispatchEvent(new Event("pagehide"));
+
+		expect(debug).toHaveBeenCalledWith("[vitals] INP: 98");
+	});
+
+	it("recreates measurement state after a bfcache restore", () => {
+		initAnalytics();
+		const [lcp] = FakePerformanceObserver.instances;
+		lcp.emit([entry({ startTime: 100 })]);
+		window.dispatchEvent(new Event("pagehide"));
+
+		const pageshow = new Event("pageshow");
+		Object.defineProperty(pageshow, "persisted", { value: true });
+		window.dispatchEvent(pageshow);
+
+		expect(FakePerformanceObserver.instances).toHaveLength(6);
+		const [restoredLcp, restoredCls, restoredInp] = FakePerformanceObserver.instances.slice(3);
+		restoredLcp.emit([entry({ startTime: 500 })]);
+		restoredCls.emit([entry({ startTime: 500, value: 0.25, hadRecentInput: false })]);
+		restoredInp.emit([entry({ interactionId: 9, duration: 90 })]);
+		window.dispatchEvent(new Event("pagehide"));
+
+		expect(debug.mock.calls).toEqual([
+			["[vitals] LCP: 100"],
+			["[vitals] LCP: 500"],
+			["[vitals] CLS: 0"],
+			["[vitals] INP: 90"],
+		]);
 	});
 });

--- a/web/app/src/lib/analytics-stub.test.ts
+++ b/web/app/src/lib/analytics-stub.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { initAnalytics } from "./analytics-stub";
+
+type FakePerformanceObserverList = {
+	getEntries: () => PerformanceEntryList;
+};
+
+class FakePerformanceObserver {
+	static instances: FakePerformanceObserver[] = [];
+
+	private pendingEntries: PerformanceEntryList = [];
+
+	constructor(private readonly callback: (list: FakePerformanceObserverList) => void) {
+		FakePerformanceObserver.instances.push(this);
+	}
+
+	observe(_options: PerformanceObserverInit): void {}
+
+	disconnect(): void {}
+
+	takeRecords(): PerformanceEntryList {
+		const entries = this.pendingEntries;
+		this.pendingEntries = [];
+		return entries;
+	}
+
+	emit(entries: PerformanceEntryList): void {
+		this.callback({ getEntries: () => entries });
+	}
+}
+
+function entry(values: Partial<PerformanceEntry> & Record<string, unknown>): PerformanceEntry {
+	return values as PerformanceEntry;
+}
+
+describe("initAnalytics web vitals", () => {
+	let debug: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		FakePerformanceObserver.instances = [];
+		vi.stubGlobal("PerformanceObserver", FakePerformanceObserver);
+		debug = vi.spyOn(console, "debug").mockImplementation(() => {});
+		delete (window as unknown as { __fleetVitalsInit?: boolean }).__fleetVitalsInit;
+	});
+
+	afterEach(() => {
+		delete (window as unknown as { __fleetVitalsInit?: boolean }).__fleetVitalsInit;
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+	});
+
+	it("reports finalized LCP, CLS, and INP values at the page boundary", () => {
+		initAnalytics();
+		expect(FakePerformanceObserver.instances).toHaveLength(3);
+
+		const [lcp, cls, inp] = FakePerformanceObserver.instances;
+		lcp.emit([entry({ startTime: 100 }), entry({ startTime: 300 })]);
+		cls.emit([
+			entry({ startTime: 100, value: 0.1, hadRecentInput: false }),
+			entry({ startTime: 500, value: 0.2, hadRecentInput: false }),
+			entry({ startTime: 2_000, value: 0.8, hadRecentInput: false }),
+			entry({ startTime: 2_100, value: 99, hadRecentInput: true }),
+			entry({ startTime: 2_500, value: 0.9, hadRecentInput: false }),
+		]);
+		inp.emit([
+			entry({ interactionId: 7, duration: 60 }),
+			entry({ interactionId: 7, duration: 120 }),
+			entry({ interactionId: 8, duration: 80 }),
+		]);
+
+		expect(debug).not.toHaveBeenCalled();
+
+		window.dispatchEvent(new Event("pagehide"));
+
+		expect(debug.mock.calls).toEqual([["[vitals] LCP: 300"], ["[vitals] CLS: 2"], ["[vitals] INP: 120"]]);
+	});
+});

--- a/web/app/src/lib/analytics-stub.ts
+++ b/web/app/src/lib/analytics-stub.ts
@@ -18,12 +18,16 @@ function observeWebVitals(onVital: (vital: WebVital) => void): () => void {
 	}
 	const url = window.location.pathname;
 	const observers: Array<PerformanceObserver> = [];
+	let lcpValue: number | undefined;
+	let lcpReported = false;
+	let pageMetricsReported = false;
 	try {
 		const lcp = new PerformanceObserver((list) => {
+			if (lcpReported) return;
 			const entries = list.getEntries();
 			const entry = entries[entries.length - 1];
 			if (entry) {
-				onVital({ name: "LCP", value: entry.startTime, url });
+				lcpValue = entry.startTime;
 			}
 		});
 		lcp.observe({ type: "largest-contentful-paint", buffered: true });
@@ -34,9 +38,8 @@ function observeWebVitals(onVital: (vital: WebVital) => void): () => void {
 		let clsSessionStart = 0;
 		let clsSessionEnd = 0;
 		let hasClsSession = false;
-		const cls = new PerformanceObserver((list) => {
-			let measuredLayoutShift = false;
-			for (const entry of list.getEntries()) {
+		const processClsEntries = (entries: PerformanceEntryList) => {
+			for (const entry of entries) {
 				const layoutEntry = entry as PerformanceEntry & {
 					hadRecentInput?: boolean;
 					value?: number;
@@ -56,18 +59,16 @@ function observeWebVitals(onVital: (vital: WebVital) => void): () => void {
 					hasClsSession = true;
 					clsSessionEnd = entry.startTime;
 					clsValue = Math.max(clsValue, clsSessionValue);
-					measuredLayoutShift = true;
 				}
 			}
-			if (measuredLayoutShift) onVital({ name: "CLS", value: clsValue, url });
-		});
+		};
+		const cls = new PerformanceObserver((list) => processClsEntries(list.getEntries()));
 		cls.observe({ type: "layout-shift", buffered: true });
 		observers.push(cls);
 
 		const interactionDurations = new Map<number, number>();
-		const inp = new PerformanceObserver((list) => {
-			let measuredInteraction = false;
-			for (const entry of list.getEntries()) {
+		const processInteractionEntries = (entries: PerformanceEntryList) => {
+			for (const entry of entries) {
 				const eventEntry = entry as PerformanceEntry & {
 					interactionId?: number;
 					duration?: number;
@@ -77,15 +78,52 @@ function observeWebVitals(onVital: (vital: WebVital) => void): () => void {
 						eventEntry.interactionId,
 						Math.max(interactionDurations.get(eventEntry.interactionId) ?? 0, eventEntry.duration ?? 0),
 					);
-					measuredInteraction = true;
 				}
 			}
-			if (measuredInteraction) {
-				onVital({ name: "INP", value: Math.max(...interactionDurations.values()), url });
-			}
-		});
+		};
+		const inp = new PerformanceObserver((list) => processInteractionEntries(list.getEntries()));
 		inp.observe({ type: "event", buffered: true, durationThreshold: 40 } as PerformanceObserverInit);
 		observers.push(inp);
+
+		const finalizeLcp = () => {
+			if (lcpReported) return;
+			const pendingEntries = lcp.takeRecords();
+			const entry = pendingEntries[pendingEntries.length - 1];
+			if (entry) lcpValue = entry.startTime;
+			lcpReported = true;
+			if (lcpValue !== undefined) onVital({ name: "LCP", value: lcpValue, url });
+		};
+		const finalizePageMetrics = () => {
+			if (pageMetricsReported) return;
+			finalizeLcp();
+			processClsEntries(cls.takeRecords());
+			processInteractionEntries(inp.takeRecords());
+			pageMetricsReported = true;
+			if (hasClsSession) onVital({ name: "CLS", value: clsValue, url });
+			if (interactionDurations.size > 0) {
+				onVital({ name: "INP", value: Math.max(...interactionDurations.values()), url });
+			}
+		};
+		const finalizeLcpOnInteraction = () => finalizeLcp();
+		const finalizeOnVisibilityChange = () => {
+			if (document.visibilityState === "hidden") finalizePageMetrics();
+		};
+		const interactionEvents = ["pointerdown", "keydown", "touchstart"] as const;
+		for (const eventName of interactionEvents) {
+			window.addEventListener(eventName, finalizeLcpOnInteraction, { capture: true });
+		}
+		document.addEventListener("visibilitychange", finalizeOnVisibilityChange);
+		window.addEventListener("pagehide", finalizePageMetrics);
+
+		return () => {
+			finalizePageMetrics();
+			for (const eventName of interactionEvents) {
+				window.removeEventListener(eventName, finalizeLcpOnInteraction, { capture: true });
+			}
+			document.removeEventListener("visibilitychange", finalizeOnVisibilityChange);
+			window.removeEventListener("pagehide", finalizePageMetrics);
+			for (const observer of observers) observer.disconnect();
+		};
 	} catch {
 		// PerformanceObserver types vary by browser; vitals are best-effort.
 	}

--- a/web/app/src/lib/analytics-stub.ts
+++ b/web/app/src/lib/analytics-stub.ts
@@ -94,6 +94,11 @@ function observeWebVitals(onVital: (vital: WebVital) => void): () => void {
 	};
 }
 
+/**
+ * Initializes web vitals tracking for performance monitoring. Observes LCP,
+ * INP, and CLS metrics and reports them to the console in development or
+ * beacons them to the analytics endpoint in production.
+ */
 export function initAnalytics(): void {
 	if (typeof window === "undefined") return;
 	if ((window as unknown as { __fleetVitalsInit?: boolean }).__fleetVitalsInit) return;

--- a/web/app/src/lib/analytics-stub.ts
+++ b/web/app/src/lib/analytics-stub.ts
@@ -1,6 +1,89 @@
 // v1: no analytics. All imports of @/lib/analytics/posthog funnel through here.
 
-export function initAnalytics(): void {}
+type WebVital = {
+	name: "LCP" | "INP" | "CLS";
+	value: number;
+	url: string;
+};
+
+/**
+ * Hand-rolled LCP/INP/CLS observer — zero dependencies by design (do NOT add
+ * the `web-vitals` package for this). In DEV it logs to the console; in
+ * production it beacons a JSON payload to `/api/analytics/vitals` (fire and
+ * forget; the endpoint is optional — failures are silently ignored).
+ */
+function observeWebVitals(onVital: (vital: WebVital) => void): () => void {
+	if (typeof window === "undefined" || typeof PerformanceObserver === "undefined") {
+		return () => {};
+	}
+	const url = window.location.pathname;
+	const observers: Array<PerformanceObserver> = [];
+	try {
+		const lcp = new PerformanceObserver((list) => {
+			for (const entry of list.getEntries()) {
+				onVital({ name: "LCP", value: entry.startTime, url });
+			}
+		});
+		lcp.observe({ type: "largest-contentful-paint", buffered: true });
+		observers.push(lcp);
+
+		let clsValue = 0;
+		const cls = new PerformanceObserver((list) => {
+			for (const entry of list.getEntries()) {
+				const layoutEntry = entry as PerformanceEntry & {
+					hadRecentInput?: boolean;
+					value?: number;
+				};
+				if (!layoutEntry.hadRecentInput) {
+					clsValue += layoutEntry.value ?? 0;
+					onVital({ name: "CLS", value: clsValue, url });
+				}
+			}
+		});
+		cls.observe({ type: "layout-shift", buffered: true });
+		observers.push(cls);
+
+		const inp = new PerformanceObserver((list) => {
+			for (const entry of list.getEntries()) {
+				const eventEntry = entry as PerformanceEntry & {
+					interactionId?: number;
+					duration?: number;
+				};
+				if (eventEntry.interactionId) {
+					onVital({ name: "INP", value: eventEntry.duration ?? 0, url });
+				}
+			}
+		});
+		inp.observe({ type: "event", buffered: true, durationThreshold: 40 } as PerformanceObserverInit);
+		observers.push(inp);
+	} catch {
+		// PerformanceObserver types vary by browser; vitals are best-effort.
+	}
+	return () => {
+		for (const observer of observers) observer.disconnect();
+	};
+}
+
+export function initAnalytics(): void {
+	if (typeof window === "undefined") return;
+	if ((window as unknown as { __fleetVitalsInit?: boolean }).__fleetVitalsInit) return;
+	(window as unknown as { __fleetVitalsInit?: boolean }).__fleetVitalsInit = true;
+	const report = (vital: WebVital) => {
+		if (import.meta.env.DEV) {
+			console.debug(`[vitals] ${vital.name}: ${Math.round(vital.value)}`);
+			return;
+		}
+		try {
+			const payload = JSON.stringify(vital);
+			if (navigator.sendBeacon) {
+				navigator.sendBeacon("/api/analytics/vitals", payload);
+			}
+		} catch {
+			// Telemetry must never break the app.
+		}
+	};
+	observeWebVitals(report);
+}
 
 export function identifyAnalyticsUser(_user: unknown): void {}
 

--- a/web/app/src/lib/analytics-stub.ts
+++ b/web/app/src/lib/analytics-stub.ts
@@ -20,7 +20,9 @@ function observeWebVitals(onVital: (vital: WebVital) => void): () => void {
 	const observers: Array<PerformanceObserver> = [];
 	try {
 		const lcp = new PerformanceObserver((list) => {
-			for (const entry of list.getEntries()) {
+			const entries = list.getEntries();
+			const entry = entries[entries.length - 1];
+			if (entry) {
 				onVital({ name: "LCP", value: entry.startTime, url });
 			}
 		});
@@ -28,30 +30,58 @@ function observeWebVitals(onVital: (vital: WebVital) => void): () => void {
 		observers.push(lcp);
 
 		let clsValue = 0;
+		let clsSessionValue = 0;
+		let clsSessionStart = 0;
+		let clsSessionEnd = 0;
+		let hasClsSession = false;
 		const cls = new PerformanceObserver((list) => {
+			let measuredLayoutShift = false;
 			for (const entry of list.getEntries()) {
 				const layoutEntry = entry as PerformanceEntry & {
 					hadRecentInput?: boolean;
 					value?: number;
 				};
 				if (!layoutEntry.hadRecentInput) {
-					clsValue += layoutEntry.value ?? 0;
-					onVital({ name: "CLS", value: clsValue, url });
+					const entryValue = layoutEntry.value ?? 0;
+					if (
+						hasClsSession &&
+						entry.startTime - clsSessionEnd < 1_000 &&
+						entry.startTime - clsSessionStart < 5_000
+					) {
+						clsSessionValue += entryValue;
+					} else {
+						clsSessionValue = entryValue;
+						clsSessionStart = entry.startTime;
+					}
+					hasClsSession = true;
+					clsSessionEnd = entry.startTime;
+					clsValue = Math.max(clsValue, clsSessionValue);
+					measuredLayoutShift = true;
 				}
 			}
+			if (measuredLayoutShift) onVital({ name: "CLS", value: clsValue, url });
 		});
 		cls.observe({ type: "layout-shift", buffered: true });
 		observers.push(cls);
 
+		const interactionDurations = new Map<number, number>();
 		const inp = new PerformanceObserver((list) => {
+			let measuredInteraction = false;
 			for (const entry of list.getEntries()) {
 				const eventEntry = entry as PerformanceEntry & {
 					interactionId?: number;
 					duration?: number;
 				};
 				if (eventEntry.interactionId) {
-					onVital({ name: "INP", value: eventEntry.duration ?? 0, url });
+					interactionDurations.set(
+						eventEntry.interactionId,
+						Math.max(interactionDurations.get(eventEntry.interactionId) ?? 0, eventEntry.duration ?? 0),
+					);
+					measuredInteraction = true;
 				}
+			}
+			if (measuredInteraction) {
+				onVital({ name: "INP", value: Math.max(...interactionDurations.values()), url });
 			}
 		});
 		inp.observe({ type: "event", buffered: true, durationThreshold: 40 } as PerformanceObserverInit);

--- a/web/app/src/lib/analytics-stub.ts
+++ b/web/app/src/lib/analytics-stub.ts
@@ -81,6 +81,19 @@ function observeWebVitals(onVital: (vital: WebVital) => void): () => void {
 				}
 			}
 		};
+		const getFinalInpValue = (): number | undefined => {
+			if (interactionDurations.size === 0) return undefined;
+			const durations = [...interactionDurations.values()].sort((a, b) => a - b);
+			const interactionCount = (performance as Performance & { interactionCount?: number }).interactionCount;
+			const totalInteractionCount =
+				typeof interactionCount === "number" && Number.isFinite(interactionCount)
+					? Math.max(interactionCount, durations.length)
+					: durations.length;
+			// INP estimates the 98th percentile by dropping one worst interaction per 50.
+			const ignoredWorstInteractions = Math.floor(totalInteractionCount / 50);
+			const percentileIndex = Math.max(0, durations.length - ignoredWorstInteractions - 1);
+			return durations[percentileIndex];
+		};
 		const inp = new PerformanceObserver((list) => processInteractionEntries(list.getEntries()));
 		inp.observe({ type: "event", buffered: true, durationThreshold: 40 } as PerformanceObserverInit);
 		observers.push(inp);
@@ -100,8 +113,9 @@ function observeWebVitals(onVital: (vital: WebVital) => void): () => void {
 			processInteractionEntries(inp.takeRecords());
 			pageMetricsReported = true;
 			if (hasClsSession) onVital({ name: "CLS", value: clsValue, url });
-			if (interactionDurations.size > 0) {
-				onVital({ name: "INP", value: Math.max(...interactionDurations.values()), url });
+			const inpValue = getFinalInpValue();
+			if (inpValue !== undefined) {
+				onVital({ name: "INP", value: inpValue, url });
 			}
 		};
 		const finalizeLcpOnInteraction = () => finalizeLcp();
@@ -155,7 +169,13 @@ export function initAnalytics(): void {
 			// Telemetry must never break the app.
 		}
 	};
-	observeWebVitals(report);
+	let stopObserving = observeWebVitals(report);
+	window.addEventListener("pageshow", (event) => {
+		if (event.persisted) {
+			stopObserving();
+			stopObserving = observeWebVitals(report);
+		}
+	});
 }
 
 export function identifyAnalyticsUser(_user: unknown): void {}

--- a/web/app/src/lib/pi/perf/chat-render.bench.tsx
+++ b/web/app/src/lib/pi/perf/chat-render.bench.tsx
@@ -30,6 +30,13 @@ const inputBar = {
 
 const noop = () => {};
 
+/**
+ * Generates a single conversation turn with a user question and assistant
+ * response containing text and a tool call.
+ *
+ * @param index - Turn identifier used to generate unique message IDs and content
+ * @returns Array containing user and assistant messages for one conversation turn
+ */
 function textTurn(index: number): Array<ChatMessage> {
 	return [
 		{ id: `user-${index}`, role: "user", parts: [{ type: "text", text: `Question ${index}: explain the upload flow.` }] },
@@ -44,10 +51,22 @@ function textTurn(index: number): Array<ChatMessage> {
 	];
 }
 
+/**
+ * Generates a 50-turn conversation for rendering benchmarks.
+ *
+ * @returns Flattened array of chat messages representing 50 conversation turns
+ */
 function fiftyTurns(): Array<ChatMessage> {
 	return Array.from({ length: 50 }, (_, index) => textTurn(index)).flat();
 }
 
+/**
+ * Renders the FleetPiAgentChat component with the provided messages for
+ * benchmark testing.
+ *
+ * @param messages - Chat messages to render
+ * @returns Testing library render result for the mounted chat component
+ */
 function renderChat(messages: Array<ChatMessage>) {
 	return render(
 		<FleetPiAgentChat

--- a/web/app/src/lib/pi/perf/chat-render.bench.tsx
+++ b/web/app/src/lib/pi/perf/chat-render.bench.tsx
@@ -1,0 +1,111 @@
+// Render benchmarks for the Fleet Prime chat surface.
+//
+// Run: pnpm --filter @prime-agent/web bench
+// (vitest bench only; these files never run under `vitest run`.)
+//
+// Numbers are comparative, not absolute: run on the perf branch, then on
+// clean main (`git stash -u`), and compare means. happy-dom timings carry
+// noise — look for >2x deltas, not single-digit percent moves.
+//
+// The keystroke bench (#3) intentionally includes a mount per iteration so it
+// needs no cross-iteration lifecycle: subtract the mount-only bench (#2) and
+// compare THAT delta across branches to isolate keystroke cost.
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ChatMessage } from "@prime-agent/web-protocol/chat-types";
+import { beforeAll, bench, describe, vi } from "vitest";
+import { FleetPiAgentChat } from "@prime-agent/web-design/components/product/fleet-pi/chat/fleet-pi-agent-chat";
+
+vi.mock("@prime-agent/web-design/components/openui/inline-renderer", () => ({
+	GenerativeTextRenderer: () => null,
+}));
+vi.mock("@prime-agent/web-design/components/openui/openui-renderer", () => ({
+	GenerativeTextRenderer: () => null,
+}));
+
+const inputBar = {
+	modelKey: undefined,
+	models: [],
+	onModelChange: vi.fn(),
+};
+
+const noop = () => {};
+
+function textTurn(index: number): Array<ChatMessage> {
+	return [
+		{ id: `user-${index}`, role: "user", parts: [{ type: "text", text: `Question ${index}: explain the upload flow.` }] },
+		{
+			id: `assistant-${index}`,
+			role: "assistant",
+			parts: [
+				{ type: "text", text: `Answer ${index} with a fenced block:\n\n\`\`\`ts\nconst value_${index} = 42;\n\`\`\`` },
+				{ type: "tool-Bash", toolCallId: `tool-${index}`, input: { command: `ls ${index}` }, output: "done" },
+			],
+		},
+	];
+}
+
+function fiftyTurns(): Array<ChatMessage> {
+	return Array.from({ length: 50 }, (_, index) => textTurn(index)).flat();
+}
+
+function renderChat(messages: Array<ChatMessage>) {
+	return render(
+		<FleetPiAgentChat
+			inputBar={inputBar}
+			messages={messages}
+			onSend={noop}
+			onStop={noop}
+			status="ready"
+		/>,
+	);
+}
+
+describe("chat render", () => {
+	// Warm every async chunk once (activity/timeline/reasoning panels, model
+	// list, Shiki highlighting) so timed iterations measure render cost, not
+	// first-load fetching.
+	beforeAll(async () => {
+		const warmup = renderChat(fiftyTurns());
+		await screen.findByRole("button", { name: "1 tool action" });
+		await waitFor(() => {
+			if (warmup.container.querySelectorAll("pre").length === 0) {
+				throw new Error("waiting for highlighted code");
+			}
+		});
+		warmup.unmount();
+		const welcome = renderChat([]);
+		fireEvent.click(screen.getByRole("combobox", { name: "Select model and reasoning effort" }));
+		await screen.findByPlaceholderText("Search models…");
+		welcome.unmount();
+	}, 60_000);
+
+	bench(
+		"welcome mount (empty conversation)",
+		() => {
+			const view = renderChat([]);
+			view.unmount();
+		},
+		{ time: 500, warmupTime: 200, warmupIterations: 3 },
+	);
+
+	bench(
+		"50-turn conversation mount",
+		() => {
+			const view = renderChat(fiftyTurns());
+			view.unmount();
+		},
+		{ time: 1000, warmupTime: 300, warmupIterations: 2 },
+	);
+
+	let keystroke = 0;
+	bench(
+		"50-turn mount plus one keystroke",
+		() => {
+			const view = renderChat(fiftyTurns());
+			const composer = view.getByRole("textbox", { name: "Prompt" });
+			fireEvent.change(composer, { target: { value: `draft text ${keystroke++}` } });
+			view.unmount();
+		},
+		{ time: 1000, warmupTime: 300, warmupIterations: 2 },
+	);
+});

--- a/web/app/src/lib/pi/review-regressions.test.tsx
+++ b/web/app/src/lib/pi/review-regressions.test.tsx
@@ -93,7 +93,7 @@ describe("review regressions", () => {
 		expect(getByRole("button", { name: "1 tool action" }).getAttribute("aria-expanded")).toBe("true");
 	});
 
-	it("limits the active tool timeline to artifacts from the current turn", () => {
+	it("limits the active tool timeline to artifacts from the current turn", async () => {
 		const messages: Array<ChatMessage> = [
 			{ id: "user-1", role: "user", parts: [{ type: "text", text: "First turn" }] },
 			{
@@ -143,7 +143,7 @@ describe("review regressions", () => {
 			},
 		];
 
-		const { getAllByRole, queryByRole } = render(
+		const { findAllByRole, queryByRole } = render(
 			<FleetPiAgentChat
 				artifactRuns={artifactRuns}
 				inputBar={inputBar}
@@ -154,8 +154,10 @@ describe("review regressions", () => {
 			/>,
 		);
 
+		// Timeline and activity panels load lazily; wait for them first so the
+		// absence assertion below is meaningful instead of pre-load.
+		expect(await findAllByRole("button", { name: "1 tool action" })).toHaveLength(2);
 		expect(queryByRole("button", { name: "2 tool actions" })).toBeNull();
-		expect(getAllByRole("button", { name: "1 tool action" })).toHaveLength(2);
 	});
 
 	it("renders nested subagents in tree order regardless of completion order", () => {
@@ -211,8 +213,8 @@ describe("review regressions", () => {
 		await waitFor(() => expect(notifyError).toHaveBeenCalledWith("Unable to remove queued message"));
 	});
 
-	it("keeps completed reasoning presentation visible", () => {
-		const { getByLabelText } = render(
+	it("keeps completed reasoning presentation visible", async () => {
+		const { findByLabelText } = render(
 			<FleetPiAgentChat
 				inputBar={inputBar}
 				messages={[settledReasoningMessage()]}
@@ -222,7 +224,7 @@ describe("review regressions", () => {
 			/>,
 		);
 
-		expect(getByLabelText("Safe reasoning progress")).toBeTruthy();
+		expect(await findByLabelText("Safe reasoning progress")).toBeTruthy();
 	});
 
 	it("does not render legacy raw thinking parts", () => {

--- a/web/app/src/lib/pi/review-regressions.test.tsx
+++ b/web/app/src/lib/pi/review-regressions.test.tsx
@@ -143,7 +143,7 @@ describe("review regressions", () => {
 			},
 		];
 
-		const { findAllByRole, queryByRole } = render(
+		const { queryAllByRole, queryByRole } = render(
 			<FleetPiAgentChat
 				artifactRuns={artifactRuns}
 				inputBar={inputBar}
@@ -156,7 +156,7 @@ describe("review regressions", () => {
 
 		// Timeline and activity panels load lazily; wait for them first so the
 		// absence assertion below is meaningful instead of pre-load.
-		expect(await findAllByRole("button", { name: "1 tool action" })).toHaveLength(2);
+		await waitFor(() => expect(queryAllByRole("button", { name: "1 tool action" })).toHaveLength(2));
 		expect(queryByRole("button", { name: "2 tool actions" })).toBeNull();
 	});
 

--- a/web/app/src/lib/pi/use-kernel-health.ts
+++ b/web/app/src/lib/pi/use-kernel-health.ts
@@ -32,7 +32,12 @@ export function useKernelHealth(pollMs = 15_000) {
 			}
 		};
 		void tick();
-		const id = setInterval(() => void tick(), pollMs);
+		// Skip polling while the tab is hidden — health state goes stale but
+		// refreshes on the next visible tick instead of churning in background.
+		const id = setInterval(() => {
+			if (document.visibilityState === "hidden") return;
+			void tick();
+		}, pollMs);
 		return () => {
 			cancelled = true;
 			clearInterval(id);

--- a/web/app/vitest.bench.config.ts
+++ b/web/app/vitest.bench.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config"
+import viteReact from "@vitejs/plugin-react"
+
+// Dedicated bench config: `vitest run` must never pick up *.bench files
+// (bench() throws outside bench mode), so they live here instead of the
+// main include list. Invoked via `pnpm bench`.
+export default defineConfig({
+	resolve: {
+		tsconfigPaths: true,
+	},
+	plugins: [viteReact()],
+	test: {
+		environment: "happy-dom",
+		globals: true,
+		include: ["src/**/*.bench.{ts,tsx}"],
+	},
+})

--- a/web/design/src/components/openui/html-artifact.tsx
+++ b/web/design/src/components/openui/html-artifact.tsx
@@ -52,6 +52,7 @@ export function OpenUIHtmlFrame({
 			srcDoc={document}
 			referrerPolicy="no-referrer"
 			title={title}
+			loading="lazy"
 			className={`block w-full min-w-0 overflow-hidden rounded-md border border-border/60 bg-white ${className}`}
 		/>
 	);

--- a/web/design/src/components/product/fleet-pi/chat/beui-tool-renderer.tsx
+++ b/web/design/src/components/product/fleet-pi/chat/beui-tool-renderer.tsx
@@ -153,6 +153,8 @@ export const BeuiToolRenderer = memo(function BeuiToolRenderer({
           alt="Generated result"
           width={640}
           height={320}
+          loading="lazy"
+          decoding="async"
           className="h-auto max-h-80 w-full object-contain"
         />
       </ImageGeneration>

--- a/web/design/src/components/product/fleet-pi/chat/fleet-pi-agent-chat.tsx
+++ b/web/design/src/components/product/fleet-pi/chat/fleet-pi-agent-chat.tsx
@@ -1,5 +1,5 @@
 import { AlertCircle } from "lucide-react"
-import { lazy, memo, Suspense, useMemo, useState, type ComponentProps, type ReactNode } from "react"
+import { lazy, memo, Suspense, useCallback, useEffect, useMemo, useRef, useState, type ComponentProps, type ReactNode, type RefObject } from "react"
 import {
   Message,
   MessageBubble,
@@ -8,8 +8,8 @@ import {
 } from "../../../registry/beui/agents/message"
 import { MessageScroller } from "../../../registry/beui/agents/message-scroller"
 import { StreamingResponse } from "../../../registry/beui/agents/streaming-response"
-import { AgentActivity, type AgentActivityItem } from "../../../registry/beui/agents/agent-activity/index"
-import { PromptSuggestions } from "../../../registry/assistant-ui/elements/prompt-suggestions"
+import type { AgentActivityItem } from "../../../registry/beui/agents/agent-activity/index"
+import type { FleetQueueLane } from "../../../registry/assistant-ui/elements/fleet-message-queue"
 import { buildAssistantElements } from "../../../registry/beui/agents/message-turns"
 import { UserMessage } from "../../../registry/beui/agents/user-message"
 import { normalizeAssistantToolParts } from "../../../registry/beui/agents/utils/tool-part-normalizer"
@@ -30,10 +30,6 @@ import type {
 	PrimeAgentSessionPresentation,
 } from "@prime-agent/web-protocol/chat-protocol"
 import type { FleetPiInputBarProps } from "./fleet-pi-input-bar"
-import { FleetReasoningPanel } from "../../../registry/assistant-ui/elements/fleet-reasoning-panel"
-import { FleetMessageQueue, type FleetQueueLane } from "../../../registry/assistant-ui/elements/fleet-message-queue"
-import { FleetSubagentList } from "../../../registry/assistant-ui/elements/fleet-subagent-list"
-import { FleetToolTimeline } from "../../../registry/assistant-ui/elements/fleet-tool-timeline"
 import { groupMessages, type ConversationTurn } from "../../../../lib/pi/conversation-turns"
 
 const LazyFleetPiToolRenderer = lazy(() =>
@@ -46,6 +42,103 @@ function FleetPiToolRenderer(props: ComponentProps<typeof LazyFleetPiToolRendere
   return (
     <Suspense fallback={<div className="h-7 animate-pulse rounded-md bg-muted/40" aria-label="Loading tool" />}>
       <LazyFleetPiToolRenderer {...props} />
+    </Suspense>
+  )
+}
+
+// The components below never render on the empty welcome state, so they stay
+// out of the initial eager graph (see web/app/scripts/check-bundle-budget.mjs)
+// and load on first use behind lightweight skeleton fallbacks.
+const LazyAgentActivity = lazy(() =>
+  import("../../../registry/beui/agents/agent-activity/index").then(({ AgentActivity }) => ({
+    default: AgentActivity,
+  }))
+)
+
+function AgentActivity(props: ComponentProps<typeof LazyAgentActivity>) {
+  return (
+    <Suspense fallback={<div className="mt-2 h-8 animate-pulse rounded-md bg-muted/40" aria-label="Loading activity" />}>
+      <LazyAgentActivity {...props} />
+    </Suspense>
+  )
+}
+
+const LazyFleetReasoningPanel = lazy(() =>
+  import("../../../registry/assistant-ui/elements/fleet-reasoning-panel").then(
+    ({ FleetReasoningPanel }) => ({
+      default: FleetReasoningPanel,
+    }),
+  )
+)
+
+function FleetReasoningPanel(props: ComponentProps<typeof LazyFleetReasoningPanel>) {
+  return (
+    <Suspense fallback={<div className="mb-2 h-6 animate-pulse rounded-md bg-muted/40" aria-label="Loading reasoning" />}>
+      <LazyFleetReasoningPanel {...props} />
+    </Suspense>
+  )
+}
+
+const LazyFleetToolTimeline = lazy(() =>
+  import("../../../registry/assistant-ui/elements/fleet-tool-timeline").then(
+    ({ FleetToolTimeline }) => ({
+      default: FleetToolTimeline,
+    }),
+  )
+)
+
+function FleetToolTimeline(props: ComponentProps<typeof LazyFleetToolTimeline>) {
+  return (
+    <Suspense fallback={<div className="h-6 animate-pulse rounded-md bg-muted/40" aria-label="Loading timeline" />}>
+      <LazyFleetToolTimeline {...props} />
+    </Suspense>
+  )
+}
+
+const LazyFleetSubagentList = lazy(() =>
+  import("../../../registry/assistant-ui/elements/fleet-subagent-list").then(
+    ({ FleetSubagentList }) => ({
+      default: FleetSubagentList,
+    }),
+  )
+)
+
+function FleetSubagentList(props: ComponentProps<typeof LazyFleetSubagentList>) {
+  return (
+    <Suspense fallback={<div className="h-6 animate-pulse rounded-md bg-muted/40" aria-label="Loading subagents" />}>
+      <LazyFleetSubagentList {...props} />
+    </Suspense>
+  )
+}
+
+const LazyPromptSuggestions = lazy(() =>
+  import("../../../registry/assistant-ui/elements/prompt-suggestions").then(
+    ({ PromptSuggestions }) => ({
+      default: PromptSuggestions,
+    }),
+  )
+)
+
+function PromptSuggestions(props: ComponentProps<typeof LazyPromptSuggestions>) {
+  return (
+    <Suspense fallback={<div className="h-8 animate-pulse rounded-full bg-muted/40" aria-label="Loading suggestions" />}>
+      <LazyPromptSuggestions {...props} />
+    </Suspense>
+  )
+}
+
+const LazyFleetMessageQueue = lazy(() =>
+  import("../../../registry/assistant-ui/elements/fleet-message-queue").then(
+    ({ FleetMessageQueue }) => ({
+      default: FleetMessageQueue,
+    }),
+  )
+)
+
+function FleetMessageQueue(props: ComponentProps<typeof LazyFleetMessageQueue>) {
+  return (
+    <Suspense fallback={null}>
+      <LazyFleetMessageQueue {...props} />
     </Suspense>
   )
 }
@@ -487,7 +580,10 @@ export const ConversationTurnView = memo(
     activity,
   }: ConversationTurnViewProps) {
     return (
-      <div className="flex flex-col gap-3">
+      <div
+        className="flex flex-col gap-3"
+        style={{ contentVisibility: "auto", containIntrinsicSize: "auto 400px" }}
+      >
         {turn.user ? (
           <Message from="user" animateIn={!state.isStreaming}>
             <MessageContent>
@@ -629,6 +725,55 @@ function WelcomeState({
 }
 
 /**
+ * Owns the composer draft state so that keystrokes re-render only the input
+ * bar instead of the whole chat (including the MessageScroller subtree).
+ * Suggestion clicks reach the draft via `draftSetterRef`, which always points
+ * at the currently mounted composer (welcome and bottom-bar composers are
+ * mutually exclusive, and the draft is cleared on send — so per-instance state
+ * is behavior-identical to the previous shared state).
+ */
+function ChatComposerHost({
+  inputBar,
+  status,
+  suggestions,
+  onSend,
+  onStop,
+  isEmpty,
+  draftSetterRef,
+}: {
+  inputBar: FleetPiAgentChatProps["inputBar"]
+  status: FleetPiAgentChatProps["status"]
+  suggestions: FleetPiAgentChatProps["suggestions"]
+  onSend: FleetPiAgentChatProps["onSend"]
+  onStop: FleetPiAgentChatProps["onStop"]
+  isEmpty: boolean
+  draftSetterRef: RefObject<((value: string) => void) | null>
+}) {
+  const [draft, setDraft] = useState("")
+  useEffect(() => {
+    draftSetterRef.current = setDraft
+  }, [draftSetterRef])
+  return (
+    <FleetPiInputBar
+      {...inputBar}
+      className={cn(inputBar.className, isEmpty && "px-0 pb-0")}
+      placeholder={
+        isEmpty
+          ? "Ask Prime to build, investigate, or change something…"
+          : inputBar.placeholder
+      }
+      controlled={{ value: draft, onChange: setDraft }}
+      status={status}
+      suggestions={suggestions}
+      onSend={onSend}
+      onStop={onStop}
+    />
+  )
+}
+
+const MemoChatComposerHost = memo(ChatComposerHost)
+
+/**
  * Renders the Fleet Prime Agent chat interface, including conversation turns, activity, suggestions, errors, and message input.
  *
  * @param messages - Conversation messages to display.
@@ -657,7 +802,11 @@ export function FleetPiAgentChat({
   queue,
   onDeleteQueuedMessage,
 }: FleetPiAgentChatProps) {
-  const [draft, setDraft] = useState("")
+  const draftSetterRef = useRef<((value: string) => void) | null>(null)
+  const setDraft = useCallback(
+    (value: string) => draftSetterRef.current?.(value),
+    [],
+  )
   const turns = useMemo(() => groupMessages(messages), [messages])
   const suggestionItems = resolveSuggestions(suggestions)
   const suggestionTexts = useMemo(
@@ -694,20 +843,15 @@ export function FleetPiAgentChat({
   )
   const isEmpty = turns.length === 0 && !error
   const errorPresentation = error ? getChatErrorPresentation(error) : null
-  const inputBarNode = (
-    <FleetPiInputBar
-      {...inputBar}
-      className={cn(inputBar.className, isEmpty && "px-0 pb-0")}
-      placeholder={
-        isEmpty
-          ? "Ask Prime to build, investigate, or change something…"
-          : inputBar.placeholder
-      }
-      controlled={{ value: draft, onChange: setDraft }}
+  const composerNode = (
+    <MemoChatComposerHost
+      inputBar={inputBar}
       status={status}
       suggestions={suggestions}
       onSend={onSend}
       onStop={onStop}
+      isEmpty={isEmpty}
+      draftSetterRef={draftSetterRef}
     />
   )
 
@@ -722,7 +866,7 @@ export function FleetPiAgentChat({
         className="flex-1"
         busy={isStreaming}
         followOutput
-        smooth={isStreaming}
+        smooth={!isStreaming}
         contentClassName={cn(
           "mx-auto flex w-full max-w-an flex-col gap-5 px-4",
           isEmpty
@@ -734,7 +878,7 @@ export function FleetPiAgentChat({
           <WelcomeState
             disabled={isStreaming}
             onSelect={(item) => setDraft(item.value ?? item.label)}
-            composer={inputBarNode}
+            composer={composerNode}
           />
         ) : null}
         {turns.map((turn, turnIndex) => {
@@ -775,7 +919,7 @@ export function FleetPiAgentChat({
           />
         ) : null}
       </MessageScroller>
-      {!isEmpty ? inputBarNode : null}
+      {!isEmpty ? composerNode : null}
       <FleetMessageQueue queue={queue ?? { steering: [], followUp: [] }} onDelete={onDeleteQueuedMessage} />
     </div>
   )

--- a/web/design/src/components/product/fleet-pi/chat/fleet-pi-agent-chat.tsx
+++ b/web/design/src/components/product/fleet-pi/chat/fleet-pi-agent-chat.tsx
@@ -38,6 +38,12 @@ const LazyFleetPiToolRenderer = lazy(() =>
   }))
 )
 
+/**
+ * Lazy-loaded wrapper for the Fleet Pi tool renderer with loading skeleton.
+ *
+ * @param props - Props forwarded to the FleetPiToolRenderer component
+ * @returns Suspense-wrapped FleetPiToolRenderer with loading fallback
+ */
 function FleetPiToolRenderer(props: ComponentProps<typeof LazyFleetPiToolRenderer>) {
   return (
     <Suspense fallback={<div className="h-7 animate-pulse rounded-md bg-muted/40" aria-label="Loading tool" />}>
@@ -55,6 +61,14 @@ const LazyAgentActivity = lazy(() =>
   }))
 )
 
+/**
+ * Lazy-loaded wrapper for the agent activity panel with loading skeleton.
+ * Defers loading until first conversation turn to keep the component out of
+ * the welcome route eager bundle.
+ *
+ * @param props - Props forwarded to the AgentActivity component
+ * @returns Suspense-wrapped AgentActivity with loading fallback
+ */
 function AgentActivity(props: ComponentProps<typeof LazyAgentActivity>) {
   return (
     <Suspense fallback={<div className="mt-2 h-8 animate-pulse rounded-md bg-muted/40" aria-label="Loading activity" />}>
@@ -71,6 +85,14 @@ const LazyFleetReasoningPanel = lazy(() =>
   )
 )
 
+/**
+ * Lazy-loaded wrapper for the Fleet reasoning panel with loading skeleton.
+ * Defers loading until first conversation turn to keep the component out of
+ * the welcome route eager bundle.
+ *
+ * @param props - Props forwarded to the FleetReasoningPanel component
+ * @returns Suspense-wrapped FleetReasoningPanel with loading fallback
+ */
 function FleetReasoningPanel(props: ComponentProps<typeof LazyFleetReasoningPanel>) {
   return (
     <Suspense fallback={<div className="mb-2 h-6 animate-pulse rounded-md bg-muted/40" aria-label="Loading reasoning" />}>
@@ -87,6 +109,14 @@ const LazyFleetToolTimeline = lazy(() =>
   )
 )
 
+/**
+ * Lazy-loaded wrapper for the Fleet tool timeline with loading skeleton.
+ * Defers loading until first conversation turn to keep the component out of
+ * the welcome route eager bundle.
+ *
+ * @param props - Props forwarded to the FleetToolTimeline component
+ * @returns Suspense-wrapped FleetToolTimeline with loading fallback
+ */
 function FleetToolTimeline(props: ComponentProps<typeof LazyFleetToolTimeline>) {
   return (
     <Suspense fallback={<div className="h-6 animate-pulse rounded-md bg-muted/40" aria-label="Loading timeline" />}>
@@ -103,6 +133,14 @@ const LazyFleetSubagentList = lazy(() =>
   )
 )
 
+/**
+ * Lazy-loaded wrapper for the Fleet subagent list with loading skeleton.
+ * Defers loading until first conversation turn to keep the component out of
+ * the welcome route eager bundle.
+ *
+ * @param props - Props forwarded to the FleetSubagentList component
+ * @returns Suspense-wrapped FleetSubagentList with loading fallback
+ */
 function FleetSubagentList(props: ComponentProps<typeof LazyFleetSubagentList>) {
   return (
     <Suspense fallback={<div className="h-6 animate-pulse rounded-md bg-muted/40" aria-label="Loading subagents" />}>
@@ -119,6 +157,14 @@ const LazyPromptSuggestions = lazy(() =>
   )
 )
 
+/**
+ * Lazy-loaded wrapper for prompt suggestions with loading skeleton.
+ * Defers loading until first conversation turn to keep the component out of
+ * the welcome route eager bundle.
+ *
+ * @param props - Props forwarded to the PromptSuggestions component
+ * @returns Suspense-wrapped PromptSuggestions with loading fallback
+ */
 function PromptSuggestions(props: ComponentProps<typeof LazyPromptSuggestions>) {
   return (
     <Suspense fallback={<div className="h-8 animate-pulse rounded-full bg-muted/40" aria-label="Loading suggestions" />}>
@@ -135,6 +181,13 @@ const LazyFleetMessageQueue = lazy(() =>
   )
 )
 
+/**
+ * Lazy-loaded wrapper for the Fleet message queue. Defers loading until first
+ * conversation turn to keep the component out of the welcome route eager bundle.
+ *
+ * @param props - Props forwarded to the FleetMessageQueue component
+ * @returns Suspense-wrapped FleetMessageQueue with no loading fallback
+ */
 function FleetMessageQueue(props: ComponentProps<typeof LazyFleetMessageQueue>) {
   return (
     <Suspense fallback={null}>
@@ -188,6 +241,12 @@ function textFromMessage(message: ChatMessage) {
     .join("\n\n")
 }
 
+/**
+ * Type guard that extracts a record from an unknown value.
+ *
+ * @param value - The value to check
+ * @returns The value cast as a record if it is a plain object, otherwise undefined
+ */
 function record(value: unknown): Record<string, unknown> | undefined {
   return typeof value === "object" && value !== null && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -562,6 +621,13 @@ type ConversationTurnViewProps = {
   }
 }
 
+/**
+ * Checks if two message arrays contain identical message references.
+ *
+ * @param previous - The previous message array
+ * @param next - The next message array
+ * @returns True if both arrays have the same length and identical message references
+ */
 function sameMessages(
   previous: Array<ChatMessage>,
   next: Array<ChatMessage>
@@ -625,11 +691,25 @@ export const ConversationTurnView = memo(
     previous.activity.artifactRuns === next.activity.artifactRuns
 )
 
+/**
+ * Determines if an activity label indicates a lifecycle event rather than
+ * content generation.
+ *
+ * @param label - The activity label to check
+ * @returns True if the label matches a lifecycle event pattern
+ */
 function isLifecycleNotice(label: string | undefined) {
   if (!label) return false
   return /queued|steered|retry|compact|reset|recover|sign in/i.test(label)
 }
 
+/**
+ * Generates a descriptive label for active agent activity based on the
+ * types and count of items.
+ *
+ * @param items - The active agent activity items
+ * @returns A human-readable label describing the current activity
+ */
 function activityLabelFor(items: AgentActivityItem[]) {
 	if (items.length === 1) {
 		const item = items[0]
@@ -640,6 +720,12 @@ function activityLabelFor(items: AgentActivityItem[]) {
   return "Working through the run…"
 }
 
+/**
+ * Generates a summary message for completed agent activity.
+ *
+ * @param items - The completed agent activity items
+ * @returns A human-readable summary of completed actions
+ */
 function activitySummary(items: AgentActivityItem[]) {
 	const count = items.length
   if (count === 1) return "Completed 1 tracked action"
@@ -683,6 +769,15 @@ const WELCOME_TASKS: SuggestionItem[] = [
   },
 ]
 
+/**
+ * Renders the welcome screen displayed when the conversation is empty,
+ * including the composer and suggested prompt buttons.
+ *
+ * @param disabled - Whether interactions should be disabled (e.g., during streaming)
+ * @param onSelect - Callback invoked when a suggested prompt is clicked
+ * @param composer - The composer input component to display
+ * @returns The welcome state UI
+ */
 function WelcomeState({
   disabled,
   onSelect,

--- a/web/design/src/components/product/fleet-pi/chat/fleet-pi-input-bar.tsx
+++ b/web/design/src/components/product/fleet-pi/chat/fleet-pi-input-bar.tsx
@@ -179,6 +179,9 @@ function FleetPiInputBarContent({
                 <img
                   src={image.url}
                   alt={image.filename}
+                  width={64}
+                  height={64}
+                  loading="lazy"
                   className="size-16 rounded-lg border object-cover"
                 />
                 <Button

--- a/web/design/src/components/registry/assistant-ui/elements/model-selector-list.tsx
+++ b/web/design/src/components/registry/assistant-ui/elements/model-selector-list.tsx
@@ -1,0 +1,129 @@
+"use client"
+
+import { Check, Gauge } from "lucide-react"
+import { useMemo } from "react"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "../../../ui/command"
+import { Slider } from "../../../ui/slider"
+import type {
+  ModelSelectorEffort,
+  ModelSelectorModel,
+} from "./model-selector"
+
+export interface ModelSelectorListProps {
+  models: readonly ModelSelectorModel[]
+  selectedModel: ModelSelectorModel | undefined
+  selectedEffort: ModelSelectorEffort | undefined
+  effortLabel: string
+  onModelChange?: (modelId: string) => void
+  onEffortChange?: (effortId: string) => void
+}
+
+function groupModels(models: readonly ModelSelectorModel[]) {
+  const groups = new Map<string, ModelSelectorModel[]>()
+  for (const model of models) {
+    const group = groups.get(model.provider) ?? []
+    group.push(model)
+    groups.set(model.provider, group)
+  }
+  return [...groups.entries()]
+}
+
+/**
+ * Searchable model/effort list. Split from `model-selector` so the cmdk
+ * dependency stays out of the welcome-route eager graph (see
+ * web/app/scripts/check-bundle-budget.mjs) — this module only loads when the
+ * selector popover opens.
+ */
+export function ModelSelectorList({
+  models,
+  selectedModel,
+  selectedEffort,
+  effortLabel,
+  onModelChange,
+  onEffortChange,
+}: ModelSelectorListProps) {
+  const groups = useMemo(() => groupModels(models), [models])
+
+  return (
+    <Command className="min-h-0 max-h-[min(55vh,28rem)] bg-transparent" shouldFilter>
+      <CommandInput placeholder="Search models…" aria-label="Search models" />
+      <CommandList className="min-h-0 flex-1 p-1.5">
+        <CommandEmpty>No matching models</CommandEmpty>
+        {groups.map(([provider, providerModels]) => (
+          <CommandGroup
+            key={provider}
+            heading={providerModels[0]?.providerLabel ?? provider}
+          >
+            {providerModels.map((model) => {
+              const searchValue = [
+                model.id,
+                model.name,
+                model.provider,
+                model.providerLabel,
+                model.modelId,
+                ...(model.keywords ?? []),
+              ]
+                .filter(Boolean)
+                .join(" ")
+              const selected = model.id === selectedModel?.id
+              return (
+                <CommandItem
+                  key={model.id}
+                  value={searchValue}
+                  disabled={model.disabled}
+                  onSelect={() => {
+                    if (model.disabled) return
+                    onModelChange?.(model.id)
+                  }}
+                  className="items-start gap-2 rounded-lg px-2.5 py-2"
+                >
+                  <span className="mt-0.5 shrink-0 text-muted-foreground">
+                    {model.icon ?? <Gauge aria-hidden="true" className="size-4" />}
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="flex items-center gap-2">
+                      <span className="truncate text-sm font-medium">{model.name}</span>
+                      {model.disabled ? (
+                        <span className="shrink-0 text-[10px] uppercase tracking-wide text-muted-foreground">Unavailable</span>
+                      ) : null}
+                    </span>
+                    <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+                      {model.modelId ?? model.id}
+                      {model.reasoning ? " · reasoning" : ""}
+                    </span>
+                    {model.description ? (
+                      <span className="mt-0.5 block truncate text-xs text-muted-foreground/80">{model.description}</span>
+                    ) : null}
+                  </span>
+                  {selected ? <Check aria-hidden="true" className="mt-1 size-4 shrink-0" /> : null}
+                </CommandItem>
+              )
+            })}
+          </CommandGroup>
+        ))}
+      </CommandList>
+      {selectedModel?.reasoning && selectedModel.efforts?.length ? (
+        <div className="shrink-0 border-t border-border/70 p-2">
+          <Slider
+            label={effortLabel}
+            value={Math.max(0, selectedModel.efforts.findIndex((option) => option.id === selectedEffort?.id))}
+            onChange={(nextValue) => {
+              const option = selectedModel.efforts?.[Math.round(nextValue)]
+              if (option && !option.disabled) onEffortChange?.(option.id)
+            }}
+            min={0}
+            max={Math.max(0, selectedModel.efforts.length - 1)}
+            formatValue={(nextValue) => selectedModel.efforts?.[Math.round(nextValue)]?.name ?? ""}
+          />
+        </div>
+      ) : null}
+    </Command>
+  )
+}

--- a/web/design/src/components/registry/assistant-ui/elements/model-selector-list.tsx
+++ b/web/design/src/components/registry/assistant-ui/elements/model-selector-list.tsx
@@ -25,6 +25,12 @@ export interface ModelSelectorListProps {
   onEffortChange?: (effortId: string) => void
 }
 
+/**
+ * Groups models by provider for organized display in the selector list.
+ *
+ * @param models - Models to group by their provider property
+ * @returns Array of tuples containing provider name and its associated models
+ */
 function groupModels(models: readonly ModelSelectorModel[]) {
   const groups = new Map<string, ModelSelectorModel[]>()
   for (const model of models) {

--- a/web/design/src/components/registry/assistant-ui/elements/model-selector.tsx
+++ b/web/design/src/components/registry/assistant-ui/elements/model-selector.tsx
@@ -11,6 +11,13 @@ const LazyModelSelectorList = lazy(() =>
   }))
 )
 
+/**
+ * Lazy-loaded wrapper for the model selector list that displays a loading
+ * skeleton while the cmdk dependency loads.
+ *
+ * @param props - Props forwarded to the ModelSelectorList component
+ * @returns Suspense-wrapped ModelSelectorList with loading fallback
+ */
 function ModelSelectorList(props: ComponentProps<typeof LazyModelSelectorList>) {
   return (
     <Suspense fallback={<div className="h-24 animate-pulse rounded-md bg-muted/40 p-1.5" aria-label="Loading models" role="status" />}>

--- a/web/design/src/components/registry/assistant-ui/elements/model-selector.tsx
+++ b/web/design/src/components/registry/assistant-ui/elements/model-selector.tsx
@@ -13,7 +13,7 @@ const LazyModelSelectorList = lazy(() =>
 
 function ModelSelectorList(props: ComponentProps<typeof LazyModelSelectorList>) {
   return (
-    <Suspense fallback={<div className="h-24 animate-pulse rounded-md bg-muted/40 p-1.5" aria-label="Loading models" />}>
+    <Suspense fallback={<div className="h-24 animate-pulse rounded-md bg-muted/40 p-1.5" aria-label="Loading models" role="status" />}>
       <LazyModelSelectorList {...props} />
     </Suspense>
   )

--- a/web/design/src/components/registry/assistant-ui/elements/model-selector.tsx
+++ b/web/design/src/components/registry/assistant-ui/elements/model-selector.tsx
@@ -1,18 +1,23 @@
 "use client"
 
-import { Check, ChevronDown, Gauge } from "lucide-react"
-import { memo, useId, useMemo, useState, type ReactNode } from "react"
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "../../../ui/command"
+import { ChevronDown } from "lucide-react"
+import { lazy, memo, Suspense, useId, useState, type ComponentProps, type ReactNode } from "react"
 import { Popover } from "../../beui/agents/input/input-popover"
-import { Slider } from "../../../ui/slider"
 import { cn } from "../../../../lib/utils"
+
+const LazyModelSelectorList = lazy(() =>
+  import("./model-selector-list").then(({ ModelSelectorList }) => ({
+    default: ModelSelectorList,
+  }))
+)
+
+function ModelSelectorList(props: ComponentProps<typeof LazyModelSelectorList>) {
+  return (
+    <Suspense fallback={<div className="h-24 animate-pulse rounded-md bg-muted/40 p-1.5" aria-label="Loading models" />}>
+      <LazyModelSelectorList {...props} />
+    </Suspense>
+  )
+}
 
 export type ModelSelectorEffort = {
   id: string
@@ -49,16 +54,6 @@ export type ModelSelectorProps = {
   contentClassName?: string
 }
 
-function groupModels(models: readonly ModelSelectorModel[]) {
-  const groups = new Map<string, ModelSelectorModel[]>()
-  for (const model of models) {
-    const group = groups.get(model.provider) ?? []
-    group.push(model)
-    groups.set(model.provider, group)
-  }
-  return [...groups.entries()]
-}
-
 export const ModelSelector = memo(function ModelSelector({
   models,
   value,
@@ -80,7 +75,6 @@ export const ModelSelector = memo(function ModelSelector({
     onOpenChange?.(next)
   }
   const selectedModel = models.find((model) => model.id === value) ?? models[0]
-  const groups = useMemo(() => groupModels(models), [models])
   const selectedEffort = selectedModel?.efforts?.find((option) => option.id === effort)
     ?? selectedModel?.efforts?.[0]
 
@@ -119,79 +113,14 @@ export const ModelSelector = memo(function ModelSelector({
       )}
       trigger={trigger}
     >
-      <Command className="min-h-0 max-h-[min(55vh,28rem)] bg-transparent" shouldFilter>
-        <CommandInput placeholder="Search models…" aria-label="Search models" />
-        <CommandList className="min-h-0 flex-1 p-1.5">
-          <CommandEmpty>No matching models</CommandEmpty>
-          {groups.map(([provider, providerModels]) => (
-            <CommandGroup
-              key={provider}
-              heading={providerModels[0]?.providerLabel ?? provider}
-            >
-              {providerModels.map((model) => {
-                const searchValue = [
-                  model.id,
-                  model.name,
-                  model.provider,
-                  model.providerLabel,
-                  model.modelId,
-                  ...(model.keywords ?? []),
-                ]
-                  .filter(Boolean)
-                  .join(" ")
-                const selected = model.id === selectedModel?.id
-                return (
-                  <CommandItem
-                    key={model.id}
-                    value={searchValue}
-                    disabled={model.disabled}
-                    onSelect={() => {
-                      if (model.disabled) return
-                      onModelChange?.(model.id)
-                    }}
-                    className="items-start gap-2 rounded-lg px-2.5 py-2"
-                  >
-                    <span className="mt-0.5 shrink-0 text-muted-foreground">
-                      {model.icon ?? <Gauge aria-hidden="true" className="size-4" />}
-                    </span>
-                    <span className="min-w-0 flex-1">
-                      <span className="flex items-center gap-2">
-                        <span className="truncate text-sm font-medium">{model.name}</span>
-                        {model.disabled ? (
-                          <span className="shrink-0 text-[10px] uppercase tracking-wide text-muted-foreground">Unavailable</span>
-                        ) : null}
-                      </span>
-                      <span className="mt-0.5 block truncate text-xs text-muted-foreground">
-                        {model.modelId ?? model.id}
-                        {model.reasoning ? " · reasoning" : ""}
-                      </span>
-                      {model.description ? (
-                        <span className="mt-0.5 block truncate text-xs text-muted-foreground/80">{model.description}</span>
-                      ) : null}
-                    </span>
-                    {selected ? <Check aria-hidden="true" className="mt-1 size-4 shrink-0" /> : null}
-                  </CommandItem>
-                )
-              })}
-            </CommandGroup>
-          ))}
-        </CommandList>
-        {selectedModel?.reasoning && selectedModel.efforts?.length ? (
-          <div className="shrink-0 border-t border-border/70 p-2">
-            <Slider
-              label={effortLabel}
-              value={Math.max(0, selectedModel.efforts.findIndex((option) => option.id === selectedEffort?.id))}
-              onChange={(nextValue) => {
-                const option = selectedModel.efforts?.[Math.round(nextValue)]
-                if (option && !option.disabled) onEffortChange?.(option.id)
-              }}
-              min={0}
-              max={Math.max(0, selectedModel.efforts.length - 1)}
-              formatValue={(nextValue) => selectedModel.efforts?.[Math.round(nextValue)]?.name ?? ""}
-            />
-          </div>
-        ) : null}
-      </Command>
+      <ModelSelectorList
+        models={models}
+        selectedModel={selectedModel}
+        selectedEffort={selectedEffort}
+        effortLabel={effortLabel}
+        onModelChange={onModelChange}
+        onEffortChange={onEffortChange}
+      />
     </Popover>
   )
 })

--- a/web/design/src/components/registry/beui/agents/agent-activity/activity-row.tsx
+++ b/web/design/src/components/registry/beui/agents/agent-activity/activity-row.tsx
@@ -11,7 +11,7 @@ import {
   SquareTerminal,
   Wrench,
 } from "lucide-react";
-import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { AnimatePresence, m, useReducedMotion } from "motion/react";
 import { EASE_OUT, SPRING_LAYOUT } from "@prime-agent/web-design/lib/ease";
 import { cn } from "@prime-agent/web-design/lib/utils";
 import { isSafeExternalUrl } from "../../../../../lib/safe-external-url";
@@ -38,7 +38,7 @@ function StepRow({ item }: { item: AgentActivityStep }) {
           <Check className="size-4" strokeWidth={1.8} />
         ) : state === "active" ? (
           <span className="relative grid size-3 place-items-center">
-            <motion.span
+            <m.span
               className="absolute inset-0 rounded-full bg-foreground/10"
               animate={{ opacity: [0.35, 0.8, 0.35] }}
               transition={{ duration: 1.5, repeat: Number.POSITIVE_INFINITY }}
@@ -135,7 +135,7 @@ function SearchRow({ item }: { item: AgentActivitySearch }) {
         <div className="space-y-0.5 pl-4">
           <AnimatePresence initial mode="popLayout">
             {item.results.map((result) => (
-              <motion.div
+              <m.div
                 layout="position"
                 key={result.id}
                 initial={enter}
@@ -144,14 +144,14 @@ function SearchRow({ item }: { item: AgentActivitySearch }) {
                 transition={transition}
               >
                 <SearchResultRow result={result} />
-              </motion.div>
+              </m.div>
             ))}
           </AnimatePresence>
         </div>
       ) : null}
       <AnimatePresence initial>
         {item.moreCount ? (
-          <motion.div
+          <m.div
             key="more-results"
             initial={enter}
             animate={visible}
@@ -160,7 +160,7 @@ function SearchRow({ item }: { item: AgentActivitySearch }) {
             className="px-1.5 py-1 pl-8 text-muted-foreground/55"
           >
             +{item.moreCount} more
-          </motion.div>
+          </m.div>
         ) : null}
       </AnimatePresence>
     </div>

--- a/web/design/src/components/registry/beui/agents/agent-activity/index.tsx
+++ b/web/design/src/components/registry/beui/agents/agent-activity/index.tsx
@@ -2,7 +2,7 @@
 // beui.dev/components/agents/agent-activity
 
 import { ChevronDown } from "lucide-react";
-import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { AnimatePresence, m, useReducedMotion } from "motion/react";
 import {
   type ReactNode,
   useCallback,
@@ -223,14 +223,14 @@ export function AgentActivity({
               ? renderCompletedStatus({ summary: completedSummary, duration })
               : completedSummary}
           </span>
-          <motion.span
+          <m.span
             aria-hidden="true"
             animate={{ rotate: expanded ? 180 : 0 }}
             transition={reduce ? { duration: 0 } : SPRING_SWAP}
             className="inline-flex shrink-0 text-muted-foreground/70 group-hover:text-foreground"
           >
             <ChevronDown className="size-3.5" />
-          </motion.span>
+          </m.span>
         </button>
       )}
 
@@ -249,7 +249,7 @@ export function AgentActivity({
           )}
           style={{ height: viewportHeight, maskImage, WebkitMaskImage: maskImage }}
         >
-          <motion.div
+          <m.div
             ref={contentRef}
             role="list"
             initial={false}
@@ -259,7 +259,7 @@ export function AgentActivity({
           >
             <AnimatePresence mode="popLayout">
               {items.map((item) => (
-                <motion.div
+                <m.div
                   layout="position"
                   key={item.id}
                   role="listitem"
@@ -277,10 +277,10 @@ export function AgentActivity({
                   }
                 >
                   <ActivityRow item={item} />
-                </motion.div>
+                </m.div>
               ))}
             </AnimatePresence>
-          </motion.div>
+          </m.div>
         </div>
       </AgentDisclosure>
     </div>

--- a/web/design/src/components/registry/beui/agents/agent-disclosure.tsx
+++ b/web/design/src/components/registry/beui/agents/agent-disclosure.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion, type HTMLMotionProps, useReducedMotion } from "motion/react";
+import { m, type HTMLMotionProps, useReducedMotion } from "motion/react";
 import type { CSSProperties } from "react";
 import { EASE_OUT } from "@prime-agent/web-design/lib/ease";
 import { cn } from "@prime-agent/web-design/lib/utils";
@@ -23,7 +23,7 @@ export function AgentDisclosure({
   const reduce = useReducedMotion() ?? false;
 
   return (
-    <motion.div
+    <m.div
       {...props}
       aria-hidden={!open}
       inert={!open}

--- a/web/design/src/components/registry/beui/agents/citations.tsx
+++ b/web/design/src/components/registry/beui/agents/citations.tsx
@@ -100,6 +100,7 @@ export function CitationFavicon({
           alt=""
           width={16}
           height={16}
+          loading="lazy"
           referrerPolicy="no-referrer"
           onError={() => setFailedUrl(favicon)}
           className="size-4 rounded-sm object-contain"

--- a/web/design/src/components/registry/beui/agents/markdown.tsx
+++ b/web/design/src/components/registry/beui/agents/markdown.tsx
@@ -223,6 +223,16 @@ export function MarkdownFrame({
   )
 }
 
+/**
+ * Renders markdown content without syntax highlighting. Normalizes code fence
+ * languages and fixes numbered list breaks, with memoization to optimize
+ * performance during streaming.
+ *
+ * @param content - The markdown content to render
+ * @param className - Optional CSS class for styling the markdown container
+ * @param codeControls - Optional controls for code block interactions
+ * @returns Rendered plain markdown without syntax highlighting
+ */
 function PlainMarkdown({ content, className, codeControls }: MarkdownProps) {
   // Regex preprocessing runs per render (including per streamed token), so
   // memoize on content — the transforms are pure functions of it.

--- a/web/design/src/components/registry/beui/agents/markdown.tsx
+++ b/web/design/src/components/registry/beui/agents/markdown.tsx
@@ -1,5 +1,5 @@
 import { Streamdown } from "streamdown"
-import { Fragment, isValidElement, lazy, Suspense } from "react"
+import { Fragment, isValidElement, lazy, Suspense, useMemo } from "react"
 import { cn } from "./utils/cn"
 import type { Components } from "streamdown"
 
@@ -224,8 +224,11 @@ export function MarkdownFrame({
 }
 
 function PlainMarkdown({ content, className, codeControls }: MarkdownProps) {
-  const safeContent = normalizeCodeFenceLanguages(
-    fixNumberedListBreaks(content)
+  // Regex preprocessing runs per render (including per streamed token), so
+  // memoize on content — the transforms are pure functions of it.
+  const safeContent = useMemo(
+    () => normalizeCodeFenceLanguages(fixNumberedListBreaks(content)),
+    [content],
   )
 
   return (

--- a/web/design/src/components/registry/beui/agents/tool-result.tsx
+++ b/web/design/src/components/registry/beui/agents/tool-result.tsx
@@ -14,7 +14,7 @@ import {
   SquareTerminal,
   Wrench,
 } from "lucide-react";
-import { motion, useReducedMotion } from "motion/react";
+import { m, useReducedMotion } from "motion/react";
 import {
   type ReactNode,
   useCallback,
@@ -119,7 +119,7 @@ function ToolResultAction({
   const reduce = useReducedMotion() ?? false;
 
   return (
-    <motion.button
+    <m.button
       type="button"
       aria-label={label}
       title={label}
@@ -129,7 +129,7 @@ function ToolResultAction({
       className="grid size-7 place-items-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
     >
       {children}
-    </motion.button>
+    </m.button>
   );
 }
 
@@ -297,14 +297,14 @@ export function ToolResult({
           <StatusIcon status={status} reduce={reduce} />
           <ActionSwapRollText value={status}>{statusLabel}</ActionSwapRollText>
         </span>
-        <motion.span
+        <m.span
           aria-hidden="true"
           animate={{ rotate: currentOpen ? 180 : 0 }}
           transition={reduce ? { duration: 0 } : SPRING_SWAP}
           className="shrink-0 text-muted-foreground/50 transition-colors group-hover:text-muted-foreground"
         >
           <ChevronDown className="size-3.5" />
-        </motion.span>
+        </m.span>
       </button>
 
       <AgentDisclosure


### PR DESCRIPTION
## Summary
- lazy() six never-on-welcome chat components (activity, suggestions, reasoning, queue, subagents, timeline) behind skeleton fallbacks
- motion -> m in agent-activity/disclosure/tool-result (LazyMotion-safe)
- Split cmdk ModelSelector list into lazy chunk (was eager via input bar)
- ChatComposerHost owns draft state: keystrokes skip transcript re-render
- Instant scroll-follow while streaming; content-visibility on turns
- loading=lazy on chat images, favicons, artifact iframe; markdown memo; kernel-health poll skips hidden tabs
- Hand-rolled LCP/INP/CLS observer in analytics stub (zero deps)
- Bundle gate ratcheted (streamdown/lottie/cmdk) + emits bundle-budget.json
- New perf-smoke.spec.ts (no-deferred-chunks + LCP budget)
- Render benchmarks via vitest bench (welcome mount, 50-turn mount, mount+keystroke) + pnpm bench

## Measured gain
- Eager gzip: 363137 -> 338134 bytes (-6.9%), gate passes
- 50-turn mount (happy-dom): ~149ms main -> ~80ms branch (~-46%)
- Welcome mount unchanged (~2.2ms, expected); keystroke delta within harness noise

## Verification
- check:bundle, typecheck (app+design), vitest 170/170, web boundaries, component contracts/registries green
- perf-smoke 2/2 on fresh dev server; 3 pre-existing e2e failures proven on baseline (kernel-dependent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)