### PR TITLE
ci: add CircleCI deploy tracking and rollback

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,11 +9,13 @@ executors:
   node-lts:
     docker:
       - image: cimg/node:22.23.2
+    resource_class: medium
     working_directory: ~/prime-agent
 
   node-release-smoke:
     docker:
       - image: cimg/node:22.12.0
+    resource_class: small
     working_directory: ~/prime-agent
 
   macos-release-smoke:
@@ -247,15 +249,45 @@ jobs:
           command: sudo npm install --global npm@11.15.0
       - install-pnpm
       - run:
-          name: Publish the verified artifact and GitHub release
+          name: Plan Fleet production release marker
           command: |
             if [ "<< pipeline.parameters.release_retry >>" = "true" ]; then
-              export FORCE_RELEASE=1
+              echo 'export FORCE_RELEASE=1' >> "${BASH_ENV}"
             fi
+            node scripts/release-marker.mjs plan
+      - run:
+          name: Publish the verified artifact and GitHub release
+          command: |
             pnpm run release:publish
+      - run:
+          name: Mark Fleet production release successful
+          command: |
+            export RELEASE_MARKER_STATUS=SUCCESS
+            node scripts/release-marker.mjs update
+          when: on_success
+      - run:
+          name: Mark Fleet production release failed
+          command: |
+            export RELEASE_MARKER_STATUS=FAILED
+            export RELEASE_MARKER_FAILURE_REASON="release-publish failed"
+            node scripts/release-marker.mjs update
+          when: on_fail
       - store_artifacts:
           path: dist-release
           destination: dist-release/release
+
+  cancel-release-marker:
+    executor: node-lts
+    steps:
+      - checkout
+      - run:
+          name: Mark canceled Fleet production release
+          command: |
+            if [ "<< pipeline.parameters.release_retry >>" = "true" ]; then
+              echo 'export FORCE_RELEASE=1' >> "${BASH_ENV}"
+            fi
+            export RELEASE_MARKER_STATUS=CANCELED
+            node scripts/release-marker.mjs update
 
 workflows:
   ci:
@@ -308,7 +340,16 @@ workflows:
             - ci-success
           context:
             - github-release
-          serial-group: fleet-release-publication
+          serial-group: fleet-release-operations
+          filters:
+            branches:
+              only: main
+            tags:
+              ignore: /.*/
+      - cancel-release-marker:
+          requires:
+            - release-publish:
+                - canceled
           filters:
             branches:
               only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,6 +252,7 @@ jobs:
           name: Plan Fleet production release marker
           command: |
             if [ "<< pipeline.parameters.release_retry >>" = "true" ]; then
+              export FORCE_RELEASE=1
               echo 'export FORCE_RELEASE=1' >> "${BASH_ENV}"
             fi
             node scripts/release-marker.mjs plan
@@ -284,6 +285,7 @@ jobs:
           name: Mark canceled Fleet production release
           command: |
             if [ "<< pipeline.parameters.release_retry >>" = "true" ]; then
+              export FORCE_RELEASE=1
               echo 'export FORCE_RELEASE=1' >> "${BASH_ENV}"
             fi
             export RELEASE_MARKER_STATUS=CANCELED

--- a/.circleci/rollback.yml
+++ b/.circleci/rollback.yml
@@ -1,0 +1,73 @@
+version: 2.1
+
+executors:
+  node-rollback:
+    docker:
+      - image: cimg/node:22.23.2
+    resource_class: medium
+    working_directory: ~/prime-agent
+
+jobs:
+  rollback-fleet:
+    executor: node-rollback
+    environment:
+      ROLLBACK_CURRENT_VERSION: << pipeline.deploy.current_version >>
+      ROLLBACK_TARGET_VERSION: << pipeline.deploy.target_version >>
+    steps:
+      - checkout
+      - run:
+          name: Configure scoped npm rollback credentials
+          command: |
+            set -euo pipefail
+            if [ -z "${NPM_TOKEN:-}" ]; then
+              echo "NPM_TOKEN is required for dist-tag rollback" >&2
+              exit 1
+            fi
+            npmrc_path="$(mktemp)"
+            chmod 600 "${npmrc_path}"
+            printf '%s\n' "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > "${npmrc_path}"
+            echo "export NPM_CONFIG_USERCONFIG=${npmrc_path}" >> "${BASH_ENV}"
+      - run:
+          name: Plan Fleet rollback marker
+          command: |
+            set -euo pipefail
+            circleci run release plan fleet-rollback \
+              --environment-name=production \
+              --component-name=fleet-cli \
+              --target-version="${ROLLBACK_TARGET_VERSION}" \
+              --rollback
+      - run:
+          name: Restore npm latest dist-tag
+          command: node scripts/rollback-release.mjs
+      - run:
+          name: Mark Fleet rollback successful
+          command: circleci run release update --status=SUCCESS
+          when: on_success
+      - run:
+          name: Mark Fleet rollback failed
+          command: |
+            circleci run release update \
+              --status=FAILED \
+              --failure-reason="npm dist-tag rollback failed"
+          when: on_fail
+
+  cancel-rollback-marker:
+    executor: node-rollback
+    steps:
+      - run:
+          name: Mark canceled Fleet rollback
+          command: circleci run release update --status=CANCELED
+
+workflows:
+  rollback:
+    jobs:
+      - rollback-fleet:
+          context:
+            - npm-dist-tag-rollback
+          serial-group: fleet-release-operations
+          filters: pipeline.git.branch == "main"
+      - cancel-rollback-marker:
+          requires:
+            - rollback-fleet:
+                - canceled
+          filters: pipeline.git.branch == "main"

--- a/.circleci/rollback.yml
+++ b/.circleci/rollback.yml
@@ -41,22 +41,23 @@ jobs:
           command: node scripts/rollback-release.mjs
       - run:
           name: Mark Fleet rollback successful
-          command: circleci run release update --status=SUCCESS
+          command: node scripts/rollback-marker.mjs SUCCESS
           when: on_success
       - run:
           name: Mark Fleet rollback failed
-          command: |
-            circleci run release update \
-              --status=FAILED \
-              --failure-reason="npm dist-tag rollback failed"
+          command: ROLLBACK_FAILURE_REASON="npm dist-tag rollback failed" node scripts/rollback-marker.mjs FAILED
           when: on_fail
 
   cancel-rollback-marker:
     executor: node-rollback
+    environment:
+      ROLLBACK_CURRENT_VERSION: << pipeline.deploy.current_version >>
+      ROLLBACK_TARGET_VERSION: << pipeline.deploy.target_version >>
     steps:
+      - checkout
       - run:
           name: Mark canceled Fleet rollback
-          command: circleci run release update --status=CANCELED
+          command: node scripts/rollback-marker.mjs CANCELED
 
 workflows:
   rollback:

--- a/docs/guides/releasing.md
+++ b/docs/guides/releasing.md
@@ -32,7 +32,7 @@ Do not publish or create a release as a local validation step.
 4. After the release commit passes CI, the `release-publish` job builds or consumes the verified package artifact and runs `pnpm run release:publish`.
 5. Publication uses the repository's configured npm/GitHub release credentials, verifies package metadata and checksums, publishes the immutable npm version, waits for registry visibility, and creates the matching GitHub release with the package artifact and checksums.
 
-Each release lane has a serial group, publication waits for the verified CI artifact, and the guarded scripts handle reruns against the existing release version and artifact expectations.
+Each release lane has a serial group, publication waits for the verified CI artifact, and the guarded scripts handle reruns against the existing release version and artifact expectations. CircleCI tracks successful package publications as the `fleet-cli` component in the `production` environment.
 
 ## One-time CircleCI and npm setup
 
@@ -67,6 +67,30 @@ After this configuration is pushed, prove a pull request reports the CircleCI ag
 Never republish a published version with a different tarball checksum. The publication script refuses that state. Investigate the artifact, tag, registry metadata, and job output; use the release workflow's retry path only after the expected version and checksum are confirmed.
 
 Do not manually edit generated changelogs or release tags to bypass Changesets. If the release is not ready, fix the source change or release PR and let the guarded job run again.
+
+## CircleCI deploy tracking and rollback
+
+The main CircleCI release workflow adds a deploy marker only around `release-publish`; release preparation is not a production deployment. The marker uses:
+
+- component: `fleet-cli`
+- environment: `production`
+- version: the exact stable `@qredence/fleet` package version
+
+The project rollback pipeline is `.circleci/rollback.yml`. Register it as the project's rollback pipeline in CircleCI Project Settings → Deploys, create/select the `production` environment, and use the restricted `npm-dist-tag-rollback` context containing only the npm credential required to update this package's `latest` dist-tag.
+
+Manual rollback from the CircleCI Deploys UI is equivalent to:
+
+~~~bash
+circleci deploy rollback <target-version> \
+  --component fleet-cli \
+  --environment production \
+  --from <current-version> \
+  --reason "<incident reason>"
+~~~
+
+The rollback pipeline verifies that npm `latest` still equals `<current-version>` and that `<target-version>` is an already-published older version before running `npm dist-tag add @qredence/fleet@<target-version> latest`. It never unpublishes or repackages an npm version. Publication and rollback share the `fleet-release-operations` serial group so they cannot race.
+
+Deploy tracking is enabled without a Smart Deployments validation policy. Automatic rollback remains disabled until a Datadog, Prometheus-compatible, or custom webhook health signal is selected and documented.
 
 ## Rollback
 

--- a/scripts/__tests__/release-utils.test.mjs
+++ b/scripts/__tests__/release-utils.test.mjs
@@ -24,6 +24,7 @@ import {
 } from "../publish-release.mjs";
 import { releaseMarkerArgs, runReleaseMarker } from "../release-marker.mjs";
 import { assertReleaseVersion, compareVersions, parseStableVersion } from "../release-utils.mjs";
+import { reconcileRollbackMarker, resolveRollbackMarker, rollbackMarkerArgs } from "../rollback-marker.mjs";
 import { rollbackRelease, validateRollback } from "../rollback-release.mjs";
 
 const packageManifest = JSON.parse(
@@ -149,7 +150,7 @@ test("builds deploy marker commands for the Fleet production component", () => {
 	]);
 	assert.deepEqual(
 		releaseMarkerArgs({ action: "update", status: "FAILED", failureReason: "release-publish failed" }),
-		["run", "release", "update", "--status=FAILED", "--failure-reason=release-publish failed"],
+		["run", "release", "update", "fleet-release", "--status=FAILED", "--failure-reason=release-publish failed"],
 	);
 });
 
@@ -238,6 +239,120 @@ test("rejects incomplete or failed rollback mutations", async () => {
 			}),
 		/dist-tag service unavailable/,
 	);
+});
+
+test("resolves rollback marker status from the npm latest version", () => {
+	assert.deepEqual(rollbackMarkerArgs({ status: "CANCELED" }), [
+		"run",
+		"release",
+		"update",
+		"fleet-rollback",
+		"--status=CANCELED",
+	]);
+	assert.deepEqual(rollbackMarkerArgs({ status: "FAILED", failureReason: "npm dist-tag rollback failed" }), [
+		"run",
+		"release",
+		"update",
+		"fleet-rollback",
+		"--status=FAILED",
+		"--failure-reason=npm dist-tag rollback failed",
+	]);
+	assert.deepEqual(
+		resolveRollbackMarker({
+			requestedStatus: "CANCELED",
+			currentVersion: "0.5.8",
+			targetVersion: "0.5.7",
+			latestVersion: "0.5.7",
+		}),
+		{ status: "SUCCESS" },
+	);
+	assert.deepEqual(
+		resolveRollbackMarker({
+			requestedStatus: "CANCELED",
+			currentVersion: "0.5.8",
+			targetVersion: "0.5.7",
+			latestVersion: "0.5.8",
+		}),
+		{ status: "CANCELED" },
+	);
+	assert.deepEqual(
+		resolveRollbackMarker({
+			requestedStatus: "SUCCESS",
+			currentVersion: "0.5.8",
+			targetVersion: "0.5.7",
+			latestVersion: "0.5.6",
+		}),
+		{
+			status: "FAILED",
+			failureReason: "npm latest is 0.5.6; expected 0.5.7 (rollback target) or 0.5.8 (current version)",
+		},
+	);
+});
+
+test("reconciles rollback markers and skips a second terminal update", async () => {
+	const statePath = join(mkdtempSync(join(tmpdir(), "fleet-rollback-marker-")), "state.json");
+	const calls = [];
+	const options = {
+		currentVersion: "0.5.8",
+		targetVersion: "0.5.7",
+		requestedStatus: "FAILED",
+		fetchImpl: async () =>
+			response(200, {
+				"dist-tags": { latest: "0.5.7" },
+				versions: { "0.5.7": { version: "0.5.7" } },
+			}),
+		execImpl: async (args) => calls.push(args),
+		statePath,
+	};
+	try {
+		assert.deepEqual(await reconcileRollbackMarker(options), {
+			status: "SUCCESS",
+			latestVersion: "0.5.7",
+			skipped: false,
+		});
+		assert.deepEqual(calls, [rollbackMarkerArgs({ status: "SUCCESS" })]);
+		assert.deepEqual(await reconcileRollbackMarker(options), {
+			status: "SUCCESS",
+			latestVersion: "0.5.7",
+			skipped: true,
+		});
+		assert.deepEqual(calls, [rollbackMarkerArgs({ status: "SUCCESS" })]);
+	} finally {
+		rmSync(statePath, { force: true });
+		rmSync(statePath.replace(/\/state\.json$/, ""), { recursive: true, force: true });
+	}
+});
+
+test("does not retry a rollback marker after a terminal update error", async () => {
+	const stateDirectory = mkdtempSync(join(tmpdir(), "fleet-rollback-marker-terminal-"));
+	const statePath = join(stateDirectory, "state.json");
+	const calls = [];
+	const options = {
+		currentVersion: "0.5.8",
+		targetVersion: "0.5.7",
+		requestedStatus: "FAILED",
+		fetchImpl: async () =>
+			response(200, {
+				"dist-tags": { latest: "0.5.8" },
+				versions: { "0.5.7": { version: "0.5.7" } },
+			}),
+		execImpl: async (args) => {
+			calls.push(args);
+			throw new Error("release is already terminal");
+		},
+		statePath,
+	};
+	try {
+		await assert.rejects(() => reconcileRollbackMarker(options), /already terminal/);
+		assert.deepEqual(await reconcileRollbackMarker(options), {
+			status: "FAILED",
+			latestVersion: "0.5.8",
+			skipped: true,
+		});
+		assert.equal(calls.length, 1);
+	} finally {
+		rmSync(stateDirectory, { recursive: true, force: true });
+	}
 });
 
 test("enforces the packed artifact allowlist", () => {

--- a/scripts/__tests__/release-utils.test.mjs
+++ b/scripts/__tests__/release-utils.test.mjs
@@ -22,7 +22,9 @@ import {
 	sha256,
 	waitForPublishedVersion,
 } from "../publish-release.mjs";
+import { releaseMarkerArgs, runReleaseMarker } from "../release-marker.mjs";
 import { assertReleaseVersion, compareVersions, parseStableVersion } from "../release-utils.mjs";
+import { rollbackRelease, validateRollback } from "../rollback-release.mjs";
 
 const packageManifest = JSON.parse(
 	readFileSync(new URL("../../packages/fleet-web/package.json", import.meta.url), "utf8"),
@@ -133,6 +135,109 @@ test("detects only package-version commits on main", () => {
 		false,
 	);
 	assert.equal(isPackageVersionCommit({ branch: "feature/release", forceRelease: true }), true);
+});
+
+test("builds deploy marker commands for the Fleet production component", () => {
+	assert.deepEqual(releaseMarkerArgs({ action: "plan", version: "0.5.9" }), [
+		"run",
+		"release",
+		"plan",
+		"fleet-release",
+		"--environment-name=production",
+		"--component-name=fleet-cli",
+		"--target-version=0.5.9",
+	]);
+	assert.deepEqual(
+		releaseMarkerArgs({ action: "update", status: "FAILED", failureReason: "release-publish failed" }),
+		["run", "release", "update", "--status=FAILED", "--failure-reason=release-publish failed"],
+	);
+});
+
+test("does not create a deploy marker for a non-release commit", () => {
+	const calls = [];
+	assert.equal(
+		runReleaseMarker("plan", {}, { isVersionCommitImpl: () => false, execImpl: (args) => calls.push(args) }),
+		false,
+	);
+	assert.deepEqual(calls, []);
+});
+
+test("validates npm rollback fencing and published target versions", () => {
+	assert.deepEqual(
+		validateRollback({
+			currentVersion: "0.5.8",
+			targetVersion: "0.5.7",
+			latestVersion: "0.5.8",
+			targetMetadata: { version: "0.5.7" },
+		}),
+		{ currentVersion: "0.5.8", targetVersion: "0.5.7" },
+	);
+	assert.throws(
+		() =>
+			validateRollback({
+				currentVersion: "0.5.8",
+				targetVersion: "0.5.7",
+				latestVersion: "0.5.9",
+				targetMetadata: { version: "0.5.7" },
+			}),
+		/npm latest is 0.5.9/,
+	);
+	assert.throws(
+		() =>
+			validateRollback({
+				currentVersion: "0.5.8",
+				targetVersion: "0.5.7",
+				latestVersion: "0.5.8",
+				targetMetadata: undefined,
+			}),
+		/not published/,
+	);
+	assert.throws(
+		() =>
+			validateRollback({
+				currentVersion: "0.5.8",
+				targetVersion: "0.5.8",
+				latestVersion: "0.5.8",
+				targetMetadata: { version: "0.5.8" },
+			}),
+		/already active/,
+	);
+});
+
+test("moves only the npm latest dist-tag after rollback verification", async () => {
+	const calls = [];
+	const result = await rollbackRelease({
+		currentVersion: "0.5.8",
+		targetVersion: "0.5.7",
+		fetchImpl: async () =>
+			response(200, {
+				"dist-tags": { latest: "0.5.8" },
+				versions: { "0.5.7": { version: "0.5.7" } },
+			}),
+		distTagAddImpl: async (version) => calls.push(version),
+	});
+	assert.deepEqual(result, { currentVersion: "0.5.8", targetVersion: "0.5.7" });
+	assert.deepEqual(calls, ["0.5.7"]);
+});
+
+test("rejects incomplete or failed rollback mutations", async () => {
+	await assert.rejects(() => rollbackRelease({ currentVersion: "0.5.8" }), /requires current and target versions/);
+	await assert.rejects(
+		() =>
+			rollbackRelease({
+				currentVersion: "0.5.8",
+				targetVersion: "0.5.7",
+				fetchImpl: async () =>
+					response(200, {
+						"dist-tags": { latest: "0.5.8" },
+						versions: { "0.5.7": { version: "0.5.7" } },
+					}),
+				distTagAddImpl: async () => {
+					throw new Error("dist-tag service unavailable");
+				},
+			}),
+		/dist-tag service unavailable/,
+	);
 });
 
 test("enforces the packed artifact allowlist", () => {

--- a/scripts/release-marker.mjs
+++ b/scripts/release-marker.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { isPackageVersionCommit } from "./publish-release.mjs";
+
+const packageManifest = JSON.parse(
+	readFileSync(new URL("../packages/fleet-web/package.json", import.meta.url), "utf8"),
+);
+const COMPONENT_NAME = "fleet-cli";
+const ENVIRONMENT_NAME = "production";
+
+export function releaseMarkerArgs({ action, status, version = packageManifest.version, failureReason } = {}) {
+	if (action === "plan") {
+		return [
+			"run",
+			"release",
+			"plan",
+			"fleet-release",
+			`--environment-name=${ENVIRONMENT_NAME}`,
+			`--component-name=${COMPONENT_NAME}`,
+			`--target-version=${version}`,
+		];
+	}
+	if (action === "update" && status) {
+		return [
+			"run",
+			"release",
+			"update",
+			`--status=${status}`,
+			...(failureReason ? [`--failure-reason=${failureReason}`] : []),
+		];
+	}
+	throw new Error("Release marker action must be plan or update with a status");
+}
+
+export function runReleaseMarker(
+	action,
+	options = {},
+	{ isVersionCommitImpl = isPackageVersionCommit, execImpl = (args) => execFileSync("circleci", args, { stdio: "inherit" }) } = {},
+) {
+	if (!isVersionCommitImpl()) {
+		console.log("This commit does not version @qredence/fleet; deploy marker is a no-op.");
+		return false;
+	}
+	execImpl(releaseMarkerArgs({ action, ...options }));
+	return true;
+}
+
+const action = process.argv[2];
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+	try {
+		runReleaseMarker(action, {
+			status: process.env.RELEASE_MARKER_STATUS,
+			failureReason: process.env.RELEASE_MARKER_FAILURE_REASON,
+		});
+	} catch (error) {
+		console.error(error instanceof Error ? error.message : String(error));
+		process.exit(1);
+	}
+}

--- a/scripts/release-marker.mjs
+++ b/scripts/release-marker.mjs
@@ -28,6 +28,7 @@ export function releaseMarkerArgs({ action, status, version = packageManifest.ve
 			"run",
 			"release",
 			"update",
+			"fleet-release",
 			`--status=${status}`,
 			...(failureReason ? [`--failure-reason=${failureReason}`] : []),
 		];

--- a/scripts/rollback-marker.mjs
+++ b/scripts/rollback-marker.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { readRegistryMetadata } from "./rollback-release.mjs";
+import { parseStableVersion } from "./release-utils.mjs";
+
+export const ROLLBACK_DEPLOY_NAME = "fleet-rollback";
+export const ROLLBACK_MARKER_STATE_PATH = ".circleci/rollback-marker.state.json";
+
+const TERMINAL_STATUSES = new Set(["SUCCESS", "FAILED", "CANCELED"]);
+
+export function rollbackMarkerArgs({ status, failureReason } = {}) {
+	if (!TERMINAL_STATUSES.has(status)) {
+		throw new Error(`Rollback marker status must be one of ${[...TERMINAL_STATUSES].join(", ")}`);
+	}
+	return [
+		"run",
+		"release",
+		"update",
+		ROLLBACK_DEPLOY_NAME,
+		`--status=${status}`,
+		...(status === "FAILED" && failureReason ? [`--failure-reason=${failureReason}`] : []),
+	];
+}
+
+export function resolveRollbackMarker({ requestedStatus, currentVersion, targetVersion, latestVersion, failureReason } = {}) {
+	if (!TERMINAL_STATUSES.has(requestedStatus)) {
+		throw new Error(`Rollback marker status must be one of ${[...TERMINAL_STATUSES].join(", ")}`);
+	}
+	parseStableVersion(currentVersion);
+	parseStableVersion(targetVersion);
+	parseStableVersion(latestVersion);
+
+	if (latestVersion === targetVersion) return { status: "SUCCESS" };
+	if (latestVersion === currentVersion && requestedStatus === "CANCELED") return { status: "CANCELED" };
+	if (latestVersion === currentVersion) {
+		return { status: "FAILED", failureReason: failureReason ?? "npm dist-tag rollback did not change latest" };
+	}
+	return {
+		status: "FAILED",
+		failureReason:
+			`${failureReason ? `${failureReason}; ` : ""}npm latest is ${latestVersion}; expected ${targetVersion} (rollback target) or ${currentVersion} (current version)`,
+	};
+}
+
+function readMarkerState(statePath) {
+	try {
+		return JSON.parse(readFileSync(statePath, "utf8"));
+	} catch (error) {
+		if (error?.code === "ENOENT") return undefined;
+		throw error;
+	}
+}
+
+function writeMarkerState(statePath, state) {
+	writeFileSync(statePath, `${JSON.stringify(state)}\n`, { mode: 0o600 });
+}
+
+function stateAlreadyAttempted(state) {
+	return Boolean(state?.attempted);
+}
+
+function isTerminalMarkerError(error) {
+	return /terminal|already.*(?:success|failed|canceled)|cannot update.*(?:success|failed|canceled)/i.test(
+		error instanceof Error ? error.message : String(error),
+	);
+}
+
+/**
+ * Reconciles npm latest before recording a rollback marker terminal status.
+ * The state file prevents a second terminal update after an uncertain command result.
+ */
+export async function reconcileRollbackMarker({
+	currentVersion,
+	targetVersion,
+	requestedStatus,
+	failureReason = "npm dist-tag rollback failed",
+	fetchImpl = fetch,
+	execImpl = (args) => execFileSync("circleci", args, { stdio: "inherit" }),
+	statePath = ROLLBACK_MARKER_STATE_PATH,
+} = {}) {
+	const previousState = readMarkerState(statePath);
+	if (stateAlreadyAttempted(previousState)) {
+		return {
+			status: previousState.status,
+			latestVersion: previousState.latestVersion,
+			skipped: true,
+		};
+	}
+
+	if (!currentVersion || !targetVersion) throw new Error("Rollback marker reconciliation requires current and target versions");
+	const metadata = await readRegistryMetadata({ fetchImpl });
+	const latestVersion = metadata?.["dist-tags"]?.latest;
+	if (!latestVersion) throw new Error("npm metadata has no latest dist-tag for @qredence/fleet");
+	const resolution = resolveRollbackMarker({
+		requestedStatus,
+		currentVersion,
+		targetVersion,
+		latestVersion,
+		failureReason,
+	});
+
+	try {
+		await execImpl(rollbackMarkerArgs(resolution));
+	} catch (error) {
+		if (isTerminalMarkerError(error)) {
+			writeMarkerState(statePath, {
+				attempted: true,
+				status: resolution.status,
+				latestVersion,
+				markerUpdateError: error instanceof Error ? error.message : String(error),
+			});
+		}
+		throw error;
+	}
+
+	writeMarkerState(statePath, { attempted: true, status: resolution.status, latestVersion });
+	if (requestedStatus === "SUCCESS" && resolution.status !== "SUCCESS") {
+		throw new Error(`Rollback marker reconciled to ${resolution.status}; npm latest is ${latestVersion}`);
+	}
+	return { status: resolution.status, latestVersion, skipped: false };
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+	const requestedStatus = process.argv[2];
+	reconcileRollbackMarker({
+		currentVersion: process.env.ROLLBACK_CURRENT_VERSION,
+		targetVersion: process.env.ROLLBACK_TARGET_VERSION,
+		requestedStatus,
+		failureReason: process.env.ROLLBACK_FAILURE_REASON,
+	})
+		.then((result) => {
+			if (result.skipped) console.log(`Rollback marker update skipped after prior ${result.status ?? "uncertain"} attempt.`);
+		})
+		.catch((error) => {
+			console.error(error instanceof Error ? error.message : String(error));
+			process.exit(1);
+		});
+}

--- a/scripts/rollback-release.mjs
+++ b/scripts/rollback-release.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { NPM_REGISTRY, compareVersions, parseStableVersion } from "./release-utils.mjs";
+
+export const PACKAGE_NAME = "@qredence/fleet";
+
+function registryUrl() {
+	return `${NPM_REGISTRY}${encodeURIComponent(PACKAGE_NAME)}`;
+}
+
+async function readRegistryMetadata({ fetchImpl = fetch } = {}) {
+	const response = await fetchImpl(registryUrl(), {
+		headers: { Accept: "application/json" },
+	});
+	if (response.status === 404) throw new Error(`${PACKAGE_NAME} is not published`);
+	if (!response.ok) throw new Error(`npm registry metadata lookup failed with HTTP ${response.status}`);
+	return response.json();
+}
+
+/**
+ * Validates the optimistic-concurrency and immutability rules for a rollback.
+ * @param {object} options
+ * @param {string} options.currentVersion - Version CircleCI recorded as deployed.
+ * @param {string} options.targetVersion - Version selected for rollback.
+ * @param {string} options.latestVersion - Version currently assigned to npm latest.
+ * @param {object|undefined} options.targetMetadata - Published npm metadata for the target version.
+ * @returns {{currentVersion: string, targetVersion: string}}
+ */
+export function validateRollback({ currentVersion, targetVersion, latestVersion, targetMetadata }) {
+	parseStableVersion(currentVersion);
+	parseStableVersion(targetVersion);
+	parseStableVersion(latestVersion);
+	if (latestVersion !== currentVersion) {
+		throw new Error(
+			`Refusing rollback: npm latest is ${latestVersion}, but CircleCI expected ${currentVersion}; a newer deployment may have started.`,
+		);
+	}
+	if (targetVersion === currentVersion) throw new Error(`Refusing rollback: target version ${targetVersion} is already active`);
+	if (compareVersions(targetVersion, currentVersion) >= 0) {
+		throw new Error(`Refusing rollback: target version ${targetVersion} is not older than ${currentVersion}`);
+	}
+	if (!targetMetadata || targetMetadata.version !== targetVersion) {
+		throw new Error(`Refusing rollback: ${PACKAGE_NAME}@${targetVersion} is not published`);
+	}
+	return { currentVersion, targetVersion };
+}
+
+/**
+ * Verifies the selected npm version and moves only the latest dist-tag.
+ * @param {object} options
+ * @param {string} options.currentVersion - Version CircleCI recorded as deployed.
+ * @param {string} options.targetVersion - Version selected for rollback.
+ * @param {Function} [options.fetchImpl=fetch] - Registry metadata implementation.
+ * @param {Function} [options.distTagAddImpl] - Mutation implementation.
+ * @returns {Promise<{currentVersion: string, targetVersion: string}>}
+ */
+export async function rollbackRelease({
+	currentVersion,
+	targetVersion,
+	fetchImpl = fetch,
+	distTagAddImpl = (version) =>
+		execFileSync("npm", ["dist-tag", "add", `${PACKAGE_NAME}@${version}`, "latest"], { stdio: "inherit" }),
+} = {}) {
+	if (!currentVersion || !targetVersion) throw new Error("Rollback requires current and target versions");
+	const metadata = await readRegistryMetadata({ fetchImpl });
+	const latestVersion = metadata?.["dist-tags"]?.latest;
+	if (!latestVersion) throw new Error(`npm metadata has no latest dist-tag for ${PACKAGE_NAME}`);
+	const targetMetadata = metadata?.versions?.[targetVersion];
+	const result = validateRollback({ currentVersion, targetVersion, latestVersion, targetMetadata });
+	await distTagAddImpl(targetVersion);
+	return result;
+}
+
+async function main() {
+	const result = await rollbackRelease({
+		currentVersion: process.env.ROLLBACK_CURRENT_VERSION,
+		targetVersion: process.env.ROLLBACK_TARGET_VERSION,
+	});
+	console.log(`Moved ${PACKAGE_NAME} latest from ${result.currentVersion} to ${result.targetVersion}.`);
+}
+
+if (process.argv[1] && new URL(import.meta.url).pathname === process.argv[1]) {
+	main().catch((error) => {
+		console.error(error instanceof Error ? error.message : String(error));
+		process.exit(1);
+	});
+}

--- a/scripts/rollback-release.mjs
+++ b/scripts/rollback-release.mjs
@@ -9,7 +9,7 @@ function registryUrl() {
 	return `${NPM_REGISTRY}${encodeURIComponent(PACKAGE_NAME)}`;
 }
 
-async function readRegistryMetadata({ fetchImpl = fetch } = {}) {
+export async function readRegistryMetadata({ fetchImpl = fetch } = {}) {
 	const response = await fetchImpl(registryUrl(), {
 		headers: { Accept: "application/json" },
 	});


### PR DESCRIPTION
## Summary
- Add explicit CircleCI-hosted resource classes and serialize release/rollback operations.
- Add deploy marker lifecycle steps for the real npm publish job, with a no-op marker helper for non-release commits.
- Add an audited rollback pipeline that verifies the npm latest fence and immutable target before moving only the latest dist-tag.
- Document the fleet-cli/production mapping and manual rollback procedure.

## Validation
- `pnpm run check`
- `pnpm run test:release`
- `pnpm run test:web`
- `circleci config validate .circleci/config.yml`
- `circleci config validate .circleci/rollback.yml`
- `git diff --check`

No npm publication or dist-tag mutation was performed. Live CircleCI deploy/rollback setup remains a post-merge operation; automatic Smart Deployment validation is intentionally not enabled.