### PR TITLE
ci: serialize npm deployment promotion

### DIFF
--- a/.circleci/deploy.yml
+++ b/.circleci/deploy.yml
@@ -89,6 +89,7 @@ workflows:
       - deploy-fleet:
           context:
             - npm-dist-tag-deploy
+          serial-group: fleet-release-operations
           filters:
             branches:
               only: main


### PR DESCRIPTION
## Summary\n- serialize forward npm dist-tag promotion with the existing fleet-release-operations group\n- prevent deploy promotion from racing publication or rollback\n\n## Validation\n- circleci config validate .circleci/deploy.yml\n- pnpm run check (pre-commit)\n- git diff --check\n\nNo npm tag mutation was performed.