### PR TITLE
fix: make release artifacts deterministic

### DIFF
--- a/.changeset/deterministic-release-artifact.md
+++ b/.changeset/deterministic-release-artifact.md
@@ -1,0 +1,5 @@
+---
+"@qredence/fleet": patch
+---
+
+Make the generated bundle-budget release metadata deterministic so immutable npm release retries produce the same artifact checksum.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,13 @@ jobs:
       - install-pnpm
       - install-dependencies
       - run:
+          name: Set deterministic release timestamp
+          command: |
+            SOURCE_DATE_EPOCH="$(git show -s --format=%ct HEAD)"
+            echo "export SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}" >> "${BASH_ENV}"
+            export SOURCE_DATE_EPOCH
+            echo "SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}"
+      - run:
           name: Build web bundle and release artifacts
           command: pnpm run build:web:release
       - run:

--- a/web/app/scripts/check-bundle-budget.mjs
+++ b/web/app/scripts/check-bundle-budget.mjs
@@ -7,6 +7,10 @@ const baselineRouteEntryGzipBytes = 1_058_534
 const acceptedEagerGraphGzipBytes = 352_192
 const maximumEagerGraphGzipBytes = 450 * 1024
 const maximumGrowthFactor = 1.05
+const sourceDateEpoch = Number(process.env.SOURCE_DATE_EPOCH)
+const snapshotTimestamp = Number.isFinite(sourceDateEpoch)
+  ? new Date(sourceDateEpoch * 1000).toISOString()
+  : new Date().toISOString()
 
 if (!existsSync(assetsDirectory)) {
   throw new Error("Bundle contract requires a fresh @prime-agent/web production build.")
@@ -78,7 +82,7 @@ writeFileSync(
   resolve(assetsDirectory, "..", "bundle-budget.json"),
   JSON.stringify(
     {
-      timestamp: new Date().toISOString(),
+      timestamp: snapshotTimestamp,
       routeEntry: routeEntries[0],
       routeEntryGzipBytes,
       routeEntryReduction: reduction,


### PR DESCRIPTION
## Summary
- make bundle-budget release metadata stable from the commit timestamp
- export SOURCE_DATE_EPOCH in the CircleCI build artifact lane
- add a patch Changeset so the guarded release flow can publish the next immutable package

## Validation
- pnpm run check
- pnpm run test:release
- pnpm run test:web
- both local repeat-build snapshots match
- all CircleCI configs validate
- git diff --check

This fixes the failed release retry that correctly detected a timestamp-only checksum mismatch for @qredence/fleet@0.5.8.