### PR TITLE
feat(web): TUI parity for slash args, session titles, and MCP settings

### DIFF
--- a/.changeset/web-tui-parity.md
+++ b/.changeset/web-tui-parity.md
@@ -1,0 +1,5 @@
+---
+"@qredence/fleet": minor
+---
+
+Keep slash commands with arguments in the composer until submit, title command-only sessions from Fleet sidecars instead of "(no messages)", and add a Settings MCP connections surface with browser-safe list, add, login, and logout.

--- a/web/app/src/lib/pi/chat-client.ts
+++ b/web/app/src/lib/pi/chat-client.ts
@@ -7,6 +7,11 @@ import type {
 } from "@prime-agent/web-protocol";
 import type {
 	ChatCommandsResponse,
+	ChatMcpDeleteRequest,
+	ChatMcpListResponse,
+	ChatMcpOAuthLoginRequest,
+	ChatMcpOAuthLoginResponse,
+	ChatMcpUpsertRequest,
 	ChatModelsDiscoverRequest,
 	ChatModelsDiscoverResponse,
 	ChatModelsResponse,
@@ -39,6 +44,11 @@ import type {
 } from "@prime-agent/web-protocol/chat-protocol";
 import {
 	ChatCommandsResponseSchema,
+	ChatMcpDeleteRequestSchema,
+	ChatMcpListResponseSchema,
+	ChatMcpOAuthLoginRequestSchema,
+	ChatMcpOAuthLoginResponseSchema,
+	ChatMcpUpsertRequestSchema,
 	ChatModelsDiscoverRequestSchema,
 	ChatModelsDiscoverResponseSchema,
 	ChatModelsResponseSchema,
@@ -118,6 +128,10 @@ export type ChatClient = {
 		onEvent: (event: ChatStreamEvent) => void,
 		signal?: AbortSignal,
 	) => Promise<void>;
+	getMcpConnections: () => Promise<ChatMcpListResponse>;
+	upsertMcpConnection: (request: ChatMcpUpsertRequest) => Promise<ChatMcpListResponse>;
+	removeMcpConnection: (request: ChatMcpDeleteRequest) => Promise<ChatMcpListResponse>;
+	mcpOAuth: (request: ChatMcpOAuthLoginRequest) => Promise<ChatMcpOAuthLoginResponse>;
 	getProviders: () => Promise<{ providers: Array<ChatProviderInfo> }>;
 	oauthLoginProvider: (request: ChatProviderOAuthLoginRequest) => Promise<ChatProviderOAuthLoginResponse>;
 	updateProvider: (request: ChatProviderUpdateRequest) => Promise<ChatProviderUpdateResponse>;
@@ -387,6 +401,37 @@ export const chatClient: ChatClient = {
 		};
 
 		await attempt(true);
+	},
+
+	async getMcpConnections() {
+		return fetchValidatedJson("/api/chat/mcp", ChatMcpListResponseSchema);
+	},
+
+	async upsertMcpConnection(request: ChatMcpUpsertRequest) {
+		const body = ChatMcpUpsertRequestSchema.parse(request);
+		return fetchValidatedJson("/api/chat/mcp", ChatMcpListResponseSchema, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		});
+	},
+
+	async removeMcpConnection(request: ChatMcpDeleteRequest) {
+		const body = ChatMcpDeleteRequestSchema.parse(request);
+		return fetchValidatedJson("/api/chat/mcp", ChatMcpListResponseSchema, {
+			method: "DELETE",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		});
+	},
+
+	async mcpOAuth(request: ChatMcpOAuthLoginRequest) {
+		const body = ChatMcpOAuthLoginRequestSchema.parse(request);
+		return fetchValidatedJson("/api/chat/mcp/oauth", ChatMcpOAuthLoginResponseSchema, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		});
 	},
 
 	async getProviders() {

--- a/web/app/src/lib/pi/chat-queries.ts
+++ b/web/app/src/lib/pi/chat-queries.ts
@@ -1,5 +1,10 @@
 import type { ProjectId } from "@prime-agent/web-protocol";
 import type {
+	ChatMcpDeleteRequest,
+	ChatMcpListResponse,
+	ChatMcpOAuthLoginRequest,
+	ChatMcpOAuthLoginResponse,
+	ChatMcpUpsertRequest,
 	ChatProviderOAuthLoginRequest,
 	ChatProviderOAuthLoginResponse,
 	ChatProviderRemoveRequest,
@@ -15,6 +20,7 @@ export const chatQueryKeys = {
 	models: (projectId?: ProjectId) => ["chat", "models", projectId ?? "default"] as const,
 	modelCatalog: (projectId?: ProjectId) => ["chat", "models", "catalog", projectId ?? "default"] as const,
 	providers: ["chat", "providers"] as const,
+	mcp: ["chat", "mcp"] as const,
 	resources: (projectId?: ProjectId) => ["chat", "resources", projectId ?? "default"] as const,
 	commands: (projectId?: ProjectId) => ["chat", "commands", projectId ?? "default"] as const,
 	settings: (projectId?: ProjectId) => ["chat", "settings", projectId ?? "default"] as const,
@@ -103,6 +109,47 @@ export function useWorkspaceTree(projectId?: ProjectId, options?: { enabled?: bo
 		queryKey: keys.workspace(projectId),
 		queryFn: () => chatClient.getWorkspaceTree(projectId),
 		enabled: Boolean(projectId) && options?.enabled !== false,
+	});
+}
+
+export function useChatMcpConnections() {
+	return useQuery({
+		queryKey: keys.mcp,
+		queryFn: () => chatClient.getMcpConnections(),
+	});
+}
+
+export function useUpdateMcpConnection() {
+	const queryClient = useQueryClient();
+	return useMutation<ChatMcpListResponse, Error, ChatMcpUpsertRequest>({
+		mutationFn: (request) => chatClient.upsertMcpConnection(request),
+		onSuccess: (data) => {
+			queryClient.setQueryData(keys.mcp, data);
+			void queryClient.invalidateQueries({ queryKey: ["chat", "resources"] });
+		},
+	});
+}
+
+export function useRemoveMcpConnection() {
+	const queryClient = useQueryClient();
+	return useMutation<ChatMcpListResponse, Error, ChatMcpDeleteRequest>({
+		mutationFn: (request) => chatClient.removeMcpConnection(request),
+		onSuccess: (data) => {
+			queryClient.setQueryData(keys.mcp, data);
+			void queryClient.invalidateQueries({ queryKey: ["chat", "resources"] });
+		},
+	});
+}
+
+export function useMcpOAuth() {
+	const queryClient = useQueryClient();
+	return useMutation<ChatMcpOAuthLoginResponse, Error, ChatMcpOAuthLoginRequest>({
+		mutationFn: (request) => chatClient.mcpOAuth(request),
+		onSuccess: (data) => {
+			if (data.status !== "success" || !data.connections) return;
+			queryClient.setQueryData(keys.mcp, { connections: data.connections });
+			void queryClient.invalidateQueries({ queryKey: ["chat", "resources"] });
+		},
 	});
 }
 

--- a/web/app/src/lib/pi/session-sidebar-model.test.ts
+++ b/web/app/src/lib/pi/session-sidebar-model.test.ts
@@ -74,4 +74,16 @@ describe("Fleet session sidebar model", () => {
 			"draft-chat",
 		]);
 	});
+
+	it("lists command-only sessions after sidecar join bumps their count", () => {
+		const commandOnly: ChatSessionInfo = {
+			...session("refine-chat", "2026-01-03T00:00:00.000Z"),
+			title: "Tighten the plan",
+			firstMessage: "Tighten the plan",
+			messageCount: 1,
+		};
+		expect(displayProjectSessions([commandOnly], undefined).map(({ sessionId }) => sessionId)).toEqual([
+			"refine-chat",
+		]);
+	});
 });

--- a/web/app/src/lib/pi/session-sidebar.test.tsx
+++ b/web/app/src/lib/pi/session-sidebar.test.tsx
@@ -412,7 +412,7 @@ describe("FleetSessionSidebar draft sessions", () => {
   })
 
   it("keeps the active message-less session visible while composing", () => {
-    const { getByRole } = render(
+    const { getByRole, queryByRole } = render(
       <AnimatedSidebarProvider>
         <SidebarHarness
           sessions={[draftSession("draft-chat", "alpha")]}
@@ -428,7 +428,8 @@ describe("FleetSessionSidebar draft sessions", () => {
       </AnimatedSidebarProvider>,
     )
 
-    expect(getByRole("treeitem", { name: /\(no messages\)/i })).toBeTruthy()
+    expect(getByRole("treeitem", { name: /draft-ch/i })).toBeTruthy()
+    expect(queryByRole("treeitem", { name: /\(no messages\)/i })).toBeNull()
   })
 
   it("offers Start first chat when a project only has message-less sessions", () => {
@@ -448,5 +449,27 @@ describe("FleetSessionSidebar draft sessions", () => {
     )
 
     expect(getByRole("treeitem", { name: "Start first chat" })).toBeTruthy()
+  })
+
+  it("distinguishes duplicate session titles with a short id suffix", () => {
+    const first = { ...session("refine-aaaa", "alpha"), title: "Tighten the plan", firstMessage: "Tighten the plan" }
+    const second = { ...session("refine-bbbb", "alpha"), title: "Tighten the plan", firstMessage: "Tighten the plan" }
+    const { getByRole } = render(
+      <AnimatedSidebarProvider>
+        <SidebarHarness
+          sessions={[first, second]}
+          projects={[project("alpha")]}
+          projectSessions={[first, second]}
+          activeProjectId="alpha"
+          onNewSession={vi.fn()}
+          onResumeSession={vi.fn()}
+          onRenameSession={vi.fn()}
+          onDeleteSession={vi.fn()}
+        />
+      </AnimatedSidebarProvider>,
+    )
+
+    expect(getByRole("treeitem", { name: /Tighten the plan · aaaa/i })).toBeTruthy()
+    expect(getByRole("treeitem", { name: /Tighten the plan · bbbb/i })).toBeTruthy()
   })
 })

--- a/web/app/src/lib/pi/slash-commands.test.ts
+++ b/web/app/src/lib/pi/slash-commands.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { buildSlashCommands, resolveLocalSlashAction, WEB_BUILTIN_SLASH_COMMANDS } from "./slash-commands";
+import {
+	buildSlashCommands,
+	resolveLocalSlashAction,
+	slashCommandInsertsPrefixOnSelect,
+	WEB_BUILTIN_SLASH_COMMANDS,
+} from "./slash-commands";
 
 describe("buildSlashCommands", () => {
 	it("keeps client dispatcher builtins when the API returns a short catalog", () => {
@@ -60,6 +65,19 @@ describe("resolveLocalSlashAction", () => {
 		expect(unresolved).toEqual([]);
 	});
 
+	it("resolves /mcp locally so it can open the MCP settings surface", () => {
+		expect(resolveLocalSlashAction("mcp")).toEqual({ type: "open-mcp", args: "" });
+		expect(resolveLocalSlashAction("mcp", "logout linear")).toEqual({
+			type: "open-mcp",
+			args: "logout linear",
+		});
+	});
+
+	it("does not execute empty /name on select so Usage is not shown until submit", () => {
+		expect(slashCommandInsertsPrefixOnSelect({ id: "name" })).toBe(true);
+		expect(resolveLocalSlashAction("name")).toEqual({ type: "session-rename", name: undefined });
+	});
+
 	it("leaves session commands for the backend chat transport", () => {
 		for (const [command, args] of [
 			["compact", "keep the latest context"],
@@ -75,9 +93,33 @@ describe("resolveLocalSlashAction", () => {
 		const openui = buildSlashCommands(null, false).find((item) => item.id === "openui");
 		expect(openui).toMatchObject({
 			label: "/openui",
-			value: "/openui <request> ",
+			value: "/openui ",
 			description: "Generate a durable OpenUI HTML artifact",
+			metadata: { argumentHint: "<request>" },
 		});
 		expect(resolveLocalSlashAction("compact", "summarize")).toBeNull();
+	});
+});
+
+describe("slashCommandInsertsPrefixOnSelect", () => {
+	it("inserts a prefix for argument-taking builtins instead of executing them", () => {
+		for (const id of ["name", "import", "btw", "openui", "mcp"]) {
+			expect(slashCommandInsertsPrefixOnSelect({ id })).toBe(true);
+		}
+	});
+
+	it("still executes commands that do not take arguments", () => {
+		for (const id of ["settings", "copy", "clone", "share"]) {
+			expect(slashCommandInsertsPrefixOnSelect({ id })).toBe(false);
+		}
+	});
+
+	it("keeps the argument hint out of the composer value", () => {
+		const suggestions = buildSlashCommands(null, false);
+		for (const id of ["name", "import", "btw", "openui", "mcp"]) {
+			const suggestion = suggestions.find((item) => item.id === id);
+			expect(suggestion?.value).toBe(`/${id} `);
+			expect(suggestion?.value).not.toMatch(/\[|</);
+		}
 	});
 });

--- a/web/app/src/lib/pi/slash-commands.ts
+++ b/web/app/src/lib/pi/slash-commands.ts
@@ -136,6 +136,7 @@ export const WEB_BUILTIN_SLASH_COMMANDS: Array<ChatSlashCommandInfo> = [
 export type SettingsSlashTab =
 	| "appearance"
 	| "chat"
+	| "mcp"
 	| "sandbox"
 	| "providers"
 	| "llm-models"
@@ -330,11 +331,16 @@ export type SlashCommandSuggestion = {
 	value: string;
 	description?: string;
 	category?: "builtin" | "extension" | "prompt" | "skill";
+	metadata?: Record<string, string | undefined>;
 };
 
 function normalizeSlashCommandName(name: string) {
 	const normalized = name.trim().replace(/\s+/g, "-");
 	return /^[\w.-]+$/.test(normalized) ? normalized : "";
+}
+
+function slashSuggestionValue(name: string) {
+	return `/${name} `;
 }
 
 function toSlashSuggestion(command: {
@@ -343,13 +349,28 @@ function toSlashSuggestion(command: {
 	argumentHint?: string;
 	category?: SlashCommandSuggestion["category"];
 }): SlashCommandSuggestion {
+	const argumentHint = command.argumentHint?.trim();
 	return {
 		id: command.name,
 		label: `/${command.name}`,
-		value: `/${command.name}${command.argumentHint ? ` ${command.argumentHint}` : ""} `,
+		value: slashSuggestionValue(command.name),
 		description: command.description,
 		category: command.category ?? "builtin",
+		...(argumentHint ? { metadata: { argumentHint } } : {}),
 	};
+}
+
+/**
+ * Selecting a suggestion with an argument hint inserts `/${name} ` into the
+ * composer. Execution happens on submit so the user can type required args.
+ */
+export function slashCommandInsertsPrefixOnSelect(item: {
+	id: string;
+	metadata?: Record<string, string | undefined>;
+}): boolean {
+	if (item.metadata?.argumentHint?.trim()) return true;
+	const builtin = WEB_BUILTIN_SLASH_COMMANDS.find((command) => command.name === item.id);
+	return Boolean(builtin?.argumentHint?.trim());
 }
 
 /**
@@ -386,12 +407,14 @@ export function buildSlashCommands(
 			if (resource.activationStatus && resource.activationStatus !== "active") continue;
 			const commandName = normalizeSlashCommandName(resource.name);
 			if (!commandName || byId.has(commandName)) continue;
+			const argumentHint = resource.argumentHint?.trim();
 			byId.set(commandName, {
 				id: commandName,
 				label: `/${commandName}`,
-				value: `/${commandName} `,
+				value: slashSuggestionValue(commandName),
 				description: resource.description,
 				category,
+				...(argumentHint ? { metadata: { argumentHint } } : {}),
 			});
 		}
 	}

--- a/web/app/src/lib/pi/use-chat-view.test.ts
+++ b/web/app/src/lib/pi/use-chat-view.test.ts
@@ -29,6 +29,17 @@ describe("getActiveSessionLabel", () => {
 	it("falls back to the transcript when the active session is not listed", () => {
 		expect(getActiveSessionLabel("session-2", [session], messages)).toBe("Transcript title");
 	});
+
+	it("skips placeholder titles and uses a short session id", () => {
+		const empty: ChatSessionInfo = {
+			...session,
+			sessionId: "session-empty",
+			title: "(no messages)",
+			firstMessage: "",
+			messageCount: 0,
+		};
+		expect(getActiveSessionLabel("session-empty", [empty], [])).toBe("session-");
+	});
 });
 
 describe("buildContextSuggestions", () => {

--- a/web/app/src/lib/pi/use-chat-view.ts
+++ b/web/app/src/lib/pi/use-chat-view.ts
@@ -7,6 +7,7 @@ import type {
 	WorkspaceTreeResponse,
 } from "@prime-agent/web-protocol/chat-protocol";
 import type { ChatMessage, ChatToolPart } from "@prime-agent/web-protocol/chat-types";
+import { meaningfulSessionLabel, sessionListTitle } from "@prime-agent/web-protocol/session-label";
 import { useMemo } from "react";
 
 export function useChatSuggestions({
@@ -200,11 +201,11 @@ export function getActiveSessionLabel(
 	messages: Array<ChatMessage>,
 	presentation?: PrimeAgentSessionPresentation,
 ) {
-	if (presentation?.sessionName?.trim()) return normalizeSessionLabel(presentation.sessionName);
+	const named = meaningfulSessionLabel(presentation?.sessionName);
+	if (named) return normalizeSessionLabel(named);
 	const activeSession = sessions.find((session) => session.sessionId === activeSessionId);
-	if (activeSession?.title.trim()) {
-		return normalizeSessionLabel(activeSession.title);
-	}
+	const titled = meaningfulSessionLabel(activeSession?.title);
+	if (titled) return normalizeSessionLabel(titled);
 
 	const lastUserMessage = [...messages]
 		.reverse()
@@ -214,7 +215,11 @@ export function getActiveSessionLabel(
 
 	if (activeSession) {
 		return normalizeSessionLabel(
-			activeSession.title || activeSession.firstMessage || activeSession.sessionId.slice(0, 8),
+			sessionListTitle({
+				sessionId: activeSession.sessionId,
+				title: activeSession.title,
+				firstMessage: activeSession.firstMessage,
+			}),
 		);
 	}
 

--- a/web/app/src/lib/pi/use-chat-workspace-data.ts
+++ b/web/app/src/lib/pi/use-chat-workspace-data.ts
@@ -17,6 +17,7 @@ import { useOptionalUser } from "@/lib/auth-stub";
 import { chatClient } from "@/lib/pi/chat-client";
 import {
 	useChatCommands,
+	useChatMcpConnections,
 	useChatModelCatalog,
 	useChatModels,
 	useChatProjects,
@@ -24,10 +25,13 @@ import {
 	useChatResources,
 	useChatSettings,
 	useDiscoverChatModels,
+	useMcpOAuth,
 	useOAuthLoginProvider,
 	useRemoveChatProvider,
+	useRemoveMcpConnection,
 	useUpdateChatProvider,
 	useUpdateChatSettings,
+	useUpdateMcpConnection,
 	useWorkspaceTree,
 } from "@/lib/pi/chat-queries";
 import { assistantMessageHasPendingQuestion } from "@/lib/pi/question-pending";
@@ -81,10 +85,14 @@ export function useChatWorkspaceData() {
 		if (user) identifyAnalyticsUser(user);
 	}, [user]);
 	const { data: providersData, isLoading: isLoadingProviders } = useChatProviders();
+	const { data: mcpData, isLoading: isLoadingMcp } = useChatMcpConnections();
 	const { data: projectsData, refetch: refetchProjects } = useChatProjects();
 	const { mutateAsync: onUpdateProvider, isPending: isUpdatingProvider } = useUpdateChatProvider();
 	const { mutateAsync: onOAuthLogin } = useOAuthLoginProvider();
 	const { mutateAsync: onRemoveProvider, isPending: isRemovingProvider } = useRemoveChatProvider();
+	const { mutateAsync: onUpdateMcp, isPending: isUpdatingMcp } = useUpdateMcpConnection();
+	const { mutateAsync: onRemoveMcp, isPending: isRemovingMcp } = useRemoveMcpConnection();
+	const { mutateAsync: onMcpOAuth } = useMcpOAuth();
 	const { data: modelsData } = useChatModels(activeProjectId);
 	const { data: modelCatalogData } = useChatModelCatalog({
 		enabled: settingsDialogOpen,
@@ -568,7 +576,9 @@ export function useChatWorkspaceData() {
 		artifactRuns,
 		chatMode,
 		handleThemePreferenceChange,
+		isLoadingMcp,
 		isLoadingProviders,
+		isUpdatingMcp: isUpdatingMcp || isRemovingMcp,
 		isUpdatingProvider: isUpdatingProvider || isRemovingProvider,
 		loadSession: loadChatSession,
 		loadSubagentSession,
@@ -579,12 +589,16 @@ export function useChatWorkspaceData() {
 		models,
 		modelCatalog,
 		onDiscoverModels,
+		onMcpOAuth,
 		onOAuthLogin,
+		onRemoveMcp,
 		onRemoveProvider,
+		onUpdateMcp,
 		onUpdateProvider,
 		openWorkspacePath,
 		planLabel,
 		presentation,
+		mcpConnections: mcpData?.connections ?? [],
 		providers: providersData?.providers ?? [],
 		queue,
 		refreshResources,

--- a/web/app/src/lib/pi/use-local-slash-actions.ts
+++ b/web/app/src/lib/pi/use-local-slash-actions.ts
@@ -8,10 +8,13 @@ import {
 } from "@prime-agent/web-design/lib/pi/chat-helpers";
 import type { ChatSessionInfo, ChatSessionMetadata, ChatThinkingLevel } from "@prime-agent/web-protocol/chat-protocol";
 import type { ChatMessage } from "@prime-agent/web-protocol/chat-types";
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
+import { chatClient } from "./chat-client";
 import { assistantTextFromMessage } from "./chat-message-helpers";
+import { chatQueryKeys } from "./chat-queries";
 import type { LocalSlashAction, SettingsSlashTab } from "./slash-commands";
-import { parseSlashInput, resolveLocalSlashAction } from "./slash-commands";
+import { parseSlashInput, resolveLocalSlashAction, slashCommandInsertsPrefixOnSelect } from "./slash-commands";
 
 const CHAT_COMMAND_URL = "/api/chat/command";
 
@@ -34,6 +37,8 @@ type UseLocalSlashActionsArgs = {
 	setThinkingLevel: (level: ChatThinkingLevel) => void;
 	startNewSession: () => void;
 };
+
+const MCP_USAGE = "MCP usage: /mcp, /mcp list, /mcp login <name>, /mcp logout <name>.";
 
 function liveSessionId(metadata: ChatSessionMetadata): string | undefined {
 	const id = metadata.sessionId?.trim();
@@ -164,6 +169,7 @@ export function useLocalSlashActions({
 	setThinkingLevel,
 	startNewSession,
 }: UseLocalSlashActionsArgs) {
+	const queryClient = useQueryClient();
 	/** Fire the bridge runner and echo the result into the transcript. */
 	const chatCommand = useCallback(
 		async (command: string, args = ""): Promise<ChatCommandResult> => {
@@ -483,12 +489,38 @@ export function useLocalSlashActions({
 				case "open-logout":
 					appendLocalMessage("Provider sign-out is managed by Fleet Prime CLI commands.");
 					return true;
-				case "open-mcp":
-					openSettings("chat");
-					if (action.args) {
-						appendLocalMessage(`MCP: ${action.args}. Manage MCP connections with Fleet Prime CLI configuration.`);
+				case "open-mcp": {
+					openSettings("mcp");
+					const parts = action.args.trim().split(/\s+/).filter(Boolean);
+					const verb = parts[0];
+					const target = parts.slice(1).join(" ");
+					if (!verb || verb === "list" || ((verb === "login" || verb === "reconnect") && !target)) {
+						return true;
 					}
+					if ((verb === "login" || verb === "reconnect") && target) {
+						appendLocalMessage(`Open Settings → MCP and sign in to "${target}".`);
+						return true;
+					}
+					if (verb === "logout" && target) {
+						void (async () => {
+							try {
+								const result = await chatClient.mcpOAuth({ name: target, action: "logout" });
+								if (result.connections) {
+									queryClient.setQueryData(chatQueryKeys.mcp, { connections: result.connections });
+								}
+								void queryClient.invalidateQueries({ queryKey: ["chat", "resources"] });
+								appendLocalMessage(`Signed out of MCP connection "${target}".`);
+							} catch (error) {
+								appendLocalMessage(
+									error instanceof Error ? error.message : `Could not sign out of "${target}".`,
+								);
+							}
+						})();
+						return true;
+					}
+					appendLocalMessage(MCP_USAGE);
 					return true;
+				}
 				case "fast-toggle": {
 					void (async () => {
 						appendLocalMessage(
@@ -572,6 +604,7 @@ export function useLocalSlashActions({
 			onForkPicker,
 			openSettings,
 			onOpenUIRequest,
+			queryClient,
 			sessions,
 			setEffortPickerOpen,
 			setModelKey,
@@ -583,9 +616,7 @@ export function useLocalSlashActions({
 
 	const handleSlashCommandSelect = useCallback(
 		(item: SuggestionItem) => {
-			// Selecting /openui should seed the composer with its argument hint;
-			// dispatch happens when the completed command is submitted.
-			if (item.id === "openui") return false;
+			if (slashCommandInsertsPrefixOnSelect(item)) return false;
 			const action = resolveLocalSlashAction(item.id);
 			if (!action) return false;
 			return applyLocalSlashAction(action);

--- a/web/app/src/lib/pi/use-right-panel-context-value.ts
+++ b/web/app/src/lib/pi/use-right-panel-context-value.ts
@@ -6,6 +6,11 @@ import type {
 import type { RightPanel, ThemePreference } from "@prime-agent/web-design/lib/canvas-utils";
 import type { ChatModelOption } from "@prime-agent/web-design/lib/pi/chat-helpers";
 import type {
+	ChatMcpDeleteRequest,
+	ChatMcpListResponse,
+	ChatMcpOAuthLoginRequest,
+	ChatMcpOAuthLoginResponse,
+	ChatMcpUpsertRequest,
 	ChatMode,
 	ChatPiSettingsUpdate,
 	ChatProviderInfo,
@@ -20,6 +25,7 @@ import type {
 	ChatSessionResponse,
 	ChatSettingsResponse,
 	ChatThinkingLevel,
+	McpConnectionInfo,
 	PrimeAgentArtifactRun,
 	PrimeAgentSessionPresentation,
 	QueueState,
@@ -34,7 +40,9 @@ type UseRightPanelContextValueArgs = {
 	artifactRuns: Array<PrimeAgentArtifactRun>;
 	chatMode: ChatMode;
 	handleThemePreferenceChange: (preference: ThemePreference) => void;
+	isLoadingMcp?: boolean;
 	isLoadingProviders?: boolean;
+	isUpdatingMcp?: boolean;
 	isUpdatingProvider?: boolean;
 	loadSession: (metadata: ChatSessionMetadata) => Promise<ChatSessionResponse>;
 	loadSubagentSession: (parentSessionId: string, childId: string) => Promise<ChatSessionResponse>;
@@ -43,10 +51,14 @@ type UseRightPanelContextValueArgs = {
 	onOpenSubagentTab?: (childId: string) => void;
 	modelKey?: string;
 	models: Array<ChatModelOption>;
+	mcpConnections?: Array<McpConnectionInfo>;
 	modelCatalog?: Array<ChatModelOption>;
 	onDiscoverModels?: (providerId: string) => Promise<Array<ChatModelOption>>;
+	onMcpOAuth?: (request: ChatMcpOAuthLoginRequest) => Promise<ChatMcpOAuthLoginResponse>;
 	onOAuthLogin?: (request: ChatProviderOAuthLoginRequest) => Promise<ChatProviderOAuthLoginResponse>;
+	onRemoveMcp?: (request: ChatMcpDeleteRequest) => Promise<ChatMcpListResponse>;
 	onRemoveProvider?: (request: ChatProviderRemoveRequest) => Promise<ChatProviderRemoveResponse>;
+	onUpdateMcp?: (request: ChatMcpUpsertRequest) => Promise<ChatMcpListResponse>;
 	onUpdateProvider?: (request: ChatProviderUpdateRequest) => Promise<ChatProviderUpdateResponse>;
 	openWorkspacePath: (rawPath: string) => void;
 	planLabel?: string;
@@ -93,7 +105,9 @@ export function useRightPanelContextValue({
 	artifactRuns,
 	chatMode,
 	handleThemePreferenceChange,
+	isLoadingMcp,
 	isLoadingProviders,
+	isUpdatingMcp,
 	isUpdatingProvider,
 	loadSession,
 	loadSubagentSession,
@@ -104,12 +118,16 @@ export function useRightPanelContextValue({
 	models,
 	modelCatalog,
 	onDiscoverModels,
+	onMcpOAuth,
 	onOAuthLogin,
+	onRemoveMcp,
 	onRemoveProvider,
+	onUpdateMcp,
 	onUpdateProvider,
 	openWorkspacePath,
 	planLabel,
 	presentation,
+	mcpConnections,
 	providers,
 	queue,
 	refreshResources,
@@ -213,13 +231,19 @@ export function useRightPanelContextValue({
 
 	const settingsActions = useMemo<SettingsActionsContextValue>(
 		() => ({
+			isLoadingMcp,
 			isLoadingProviders,
+			isUpdatingMcp,
 			isUpdatingProvider,
+			mcpConnections,
 			modelCatalog,
 			onDiscoverModels,
+			onMcpOAuth,
 			onOAuthLogin,
+			onRemoveMcp,
 			onRemoveProvider,
 			onThemePreferenceChange: handleThemePreferenceChange,
+			onUpdateMcp,
 			onUpdateProvider,
 			providers,
 			saveSettings,
@@ -230,12 +254,18 @@ export function useRightPanelContextValue({
 		}),
 		[
 			handleThemePreferenceChange,
+			isLoadingMcp,
 			isLoadingProviders,
+			isUpdatingMcp,
 			isUpdatingProvider,
+			mcpConnections,
 			modelCatalog,
 			onDiscoverModels,
+			onMcpOAuth,
 			onOAuthLogin,
+			onRemoveMcp,
 			onRemoveProvider,
+			onUpdateMcp,
 			onUpdateProvider,
 			providers,
 			saveSettings,

--- a/web/app/src/routeTree.gen.ts
+++ b/web/app/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as ApiChatArtifactsRouteImport } from './routes/api/chat/artifact
 import { Route as ApiChatCommandRouteImport } from './routes/api/chat/command'
 import { Route as ApiChatCommandsRouteImport } from './routes/api/chat/commands'
 import { Route as ApiChatEventsRouteImport } from './routes/api/chat/events'
+import { Route as ApiChatMcpRouteImport } from './routes/api/chat/mcp'
 import { Route as ApiChatModelRouteImport } from './routes/api/chat/model'
 import { Route as ApiChatModelsRouteImport } from './routes/api/chat/models'
 import { Route as ApiChatNewRouteImport } from './routes/api/chat/new'
@@ -34,6 +35,7 @@ import { Route as ApiWorkspaceBrowseRouteImport } from './routes/api/workspace/b
 import { Route as ApiWorkspaceFileRouteImport } from './routes/api/workspace/file'
 import { Route as ApiWorkspaceRootRouteImport } from './routes/api/workspace/root'
 import { Route as ApiWorkspaceTreeRouteImport } from './routes/api/workspace/tree'
+import { Route as ApiChatMcpOauthRouteImport } from './routes/api/chat/mcp/oauth'
 import { Route as ApiChatModelsDiscoverRouteImport } from './routes/api/chat/models/discover'
 import { Route as ApiChatProvidersOauthRouteImport } from './routes/api/chat/providers/oauth'
 
@@ -80,6 +82,11 @@ const ApiChatCommandsRoute = ApiChatCommandsRouteImport.update({
 const ApiChatEventsRoute = ApiChatEventsRouteImport.update({
   id: '/events',
   path: '/events',
+  getParentRoute: () => ApiChatRoute,
+} as any)
+const ApiChatMcpRoute = ApiChatMcpRouteImport.update({
+  id: '/mcp',
+  path: '/mcp',
   getParentRoute: () => ApiChatRoute,
 } as any)
 const ApiChatModelRoute = ApiChatModelRouteImport.update({
@@ -162,6 +169,11 @@ const ApiWorkspaceTreeRoute = ApiWorkspaceTreeRouteImport.update({
   path: '/api/workspace/tree',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiChatMcpOauthRoute = ApiChatMcpOauthRouteImport.update({
+  id: '/oauth',
+  path: '/oauth',
+  getParentRoute: () => ApiChatMcpRoute,
+} as any)
 const ApiChatModelsDiscoverRoute = ApiChatModelsDiscoverRouteImport.update({
   id: '/discover',
   path: '/discover',
@@ -183,6 +195,7 @@ export interface FileRoutesByFullPath {
   '/api/chat/command': typeof ApiChatCommandRoute
   '/api/chat/commands': typeof ApiChatCommandsRoute
   '/api/chat/events': typeof ApiChatEventsRoute
+  '/api/chat/mcp': typeof ApiChatMcpRouteWithChildren
   '/api/chat/model': typeof ApiChatModelRoute
   '/api/chat/models': typeof ApiChatModelsRouteWithChildren
   '/api/chat/new': typeof ApiChatNewRoute
@@ -199,6 +212,7 @@ export interface FileRoutesByFullPath {
   '/api/workspace/file': typeof ApiWorkspaceFileRoute
   '/api/workspace/root': typeof ApiWorkspaceRootRoute
   '/api/workspace/tree': typeof ApiWorkspaceTreeRoute
+  '/api/chat/mcp/oauth': typeof ApiChatMcpOauthRoute
   '/api/chat/models/discover': typeof ApiChatModelsDiscoverRoute
   '/api/chat/providers/oauth': typeof ApiChatProvidersOauthRoute
 }
@@ -212,6 +226,7 @@ export interface FileRoutesByTo {
   '/api/chat/command': typeof ApiChatCommandRoute
   '/api/chat/commands': typeof ApiChatCommandsRoute
   '/api/chat/events': typeof ApiChatEventsRoute
+  '/api/chat/mcp': typeof ApiChatMcpRouteWithChildren
   '/api/chat/model': typeof ApiChatModelRoute
   '/api/chat/models': typeof ApiChatModelsRouteWithChildren
   '/api/chat/new': typeof ApiChatNewRoute
@@ -228,6 +243,7 @@ export interface FileRoutesByTo {
   '/api/workspace/file': typeof ApiWorkspaceFileRoute
   '/api/workspace/root': typeof ApiWorkspaceRootRoute
   '/api/workspace/tree': typeof ApiWorkspaceTreeRoute
+  '/api/chat/mcp/oauth': typeof ApiChatMcpOauthRoute
   '/api/chat/models/discover': typeof ApiChatModelsDiscoverRoute
   '/api/chat/providers/oauth': typeof ApiChatProvidersOauthRoute
 }
@@ -242,6 +258,7 @@ export interface FileRoutesById {
   '/api/chat/command': typeof ApiChatCommandRoute
   '/api/chat/commands': typeof ApiChatCommandsRoute
   '/api/chat/events': typeof ApiChatEventsRoute
+  '/api/chat/mcp': typeof ApiChatMcpRouteWithChildren
   '/api/chat/model': typeof ApiChatModelRoute
   '/api/chat/models': typeof ApiChatModelsRouteWithChildren
   '/api/chat/new': typeof ApiChatNewRoute
@@ -258,6 +275,7 @@ export interface FileRoutesById {
   '/api/workspace/file': typeof ApiWorkspaceFileRoute
   '/api/workspace/root': typeof ApiWorkspaceRootRoute
   '/api/workspace/tree': typeof ApiWorkspaceTreeRoute
+  '/api/chat/mcp/oauth': typeof ApiChatMcpOauthRoute
   '/api/chat/models/discover': typeof ApiChatModelsDiscoverRoute
   '/api/chat/providers/oauth': typeof ApiChatProvidersOauthRoute
 }
@@ -273,6 +291,7 @@ export interface FileRouteTypes {
     | '/api/chat/command'
     | '/api/chat/commands'
     | '/api/chat/events'
+    | '/api/chat/mcp'
     | '/api/chat/model'
     | '/api/chat/models'
     | '/api/chat/new'
@@ -289,6 +308,7 @@ export interface FileRouteTypes {
     | '/api/workspace/file'
     | '/api/workspace/root'
     | '/api/workspace/tree'
+    | '/api/chat/mcp/oauth'
     | '/api/chat/models/discover'
     | '/api/chat/providers/oauth'
   fileRoutesByTo: FileRoutesByTo
@@ -302,6 +322,7 @@ export interface FileRouteTypes {
     | '/api/chat/command'
     | '/api/chat/commands'
     | '/api/chat/events'
+    | '/api/chat/mcp'
     | '/api/chat/model'
     | '/api/chat/models'
     | '/api/chat/new'
@@ -318,6 +339,7 @@ export interface FileRouteTypes {
     | '/api/workspace/file'
     | '/api/workspace/root'
     | '/api/workspace/tree'
+    | '/api/chat/mcp/oauth'
     | '/api/chat/models/discover'
     | '/api/chat/providers/oauth'
   id:
@@ -331,6 +353,7 @@ export interface FileRouteTypes {
     | '/api/chat/command'
     | '/api/chat/commands'
     | '/api/chat/events'
+    | '/api/chat/mcp'
     | '/api/chat/model'
     | '/api/chat/models'
     | '/api/chat/new'
@@ -347,6 +370,7 @@ export interface FileRouteTypes {
     | '/api/workspace/file'
     | '/api/workspace/root'
     | '/api/workspace/tree'
+    | '/api/chat/mcp/oauth'
     | '/api/chat/models/discover'
     | '/api/chat/providers/oauth'
   fileRoutesById: FileRoutesById
@@ -425,6 +449,13 @@ declare module '@tanstack/react-router' {
       path: '/events'
       fullPath: '/api/chat/events'
       preLoaderRoute: typeof ApiChatEventsRouteImport
+      parentRoute: typeof ApiChatRoute
+    }
+    '/api/chat/mcp': {
+      id: '/api/chat/mcp'
+      path: '/mcp'
+      fullPath: '/api/chat/mcp'
+      preLoaderRoute: typeof ApiChatMcpRouteImport
       parentRoute: typeof ApiChatRoute
     }
     '/api/chat/model': {
@@ -539,6 +570,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiWorkspaceTreeRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/chat/mcp/oauth': {
+      id: '/api/chat/mcp/oauth'
+      path: '/oauth'
+      fullPath: '/api/chat/mcp/oauth'
+      preLoaderRoute: typeof ApiChatMcpOauthRouteImport
+      parentRoute: typeof ApiChatMcpRoute
+    }
     '/api/chat/models/discover': {
       id: '/api/chat/models/discover'
       path: '/discover'
@@ -555,6 +593,18 @@ declare module '@tanstack/react-router' {
     }
   }
 }
+
+interface ApiChatMcpRouteChildren {
+  ApiChatMcpOauthRoute: typeof ApiChatMcpOauthRoute
+}
+
+const ApiChatMcpRouteChildren: ApiChatMcpRouteChildren = {
+  ApiChatMcpOauthRoute: ApiChatMcpOauthRoute,
+}
+
+const ApiChatMcpRouteWithChildren = ApiChatMcpRoute._addFileChildren(
+  ApiChatMcpRouteChildren,
+)
 
 interface ApiChatModelsRouteChildren {
   ApiChatModelsDiscoverRoute: typeof ApiChatModelsDiscoverRoute
@@ -585,6 +635,7 @@ interface ApiChatRouteChildren {
   ApiChatCommandRoute: typeof ApiChatCommandRoute
   ApiChatCommandsRoute: typeof ApiChatCommandsRoute
   ApiChatEventsRoute: typeof ApiChatEventsRoute
+  ApiChatMcpRoute: typeof ApiChatMcpRouteWithChildren
   ApiChatModelRoute: typeof ApiChatModelRoute
   ApiChatModelsRoute: typeof ApiChatModelsRouteWithChildren
   ApiChatNewRoute: typeof ApiChatNewRoute
@@ -603,6 +654,7 @@ const ApiChatRouteChildren: ApiChatRouteChildren = {
   ApiChatCommandRoute: ApiChatCommandRoute,
   ApiChatCommandsRoute: ApiChatCommandsRoute,
   ApiChatEventsRoute: ApiChatEventsRoute,
+  ApiChatMcpRoute: ApiChatMcpRouteWithChildren,
   ApiChatModelRoute: ApiChatModelRoute,
   ApiChatModelsRoute: ApiChatModelsRouteWithChildren,
   ApiChatNewRoute: ApiChatNewRoute,

--- a/web/app/src/routes/api/chat/mcp.ts
+++ b/web/app/src/routes/api/chat/mcp.ts
@@ -1,0 +1,12 @@
+import { handleChatMcpDelete, handleChatMcpGet, handleChatMcpPost } from "@prime-agent/web-server";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/api/chat/mcp")({
+	server: {
+		handlers: {
+			GET: ({ request }) => handleChatMcpGet(request),
+			POST: ({ request }) => handleChatMcpPost(request),
+			DELETE: ({ request }) => handleChatMcpDelete(request),
+		},
+	},
+});

--- a/web/app/src/routes/api/chat/mcp/oauth.ts
+++ b/web/app/src/routes/api/chat/mcp/oauth.ts
@@ -1,0 +1,10 @@
+import { handleChatMcpOAuthPost } from "@prime-agent/web-server";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/api/chat/mcp/oauth")({
+	server: {
+		handlers: {
+			POST: ({ request }) => handleChatMcpOAuthPost(request),
+		},
+	},
+});

--- a/web/design/scripts/component-registry-check.ts
+++ b/web/design/scripts/component-registry-check.ts
@@ -28,7 +28,7 @@ assert.equal(RIGHT_PANEL_REGISTRY.workspace.refreshSource, "workspace")
 
 assert.deepEqual(
   SETTINGS_SECTIONS.map(({ id }) => id),
-  ["appearance", "chat", "sandbox", "providers", "llm-models", "skills", "pi-harness", "keybindings", "sessions"],
+  ["appearance", "chat", "mcp", "sandbox", "providers", "llm-models", "skills", "pi-harness", "keybindings", "sessions"],
 )
 assert.equal(new Set(SETTINGS_SECTIONS.map(({ order }) => order)).size, SETTINGS_SECTIONS.length)
 for (const section of SETTINGS_SECTIONS) {

--- a/web/design/src/components/product/fleet-pi/chat/fleet-pi-input-bar-state.tsx
+++ b/web/design/src/components/product/fleet-pi/chat/fleet-pi-input-bar-state.tsx
@@ -32,6 +32,8 @@ function slashCommandName(item: SuggestionItem) {
 }
 
 function slashArgumentHint(item: SuggestionItem) {
+  const fromMetadata = item.metadata?.argumentHint?.trim()
+  if (fromMetadata) return fromMetadata
   const value = item.value?.trim() ?? ""
   const match = value.match(/^\/\S+\s+(.+)$/)
   return match?.[1]

--- a/web/design/src/components/product/fleet-pi/layout/chat-header.tsx
+++ b/web/design/src/components/product/fleet-pi/layout/chat-header.tsx
@@ -9,7 +9,7 @@ import {
 import { Popover } from "../../../registry/beui/agents/input/input-popover"
 import { ChromePillButton } from "../primitives/chrome-pill"
 import { cn } from "../../../../lib/utils"
-import { normalizeSessionLabel } from "../../../../lib/pi/chat-helpers"
+import { sessionLabel } from "../session-sidebar/types"
 import type {
   ChatSessionInfo,
   ChatSessionMetadata,
@@ -196,7 +196,7 @@ export function SessionControls({
           </div>
         ) : (
           sessions.map((session) => {
-            const label = normalizeSessionLabel(session.title)
+            const label = sessionLabel(session, sessions)
             const active = session.sessionId === activeSessionId
             return (
               <button

--- a/web/design/src/components/product/fleet-pi/layout/right-panel-context.tsx
+++ b/web/design/src/components/product/fleet-pi/layout/right-panel-context.tsx
@@ -5,6 +5,11 @@ import type { ThemePreference } from "../../../../lib/canvas-utils"
 import type { ChatMessage, ChatStatus } from "@prime-agent/web-protocol/chat-types"
 import type { ChatModelOption } from "../../../../lib/pi/chat-helpers"
 import type {
+  ChatMcpDeleteRequest,
+  ChatMcpListResponse,
+  ChatMcpOAuthLoginRequest,
+  ChatMcpOAuthLoginResponse,
+  ChatMcpUpsertRequest,
   ChatMode,
   ChatPiSettingsUpdate,
   ChatProviderInfo,
@@ -19,6 +24,7 @@ import type {
   ChatSessionResponse,
   ChatSettingsResponse,
   ChatThinkingLevel,
+  McpConnectionInfo,
   PrimeAgentArtifactRun,
   PrimeAgentSessionPresentation,
   QueueState,
@@ -68,17 +74,29 @@ export type WorkspaceTreeContextValue = {
 }
 
 export type SettingsActionsContextValue = {
+  isLoadingMcp?: boolean
   isLoadingProviders?: boolean
+  isUpdatingMcp?: boolean
   isUpdatingProvider?: boolean
+  mcpConnections?: Array<McpConnectionInfo>
   modelCatalog?: Array<ChatModelOption>
   onDiscoverModels?: (providerId: string) => Promise<Array<ChatModelOption>>
+  onMcpOAuth?: (
+    request: ChatMcpOAuthLoginRequest
+  ) => Promise<ChatMcpOAuthLoginResponse>
   onOAuthLogin?: (
     request: ChatProviderOAuthLoginRequest
   ) => Promise<ChatProviderOAuthLoginResponse>
+  onRemoveMcp?: (
+    request: ChatMcpDeleteRequest
+  ) => Promise<ChatMcpListResponse>
   onRemoveProvider?: (
     request: ChatProviderRemoveRequest
   ) => Promise<ChatProviderRemoveResponse>
   onThemePreferenceChange: (preference: ThemePreference) => void
+  onUpdateMcp?: (
+    request: ChatMcpUpsertRequest
+  ) => Promise<ChatMcpListResponse>
   onUpdateProvider?: (
     request: ChatProviderUpdateRequest
   ) => Promise<ChatProviderUpdateResponse>

--- a/web/design/src/components/product/fleet-pi/pi/config-panel/sections/mcp-connections-section.tsx
+++ b/web/design/src/components/product/fleet-pi/pi/config-panel/sections/mcp-connections-section.tsx
@@ -1,0 +1,368 @@
+import { Plug, Plus, Trash2 } from "lucide-react"
+import { useMemo, useState } from "react"
+import { notify as toast } from "@prime-agent/web-design/lib/notify"
+import type {
+  ChatMcpDeleteRequest,
+  ChatMcpListResponse,
+  ChatMcpOAuthLoginRequest,
+  ChatMcpOAuthLoginResponse,
+  ChatMcpUpsertRequest,
+  ChatProviderOAuthLoginRequest,
+  ChatProviderOAuthLoginResponse,
+  McpConnectionInfo,
+} from "@prime-agent/web-protocol/chat-protocol"
+import { Alert, AlertDescription } from "../../../../../ui/alert"
+import { Button } from "../../../../../ui/button"
+import { Field, FieldDescription, FieldLabel } from "../../../../../ui/field"
+import { Input } from "../../../../../ui/input"
+import { Select } from "../../../../../ui/select"
+import { Spinner } from "../../../../../ui/spinner"
+import { Switch } from "../../../../../ui/switch"
+import { Textarea } from "../../../../../ui/textarea"
+import { ItemRow } from "../../../primitives/item-row"
+import { SettingsPane } from "../../../primitives/settings-pane"
+import { ProviderOAuthSignIn } from "./provider-oauth-sign-in"
+
+function statusLabel(connection: McpConnectionInfo): string {
+  switch (connection.status) {
+    case "connected":
+      return "Connected"
+    case "anonymous":
+      return "Available without sign-in"
+    case "needs_auth":
+      return "Sign-in required"
+    case "disabled":
+      return "Disabled"
+    default: {
+      const unexpected: never = connection.status
+      return unexpected
+    }
+  }
+}
+
+function connectionSubtitle(connection: McpConnectionInfo): string {
+  const details =
+    connection.transport === "http"
+      ? connection.url
+      : connection.commandPreview
+  const parts = [
+    connection.source === "builtin" ? "Built-in" : "User",
+    connection.transport === "http" ? "HTTP" : "stdio",
+    statusLabel(connection),
+    details,
+  ].filter((part): part is string => Boolean(part))
+  return parts.join(" · ")
+}
+
+export function McpConnectionsSection({
+  connections,
+  isLoading,
+  isPending,
+  onOAuth,
+  onRemove,
+  onUpsert,
+}: {
+  connections: Array<McpConnectionInfo>
+  isLoading: boolean
+  isPending: boolean
+  onOAuth?: (request: ChatMcpOAuthLoginRequest) => Promise<ChatMcpOAuthLoginResponse>
+  onRemove?: (request: ChatMcpDeleteRequest) => Promise<ChatMcpListResponse>
+  onUpsert?: (request: ChatMcpUpsertRequest) => Promise<ChatMcpListResponse>
+}) {
+  const [adding, setAdding] = useState(false)
+  const [transport, setTransport] = useState<"http" | "stdio">("http")
+  const [name, setName] = useState("")
+  const [url, setUrl] = useState("")
+  const [oauth, setOauth] = useState(true)
+  const [bearerTokenEnvVar, setBearerTokenEnvVar] = useState("")
+  const [command, setCommand] = useState("")
+  const [args, setArgs] = useState("")
+  const [cwd, setCwd] = useState("")
+  const [envLines, setEnvLines] = useState("")
+  const [confirmRemove, setConfirmRemove] = useState<string | null>(null)
+
+  const resetAddForm = () => {
+    setName("")
+    setUrl("")
+    setOauth(true)
+    setBearerTokenEnvVar("")
+    setCommand("")
+    setArgs("")
+    setCwd("")
+    setEnvLines("")
+    setTransport("http")
+    setAdding(false)
+  }
+
+  const handleAdd = async () => {
+    if (!onUpsert) return
+    const trimmedName = name.trim()
+    try {
+      if (transport === "http") {
+        await onUpsert({
+          name: trimmedName,
+          transport: "http",
+          url: url.trim(),
+          ...(oauth ? { oauth: true } : {}),
+          ...(bearerTokenEnvVar.trim() ? { bearerTokenEnvVar: bearerTokenEnvVar.trim() } : {}),
+          force: true,
+        })
+      } else {
+        const parsedArgs = args
+          .split(/\s+/)
+          .map((part) => part.trim())
+          .filter(Boolean)
+        const env = envLines
+          .split("\n")
+          .map((line) => line.trim())
+          .filter(Boolean)
+          .flatMap((line) => {
+            const equals = line.indexOf("=")
+            if (equals <= 0) return []
+            const child = line.slice(0, equals).trim()
+            const source = line.slice(equals + 1).trim()
+            if (!child || !source) return []
+            return [{ child, source }]
+          })
+        await onUpsert({
+          name: trimmedName,
+          transport: "stdio",
+          command: command.trim(),
+          ...(parsedArgs.length > 0 ? { args: parsedArgs } : {}),
+          ...(cwd.trim() ? { cwd: cwd.trim() } : {}),
+          ...(env.length > 0 ? { env } : {}),
+          force: true,
+        })
+      }
+      toast.success("MCP connection saved")
+      resetAddForm()
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not save MCP connection")
+    }
+  }
+
+  const handleRemove = async (connectionName: string) => {
+    if (!onRemove) return
+    try {
+      await onRemove({ name: connectionName })
+      toast.success(`Removed ${connectionName}`)
+      setConfirmRemove(null)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not remove MCP connection")
+    }
+  }
+
+  const handleLogout = async (connectionName: string) => {
+    if (!onOAuth) return
+    try {
+      await onOAuth({ name: connectionName, action: "logout" })
+      toast.success(`Signed out of ${connectionName}`)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not sign out")
+    }
+  }
+
+  const oauthAdapter = useMemo(() => {
+    if (!onOAuth) return undefined
+    return (connection: McpConnectionInfo) =>
+      async (request: ChatProviderOAuthLoginRequest): Promise<ChatProviderOAuthLoginResponse> => {
+        const starting = !request.loginId && !request.cancel
+        const result = await onOAuth({
+          name: connection.name,
+          action: starting && connection.status === "connected" ? "reconnect" : "login",
+          loginId: request.loginId,
+          promptAnswer: request.promptAnswer,
+          cancel: request.cancel,
+        })
+        return result
+      }
+  }, [onOAuth])
+
+  return (
+    <SettingsPane
+      title="MCP"
+      description="Connect built-in and user MCP servers. Tokens stay on the server; this list only shows status and environment-variable names."
+      actions={
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          disabled={isPending || adding}
+          onClick={() => setAdding(true)}
+        >
+          <Plus data-icon="inline-start" />
+          Add server
+        </Button>
+      }
+    >
+      {isLoading ? (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Spinner className="size-3.5" />
+          Loading MCP connections…
+        </div>
+      ) : null}
+
+      {adding ? (
+        <div className="flex flex-col gap-3 rounded-xl border p-4">
+          <Field>
+            <FieldLabel>Name</FieldLabel>
+            <Input value={name} onChange={(event) => setName(event.target.value)} aria-label="MCP server name" />
+          </Field>
+          <Field>
+            <FieldLabel>Transport</FieldLabel>
+            <Select
+              value={transport}
+              onValueChange={(value) => setTransport(value as "http" | "stdio")}
+              options={[
+                { label: "HTTP", value: "http" },
+                { label: "stdio", value: "stdio" },
+              ]}
+            />
+          </Field>
+          {transport === "http" ? (
+            <>
+              <Field>
+                <FieldLabel>URL</FieldLabel>
+                <Input value={url} onChange={(event) => setUrl(event.target.value)} aria-label="MCP server URL" />
+              </Field>
+              <Field orientation="horizontal" className="items-center justify-between">
+                <div>
+                  <FieldLabel>OAuth</FieldLabel>
+                  <FieldDescription>Use the browser sign-in flow for this server.</FieldDescription>
+                </div>
+                <Switch
+                  checked={oauth}
+                  onCheckedChange={(checked) => setOauth(checked)}
+                  aria-label="Use OAuth"
+                />
+              </Field>
+              {!oauth ? (
+                <Field>
+                  <FieldLabel>Bearer token environment variable</FieldLabel>
+                  <Input
+                    value={bearerTokenEnvVar}
+                    onChange={(event) => setBearerTokenEnvVar(event.target.value)}
+                    aria-label="Bearer token environment variable"
+                    placeholder="MCP_BEARER_TOKEN"
+                  />
+                </Field>
+              ) : null}
+            </>
+          ) : (
+            <>
+              <Field>
+                <FieldLabel>Command</FieldLabel>
+                <Input value={command} onChange={(event) => setCommand(event.target.value)} aria-label="MCP command" />
+              </Field>
+              <Field>
+                <FieldLabel>Arguments</FieldLabel>
+                <Input value={args} onChange={(event) => setArgs(event.target.value)} aria-label="MCP command arguments" />
+              </Field>
+              <Field>
+                <FieldLabel>Working directory</FieldLabel>
+                <Input value={cwd} onChange={(event) => setCwd(event.target.value)} aria-label="MCP working directory" />
+                <FieldDescription>Must stay inside the current workspace.</FieldDescription>
+              </Field>
+              <Field>
+                <FieldLabel>Environment mappings</FieldLabel>
+                <Textarea
+                  value={envLines}
+                  onChange={(event) => setEnvLines(event.target.value)}
+                  aria-label="MCP environment mappings"
+                  placeholder="CHILD=SOURCE"
+                />
+                <FieldDescription>One CHILD=SOURCE pair per line. Only variable names are stored.</FieldDescription>
+              </Field>
+            </>
+          )}
+          <div className="flex justify-end gap-2">
+            <Button type="button" size="sm" variant="ghost" onClick={resetAddForm}>
+              Cancel
+            </Button>
+            <Button type="button" size="sm" disabled={isPending || !name.trim()} onClick={() => void handleAdd()}>
+              {isPending ? <Spinner data-icon="inline-start" /> : null}
+              Save
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {!isLoading && connections.length === 0 && !adding ? (
+        <p className="text-sm text-muted-foreground">No MCP connections yet.</p>
+      ) : null}
+
+      <div className="flex flex-col gap-2">
+        {connections.map((connection) => (
+          <div key={`${connection.source}:${connection.name}`} className="flex flex-col gap-2">
+            <ItemRow
+              icon={<Plug className="size-4" />}
+              title={connection.label}
+              subtitle={connectionSubtitle(connection)}
+              trailing={
+                <div className="flex items-center gap-1.5">
+                  {connection.usesOAuth && connection.status !== "needs_auth" ? (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      disabled={isPending || !onOAuth}
+                      onClick={() => {
+                        void handleLogout(connection.name)
+                      }}
+                    >
+                      Sign out
+                    </Button>
+                  ) : null}
+                  {connection.source === "user" ? (
+                    confirmRemove === connection.name ? (
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="destructive"
+                        disabled={isPending}
+                        onClick={() => {
+                          void handleRemove(connection.name)
+                        }}
+                      >
+                        Confirm remove
+                      </Button>
+                    ) : (
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        disabled={isPending || !onRemove}
+                        aria-label={`Remove ${connection.name}`}
+                        onClick={() => setConfirmRemove(connection.name)}
+                      >
+                        <Trash2 className="size-3.5" />
+                      </Button>
+                    )
+                  ) : null}
+                </div>
+              }
+            />
+            {connection.error ? (
+              <Alert className="px-3 py-2">
+                <AlertDescription className="text-xs text-pretty">{connection.error}</AlertDescription>
+              </Alert>
+            ) : null}
+            {connection.usesOAuth && oauthAdapter ? (
+              <ProviderOAuthSignIn
+                provider={{
+                  id: connection.name,
+                  name: connection.label,
+                  isConfigured: connection.status === "connected",
+                  envVarName: "",
+                  authType: "oauth",
+                  supportsOAuth: true,
+                }}
+                onOAuthLogin={oauthAdapter(connection)}
+              />
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </SettingsPane>
+  )
+}

--- a/web/design/src/components/product/fleet-pi/pi/settings-dialog.tsx
+++ b/web/design/src/components/product/fleet-pi/pi/settings-dialog.tsx
@@ -45,6 +45,7 @@ import {
   useSettingsActionsContext,
 } from "../layout/right-panel-context"
 import { PersonalizationSection } from "./config-panel/sections/personalization-section"
+import { McpConnectionsSection } from "./config-panel/sections/mcp-connections-section"
 import { ProviderCredentialsSection } from "./config-panel/sections/provider-credentials-section"
 import { ModelDefaultsSection } from "./config-panel/sections/model-defaults-section"
 import { ResourcesSection } from "./config-panel/sections/resources-section"
@@ -107,13 +108,19 @@ function PreferenceRow({
  */
 function useSettingsForm() {
   const {
+    isLoadingMcp,
     isLoadingProviders,
+    isUpdatingMcp,
     isUpdatingProvider,
+    mcpConnections = [],
     modelCatalog,
     onDiscoverModels,
+    onMcpOAuth,
     onOAuthLogin,
+    onRemoveMcp,
     onRemoveProvider,
     onThemePreferenceChange,
+    onUpdateMcp,
     onUpdateProvider,
     providers = [],
     saveSettings,
@@ -228,11 +235,17 @@ function useSettingsForm() {
   }
 
   return {
+    isLoadingMcp,
     isLoadingProviders,
+    isUpdatingMcp,
     isUpdatingProvider,
-    onThemePreferenceChange,
+    mcpConnections,
+    onMcpOAuth,
     onOAuthLogin,
+    onRemoveMcp,
     onRemoveProvider,
+    onThemePreferenceChange,
+    onUpdateMcp,
     onUpdateProvider,
     providers,
     resources,
@@ -370,11 +383,17 @@ function SettingsDialogPaneContent({
   updatePreference: UpdatePreference
 }) {
   const {
+    isLoadingMcp,
     isLoadingProviders,
+    isUpdatingMcp,
     isUpdatingProvider,
-    onThemePreferenceChange,
+    mcpConnections,
+    onMcpOAuth,
     onOAuthLogin,
+    onRemoveMcp,
     onRemoveProvider,
+    onThemePreferenceChange,
+    onUpdateMcp,
     onUpdateProvider,
     providers,
     resources,
@@ -496,6 +515,16 @@ function SettingsDialogPaneContent({
           />
         </PreferenceRow>
       </div>
+    ),
+    mcp: () => (
+      <McpConnectionsSection
+        connections={mcpConnections}
+        isLoading={isLoadingMcp ?? false}
+        isPending={isUpdatingMcp ?? false}
+        onOAuth={onMcpOAuth}
+        onRemove={onRemoveMcp}
+        onUpsert={onUpdateMcp}
+      />
     ),
     sandbox: () => (
       <SandboxProviderSection

--- a/web/design/src/components/product/fleet-pi/pi/settings-sections.ts
+++ b/web/design/src/components/product/fleet-pi/pi/settings-sections.ts
@@ -1,10 +1,22 @@
-import { Cpu, HardDrive, Keyboard, KeyRound, MessageSquare, Paintbrush, Settings, Sparkles, Users } from "lucide-react";
+import {
+	Cpu,
+	HardDrive,
+	Keyboard,
+	KeyRound,
+	MessageSquare,
+	Paintbrush,
+	Plug,
+	Settings,
+	Sparkles,
+	Users,
+} from "lucide-react";
 
 type LucideIcon = typeof Cpu;
 
 export type SettingsSectionId =
 	| "appearance"
 	| "chat"
+	| "mcp"
 	| "sandbox"
 	| "providers"
 	| "llm-models"
@@ -34,6 +46,14 @@ export const SETTINGS_SECTION_REGISTRY = {
 		group: "workspace",
 	},
 	chat: { id: "chat", order: 20, title: "Chat", ariaLabel: "Chat settings", icon: MessageSquare, group: "workspace" },
+	mcp: {
+		id: "mcp",
+		order: 25,
+		title: "MCP",
+		ariaLabel: "MCP connection settings",
+		icon: Plug,
+		group: "workspace",
+	},
 	sandbox: {
 		id: "sandbox",
 		order: 30,

--- a/web/design/src/components/product/fleet-pi/session-sidebar/navigation.tsx
+++ b/web/design/src/components/product/fleet-pi/session-sidebar/navigation.tsx
@@ -128,7 +128,7 @@ export function FleetSessionSidebarNavigation({
 		() =>
 			sortSessions(projectSessions).map((session) => ({
 				id: session.sessionId,
-				title: sessionLabel(session),
+				title: sessionLabel(session, projectSessions),
 				preview: sessionDiscoveryMeta(session, projectById),
 				group: sessionSearchGroup(session.updatedAt),
 				// Keep the initial prompt searchable; a renamed session no longer

--- a/web/design/src/components/product/fleet-pi/session-sidebar/types.ts
+++ b/web/design/src/components/product/fleet-pi/session-sidebar/types.ts
@@ -6,6 +6,11 @@ import type {
 } from "@prime-agent/web-protocol";
 import type { ChatSessionInfo } from "@prime-agent/web-protocol/chat-protocol";
 import type { OpenPanelAction } from "@prime-agent/web-protocol/fleet-contract";
+import {
+	disambiguateSessionLabel,
+	fallbackSessionLabel,
+	sessionListTitle,
+} from "@prime-agent/web-protocol/session-label";
 import type { ReactNode } from "react";
 import { normalizeSessionLabel } from "../../../../lib/pi/chat-helpers";
 import { readStoredValue } from "../../../../lib/safe-storage";
@@ -82,8 +87,29 @@ export function idValue(id: string, prefix: string) {
 	return id.startsWith(prefix) ? id.slice(prefix.length) : null;
 }
 
-export function sessionLabel(session: ChatSessionInfo) {
-	return normalizeSessionLabel(session.title || session.firstMessage || session.sessionId.slice(0, 8));
+export function sessionBaseLabel(session: Pick<ChatSessionInfo, "sessionId" | "title" | "firstMessage">) {
+	return (
+		normalizeSessionLabel(
+			sessionListTitle({
+				sessionId: session.sessionId,
+				title: session.title,
+				firstMessage: session.firstMessage,
+			}),
+		) || fallbackSessionLabel(session.sessionId)
+	);
+}
+
+export function sessionLabel(
+	session: Pick<ChatSessionInfo, "sessionId" | "title" | "firstMessage">,
+	siblings?: ReadonlyArray<Pick<ChatSessionInfo, "sessionId" | "title" | "firstMessage">>,
+) {
+	const base = sessionBaseLabel(session);
+	if (!siblings) return base;
+	let collidingCount = 0;
+	for (const sibling of siblings) {
+		if (sessionBaseLabel(sibling) === base) collidingCount += 1;
+	}
+	return disambiguateSessionLabel(base, session.sessionId, collidingCount);
 }
 
 export function sessionDiscoveryMeta(session: ChatSessionInfo, projectById: Map<ProjectId, ProjectSummary>) {

--- a/web/design/src/components/product/fleet-pi/session-sidebar/view-model.tsx
+++ b/web/design/src/components/product/fleet-pi/session-sidebar/view-model.tsx
@@ -220,7 +220,7 @@ export function useFleetSessionSidebarViewModel({
 			const visible = visibleProjectSessions(sessionsForProject, activeSessionId, revealed);
 			const children: SidebarResource[] = visible.map((session) => ({
 				id: sessionResourceId(session.sessionId),
-				label: sessionLabel(session),
+				label: sessionLabel(session, visible),
 				kind: "file" as const,
 				...(session.isSubagent ? { indent: 1 } : {}),
 			}));
@@ -257,7 +257,7 @@ export function useFleetSessionSidebarViewModel({
 				revealedProjectIds.has("unassigned"),
 			).map((session) => ({
 				id: sessionResourceId(session.sessionId),
-				label: sessionLabel(session),
+				label: sessionLabel(session, unassigned),
 				kind: "file",
 				...(session.isSubagent ? { indent: 1 } : {}),
 			}));

--- a/web/protocol/package.json
+++ b/web/protocol/package.json
@@ -14,6 +14,7 @@
     "./model-patterns": "./src/model-patterns.ts",
     "./provider-catalog": "./src/provider-catalog.ts",
     "./session-label": "./src/session-label.ts",
+    "./mcp": "./src/mcp.ts",
     "./schemas/*": "./src/schemas/*"
   },
   "scripts": {

--- a/web/protocol/src/__tests__/mcp.test.ts
+++ b/web/protocol/src/__tests__/mcp.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { ChatMcpListResponseSchema, ChatMcpUpsertRequestSchema } from "../schemas/mcp";
+
+describe("MCP connection schemas", () => {
+	it("accepts a browser-safe connection row and drops secret-shaped extras", () => {
+		const parsed = ChatMcpListResponseSchema.parse({
+			connections: [
+				{
+					name: "docs",
+					label: "docs",
+					source: "user",
+					transport: "http",
+					url: "https://mcp.example.test/mcp",
+					usesOAuth: true,
+					enabled: false,
+					status: "needs_auth",
+					token: "super-secret-token",
+					headers: { Authorization: "Bearer super-secret-token" },
+				},
+			],
+		});
+		expect(parsed.connections[0]).toMatchObject({
+			name: "docs",
+			status: "needs_auth",
+			usesOAuth: true,
+		});
+		expect(JSON.stringify(parsed)).not.toContain("super-secret-token");
+		expect(JSON.stringify(parsed)).not.toContain("Authorization");
+	});
+
+	it("rejects reserved-looking empty names and env values on upsert", () => {
+		expect(
+			ChatMcpUpsertRequestSchema.safeParse({
+				name: "",
+				transport: "http",
+				url: "https://mcp.example.test/mcp",
+			}).success,
+		).toBe(false);
+		expect(
+			ChatMcpUpsertRequestSchema.safeParse({
+				name: "shell",
+				transport: "stdio",
+				command: "uvx",
+				env: [{ child: "TOKEN", source: "MCP_TOKEN" }],
+			}).success,
+		).toBe(true);
+		expect(
+			ChatMcpUpsertRequestSchema.safeParse({
+				name: "shell",
+				transport: "stdio",
+				command: "uvx",
+				env: [{ child: "TOKEN", source: "not valid" }],
+			}).success,
+		).toBe(false);
+	});
+});

--- a/web/protocol/src/__tests__/session-label.test.ts
+++ b/web/protocol/src/__tests__/session-label.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+	disambiguateSessionLabel,
+	EMPTY_SESSION_FIRST_MESSAGE,
+	fallbackSessionLabel,
+	meaningfulSessionLabel,
+	sessionListTitle,
+} from "../session-label";
+
+describe("meaningfulSessionLabel", () => {
+	it("drops the upstream empty-session placeholder", () => {
+		expect(meaningfulSessionLabel(EMPTY_SESSION_FIRST_MESSAGE)).toBeUndefined();
+		expect(meaningfulSessionLabel("  (no messages)  ")).toBeUndefined();
+		expect(meaningfulSessionLabel("")).toBeUndefined();
+		expect(meaningfulSessionLabel(undefined)).toBeUndefined();
+	});
+
+	it("redacts credential-shaped values", () => {
+		expect(meaningfulSessionLabel("use github_pat_example_secret_value")).toBe("use [redacted]");
+	});
+});
+
+describe("sessionListTitle", () => {
+	it("falls back to a short session id", () => {
+		expect(sessionListTitle({ sessionId: "abcdef123456", title: EMPTY_SESSION_FIRST_MESSAGE })).toBe("abcdef12");
+		expect(fallbackSessionLabel("abcdef123456")).toBe("abcdef12");
+	});
+
+	it("prefers a real title over firstMessage", () => {
+		expect(
+			sessionListTitle({
+				sessionId: "session-1",
+				title: "Named session",
+				firstMessage: "Hello",
+			}),
+		).toBe("Named session");
+	});
+});
+
+describe("disambiguateSessionLabel", () => {
+	it("appends the last four id characters when labels collide", () => {
+		expect(disambiguateSessionLabel("Tighten the plan", "session-abcd", 1)).toBe("Tighten the plan");
+		expect(disambiguateSessionLabel("Tighten the plan", "session-abcd", 2)).toBe("Tighten the plan · abcd");
+		expect(disambiguateSessionLabel("plan abcd", "session-abcd", 2)).toBe("plan abcd");
+	});
+});

--- a/web/protocol/src/chat-protocol.ts
+++ b/web/protocol/src/chat-protocol.ts
@@ -431,7 +431,7 @@ export type ChatOpenUIArtifactUpsertResponse = {
 	presentation: PrimeAgentSessionPresentation;
 };
 /** Optional, capability-gated browser enhancements owned by Fleet Prime. */
-export type FleetAdapterFeature = "reasoning-summary-v1";
+export type FleetAdapterFeature = "reasoning-summary-v1" | "mcp-connections-v1";
 
 export type FleetAdapterCapabilities = {
 	// Forward-tolerant wire shape: a newer adapter may advance either revision
@@ -513,8 +513,8 @@ export type ChatSessionSnapshotEvent = {
 
 export const FLEET_ADAPTER_CAPABILITIES: FleetAdapterCapabilities = {
 	protocolVersion: 1,
-	schemaRevision: 1,
-	features: ["reasoning-summary-v1"],
+	schemaRevision: 2,
+	features: ["reasoning-summary-v1", "mcp-connections-v1"],
 };
 
 type ChatStartEvent = {
@@ -836,3 +836,17 @@ export type ChatCommandsResponse = {
 	commands: Array<ChatSlashCommandInfo>;
 	diagnostics: Array<string>;
 };
+
+export type {
+	ChatMcpDeleteRequest,
+	ChatMcpListResponse,
+	ChatMcpOAuthAction,
+	ChatMcpOAuthLoginRequest,
+	ChatMcpOAuthLoginResponse,
+	ChatMcpUpsertRequest,
+	McpConnectionInfo,
+	McpConnectionSource,
+	McpConnectionStatus,
+	McpConnectionTransport,
+	McpEnvBinding,
+} from "./mcp";

--- a/web/protocol/src/chat-protocol.zod.ts
+++ b/web/protocol/src/chat-protocol.zod.ts
@@ -110,6 +110,14 @@ export {
 	PrimeAgentSessionPresentationSchema,
 	PrimeAgentUserBashSchema,
 } from "./schemas/chat";
+export {
+	ChatMcpDeleteRequestSchema,
+	ChatMcpListResponseSchema,
+	ChatMcpOAuthLoginRequestSchema,
+	ChatMcpOAuthLoginResponseSchema,
+	ChatMcpUpsertRequestSchema,
+	McpConnectionInfoSchema,
+} from "./schemas/mcp";
 export { ErrorResponseSchema, HealthResponseSchema } from "./schemas/misc";
 export {
 	ChatPiSettingsSchema,

--- a/web/protocol/src/index.ts
+++ b/web/protocol/src/index.ts
@@ -63,4 +63,11 @@ export {
 	ChatPayloadEventSchema,
 	ChatPayloadPartSchema,
 } from "./schemas/chat";
-export { redactSessionLabelSecrets } from "./session-label";
+export {
+	disambiguateSessionLabel,
+	EMPTY_SESSION_FIRST_MESSAGE,
+	fallbackSessionLabel,
+	meaningfulSessionLabel,
+	redactSessionLabelSecrets,
+	sessionListTitle,
+} from "./session-label";

--- a/web/protocol/src/mcp.ts
+++ b/web/protocol/src/mcp.ts
@@ -1,0 +1,80 @@
+export type McpConnectionSource = "builtin" | "user";
+
+export type McpConnectionTransport = "http" | "stdio";
+
+export type McpConnectionStatus = "connected" | "needs_auth" | "disabled" | "anonymous";
+
+export type McpEnvBinding = {
+	child: string;
+	source: string;
+};
+
+export type McpConnectionInfo = {
+	name: string;
+	label: string;
+	source: McpConnectionSource;
+	transport: McpConnectionTransport;
+	url?: string;
+	commandPreview?: string;
+	cwdPreview?: string;
+	usesOAuth: boolean;
+	enabled: boolean;
+	status: McpConnectionStatus;
+	bearerTokenEnvVar?: string;
+	envBindings?: Array<McpEnvBinding>;
+	error?: string;
+};
+
+export type ChatMcpListResponse = {
+	connections: Array<McpConnectionInfo>;
+};
+
+export type ChatMcpHttpUpsertRequest = {
+	name: string;
+	transport: "http";
+	url: string;
+	oauth?: boolean;
+	bearerTokenEnvVar?: string;
+	force?: boolean;
+};
+
+export type ChatMcpStdioUpsertRequest = {
+	name: string;
+	transport: "stdio";
+	command: string;
+	args?: Array<string>;
+	cwd?: string;
+	env?: Array<McpEnvBinding>;
+	force?: boolean;
+};
+
+export type ChatMcpUpsertRequest = ChatMcpHttpUpsertRequest | ChatMcpStdioUpsertRequest;
+
+export type ChatMcpDeleteRequest = {
+	name: string;
+};
+
+export type ChatMcpOAuthAction = "login" | "logout" | "reconnect";
+
+export type ChatMcpOAuthLoginRequest = {
+	name: string;
+	action?: ChatMcpOAuthAction;
+	loginId?: string;
+	promptAnswer?: string;
+	cancel?: boolean;
+};
+
+export type ChatMcpOAuthLoginResponse = {
+	status: "waiting" | "success" | "error";
+	loginId?: string;
+	authUrl?: string;
+	userCode?: string;
+	instructions?: string;
+	prompt?: {
+		message: string;
+		placeholder?: string;
+		allowEmpty?: boolean;
+	};
+	error?: string;
+	connections?: Array<McpConnectionInfo>;
+};

--- a/web/protocol/src/schemas/chat.ts
+++ b/web/protocol/src/schemas/chat.ts
@@ -288,7 +288,7 @@ export const ChatMessageSchema = z
 	.passthrough()
 	.openapi({ description: "Chat message" });
 
-export const FleetAdapterFeatureSchema = z.enum(["reasoning-summary-v1"]);
+export const FleetAdapterFeatureSchema = z.enum(["reasoning-summary-v1", "mcp-connections-v1"]);
 
 export const FleetAdapterCapabilitiesSchema = z
 	.object({

--- a/web/protocol/src/schemas/mcp.ts
+++ b/web/protocol/src/schemas/mcp.ts
@@ -1,0 +1,105 @@
+import { ChatProviderOAuthLoginStatusSchema, ChatProviderOAuthPromptSchema } from "./catalog";
+import { nonEmptyStringSchema, z } from "./shared";
+
+export const MCP_SERVER_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/;
+export const MCP_ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+const mcpServerNameSchema = z
+	.string()
+	.regex(
+		MCP_SERVER_NAME_PATTERN,
+		"MCP server names must be 1-64 letters, numbers, underscores, or hyphens and start with a letter or number.",
+	);
+
+const mcpEnvNameSchema = z
+	.string()
+	.regex(MCP_ENV_NAME_PATTERN, "Environment variable names must be letters, digits, or underscores.");
+
+export const McpConnectionSourceSchema = z.enum(["builtin", "user"]);
+export const McpConnectionTransportSchema = z.enum(["http", "stdio"]);
+export const McpConnectionStatusSchema = z.enum(["connected", "needs_auth", "disabled", "anonymous"]);
+
+export const McpEnvBindingSchema = z
+	.object({
+		child: mcpEnvNameSchema,
+		source: mcpEnvNameSchema,
+	})
+	.openapi({ description: "Stdio env mapping as CHILD=SOURCE variable names only" });
+
+export const McpConnectionInfoSchema = z
+	.object({
+		name: mcpServerNameSchema,
+		label: nonEmptyStringSchema,
+		source: McpConnectionSourceSchema,
+		transport: McpConnectionTransportSchema,
+		url: z.string().optional(),
+		commandPreview: z.string().optional(),
+		cwdPreview: z.string().optional(),
+		usesOAuth: z.boolean(),
+		enabled: z.boolean(),
+		status: McpConnectionStatusSchema,
+		bearerTokenEnvVar: z.string().optional(),
+		envBindings: z.array(McpEnvBindingSchema).optional(),
+		error: z.string().optional(),
+	})
+	.openapi({ description: "Browser-safe MCP connection row; never includes tokens or env values" });
+
+export const ChatMcpListResponseSchema = z
+	.object({
+		connections: z.array(McpConnectionInfoSchema),
+	})
+	.openapi({ description: "MCP connection list" });
+
+const ChatMcpHttpUpsertRequestSchema = z.object({
+	name: mcpServerNameSchema,
+	transport: z.literal("http"),
+	url: nonEmptyStringSchema,
+	oauth: z.boolean().optional(),
+	bearerTokenEnvVar: mcpEnvNameSchema.optional(),
+	force: z.boolean().optional(),
+});
+
+const ChatMcpStdioUpsertRequestSchema = z.object({
+	name: mcpServerNameSchema,
+	transport: z.literal("stdio"),
+	command: nonEmptyStringSchema,
+	args: z.array(z.string().min(1).max(1024)).max(32).optional(),
+	cwd: z.string().min(1).max(1024).optional(),
+	env: z.array(McpEnvBindingSchema).max(32).optional(),
+	force: z.boolean().optional(),
+});
+
+export const ChatMcpUpsertRequestSchema = z
+	.discriminatedUnion("transport", [ChatMcpHttpUpsertRequestSchema, ChatMcpStdioUpsertRequestSchema])
+	.openapi({ description: "Add or replace a user MCP server" });
+
+export const ChatMcpDeleteRequestSchema = z
+	.object({
+		name: mcpServerNameSchema,
+	})
+	.openapi({ description: "Remove a user MCP server" });
+
+export const ChatMcpOAuthActionSchema = z.enum(["login", "logout", "reconnect"]);
+
+export const ChatMcpOAuthLoginRequestSchema = z
+	.object({
+		name: mcpServerNameSchema,
+		action: ChatMcpOAuthActionSchema.optional(),
+		loginId: z.string().min(1).optional(),
+		promptAnswer: z.string().max(8192).optional(),
+		cancel: z.boolean().optional(),
+	})
+	.openapi({ description: "MCP OAuth login, logout, or reconnect" });
+
+export const ChatMcpOAuthLoginResponseSchema = z
+	.object({
+		status: ChatProviderOAuthLoginStatusSchema,
+		loginId: z.string().optional(),
+		authUrl: z.string().optional(),
+		userCode: z.string().optional(),
+		instructions: z.string().optional(),
+		prompt: ChatProviderOAuthPromptSchema.optional(),
+		error: z.string().optional(),
+		connections: z.array(McpConnectionInfoSchema).optional(),
+	})
+	.openapi({ description: "MCP OAuth login snapshot" });

--- a/web/protocol/src/session-label.ts
+++ b/web/protocol/src/session-label.ts
@@ -8,6 +8,9 @@ const SECRET_VALUE_PATTERNS = [
 const NAMED_SECRET_PATTERN =
 	/\b(api[ _-]?key|access[ _-]?token|auth[ _-]?token|bearer|password|secret)\s*([:=])\s*(?:"[^"]*"|'[^']*'|[^\s,;]+)/gi;
 
+/** Upstream SessionManager placeholder when a listing counted no user turns. */
+export const EMPTY_SESSION_FIRST_MESSAGE = "(no messages)";
+
 /** Removes credential-shaped values before a transcript-derived label reaches browser chrome. */
 export function redactSessionLabelSecrets(label: string): string {
 	let redacted = label.replace(
@@ -18,4 +21,32 @@ export function redactSessionLabelSecrets(label: string): string {
 		redacted = redacted.replace(pattern, "[redacted]");
 	}
 	return redacted;
+}
+
+/** Returns a secret-redacted label, or undefined when the value is empty/placeholder. */
+export function meaningfulSessionLabel(value: string | undefined): string | undefined {
+	const trimmed = value?.trim();
+	if (!trimmed || trimmed === EMPTY_SESSION_FIRST_MESSAGE) return undefined;
+	const redacted = redactSessionLabelSecrets(trimmed).trim();
+	return redacted.length > 0 ? redacted : undefined;
+}
+
+export function fallbackSessionLabel(sessionId: string): string {
+	return sessionId.slice(0, 8);
+}
+
+export function sessionListTitle(input: { sessionId: string; title?: string; firstMessage?: string }): string {
+	return (
+		meaningfulSessionLabel(input.title) ??
+		meaningfulSessionLabel(input.firstMessage) ??
+		fallbackSessionLabel(input.sessionId)
+	);
+}
+
+/** Appends a short session-id suffix when several rows share the same visible label. */
+export function disambiguateSessionLabel(base: string, sessionId: string, collidingCount: number): string {
+	if (collidingCount <= 1) return base;
+	const suffix = sessionId.slice(-4);
+	if (base.endsWith(suffix)) return base;
+	return `${base} · ${suffix}`;
 }

--- a/web/server/src/__tests__/chat-mcp-handler.test.ts
+++ b/web/server/src/__tests__/chat-mcp-handler.test.ts
@@ -1,0 +1,241 @@
+import type { OAuthLoginCallbacks } from "@earendil-works/pi-ai/oauth";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	handleChatMcpDelete,
+	handleChatMcpGet,
+	handleChatMcpOAuthPost,
+	handleChatMcpPost,
+	type McpHandlerDeps,
+} from "../handlers/chat-mcp";
+import { resetOAuthLoginsForTests } from "../handlers/chat-providers-oauth";
+import type { FleetMcpServerConfig } from "../mcp-connections";
+
+afterEach(() => {
+	resetOAuthLoginsForTests();
+});
+
+function createDeps(initial: Record<string, FleetMcpServerConfig> = {}): {
+	deps: McpHandlerDeps;
+	servers: Record<string, FleetMcpServerConfig>;
+	removed: Array<string>;
+} {
+	const servers: Record<string, FleetMcpServerConfig> = { ...initial };
+	const credentials = new Map<string, { type: string; endpoint?: string }>();
+	const removed: Array<string> = [];
+	const deps: McpHandlerDeps = {
+		getUserServers: () => ({ ...servers }),
+		setUserServer: (name, config) => {
+			servers[name] = config;
+		},
+		removeUserServer: (name) => {
+			if (!(name in servers)) return false;
+			delete servers[name];
+			return true;
+		},
+		flushSettings: async () => undefined,
+		auth: {
+			get: (provider) => credentials.get(provider),
+			removeVerified: (provider) => {
+				removed.push(provider);
+				credentials.delete(provider);
+			},
+			login: async (_providerId, callbacks: OAuthLoginCallbacks) => {
+				callbacks.onAuth({ url: "https://auth.example.test/authorize" });
+			},
+		},
+		workspaceRoot: "/workspace",
+		env: {},
+		reloadAuth: vi.fn(),
+		reloadResources: vi.fn(async () => undefined),
+	};
+	return { deps, servers, removed };
+}
+
+describe("MCP connection handlers", () => {
+	it("lists built-in catalog servers", async () => {
+		const { deps } = createDeps();
+		const response = await handleChatMcpGet(new Request("http://localhost/api/chat/mcp"), deps);
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as { connections: Array<{ name: string; source: string }> };
+		expect(body.connections.map((row) => row.name)).toEqual(expect.arrayContaining(["linear", "notion"]));
+		expect(body.connections.filter((row) => row.source === "builtin").length).toBeGreaterThan(0);
+	});
+
+	it("rejects reserved catalog names on add", async () => {
+		const { deps } = createDeps();
+		const response = await handleChatMcpPost(
+			new Request("http://localhost/api/chat/mcp", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					name: "linear",
+					transport: "http",
+					url: "https://mcp.example.test/mcp",
+					oauth: true,
+				}),
+			}),
+			deps,
+		);
+		expect(response.status).toBe(400);
+		const body = (await response.json()) as { message: string };
+		expect(body.message).toMatch(/reserved/i);
+	});
+
+	it("drops stored credentials when adding a user server", async () => {
+		const { deps, servers, removed } = createDeps();
+		const response = await handleChatMcpPost(
+			new Request("http://localhost/api/chat/mcp", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					name: "docs",
+					transport: "http",
+					url: "https://mcp.example.test/mcp",
+					oauth: true,
+				}),
+			}),
+			deps,
+		);
+		expect(response.status).toBe(200);
+		expect(servers.docs).toMatchObject({ type: "http", url: "https://mcp.example.test/mcp", oauth: true });
+		expect(removed).toEqual(["mcp:docs"]);
+		expect(deps.reloadResources).toHaveBeenCalled();
+		const body = (await response.json()) as { connections: Array<{ name: string }> };
+		expect(body.connections.some((row) => row.name === "docs")).toBe(true);
+	});
+
+	it("does not drop built-in credentials when deleting a catalog-named shadow", async () => {
+		const { deps, removed } = createDeps({
+			linear: { type: "http", url: "https://mcp.example.test/linear", oauth: true },
+		});
+		const response = await handleChatMcpDelete(
+			new Request("http://localhost/api/chat/mcp", {
+				method: "DELETE",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ name: "linear" }),
+			}),
+			deps,
+		);
+		expect(response.status).toBe(200);
+		expect(removed).toEqual([]);
+	});
+
+	it("rejects a stdio cwd that escapes the workspace", async () => {
+		const { deps } = createDeps();
+		const response = await handleChatMcpPost(
+			new Request("http://localhost/api/chat/mcp", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					name: "shell",
+					transport: "stdio",
+					command: "uvx",
+					cwd: "../escape",
+					force: true,
+				}),
+			}),
+			deps,
+		);
+		expect(response.status).toBe(400);
+		const body = (await response.json()) as { message: string };
+		expect(body.message).toMatch(/working directory/i);
+		expect(body.message).not.toContain("escape");
+	});
+
+	it("returns a waiting OAuth snapshot with an auth URL", async () => {
+		const { deps } = createDeps();
+		deps.auth.login = async (_providerId, callbacks) => {
+			callbacks.onAuth({ url: "https://auth.example.test/authorize" });
+			await new Promise<void>((_resolve, reject) => {
+				callbacks.signal?.addEventListener("abort", () => reject(new Error("Login cancelled")), { once: true });
+			});
+		};
+		const response = await handleChatMcpOAuthPost(
+			new Request("http://localhost/api/chat/mcp/oauth", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ name: "linear", action: "login" }),
+			}),
+			deps,
+		);
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as { status: string; authUrl?: string; loginId?: string };
+		expect(body.status).toBe("waiting");
+		expect(body.authUrl).toBe("https://auth.example.test/authorize");
+		expect(body.loginId).toBeTruthy();
+	});
+
+	it("returns success after a completing OAuth login", async () => {
+		const { deps } = createDeps();
+		const start = await handleChatMcpOAuthPost(
+			new Request("http://localhost/api/chat/mcp/oauth", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ name: "linear" }),
+			}),
+			deps,
+		);
+		const started = (await start.json()) as { loginId: string; status: string };
+		expect(started.status).toBe("waiting");
+		await vi.waitFor(async () => {
+			const polled = await handleChatMcpOAuthPost(
+				new Request("http://localhost/api/chat/mcp/oauth", {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({ name: "linear", loginId: started.loginId }),
+				}),
+				deps,
+			);
+			const body = (await polled.json()) as { status: string; connections?: Array<unknown> };
+			expect(body.status).toBe("success");
+			expect(body.connections).toBeTruthy();
+		});
+	});
+
+	it("returns an error snapshot when login fails", async () => {
+		const { deps } = createDeps();
+		deps.auth.login = async () => {
+			throw new Error("oauth failed");
+		};
+		const start = await handleChatMcpOAuthPost(
+			new Request("http://localhost/api/chat/mcp/oauth", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ name: "linear" }),
+			}),
+			deps,
+		);
+		const started = (await start.json()) as { loginId: string };
+		await vi.waitFor(async () => {
+			const polled = await handleChatMcpOAuthPost(
+				new Request("http://localhost/api/chat/mcp/oauth", {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({ name: "linear", loginId: started.loginId }),
+				}),
+				deps,
+			);
+			const body = (await polled.json()) as { status: string; error?: string };
+			expect(body.status).toBe("error");
+			expect(body.error).toMatch(/oauth failed/);
+		});
+	});
+
+	it("logs out stored credentials and returns the refreshed list", async () => {
+		const { deps, removed } = createDeps();
+		deps.auth.get = () => ({ type: "oauth", endpoint: "https://mcp.linear.app/mcp" });
+		const response = await handleChatMcpOAuthPost(
+			new Request("http://localhost/api/chat/mcp/oauth", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ name: "linear", action: "logout" }),
+			}),
+			deps,
+		);
+		expect(response.status).toBe(200);
+		expect(removed).toEqual(["mcp:linear"]);
+		const body = (await response.json()) as { status: string; connections?: Array<{ name: string }> };
+		expect(body.status).toBe("success");
+		expect(body.connections?.some((row) => row.name === "linear")).toBe(true);
+	});
+});

--- a/web/server/src/__tests__/mcp-connections.test.ts
+++ b/web/server/src/__tests__/mcp-connections.test.ts
@@ -1,0 +1,122 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { confineMcpStdioCwd, dropMcpServerCredentials, listMcpConnections, McpRequestError } from "../mcp-connections";
+
+describe("listMcpConnections", () => {
+	it("lists built-ins and sanitizes user servers without leaking secrets", () => {
+		const auth = {
+			get: (provider: string) =>
+				provider === "mcp:linear" ? { type: "oauth", endpoint: "https://other" } : undefined,
+			removeVerified: () => undefined,
+		};
+		const connections = listMcpConnections(
+			{
+				docs: {
+					type: "http",
+					url: "https://mcp.example.test/mcp",
+					oauth: true,
+					headers: { Authorization: "Bearer super-secret-token" },
+				} as never,
+				shell: {
+					type: "stdio",
+					command: "uvx",
+					args: ["mcp-server"],
+					cwd: "/Users/example/project",
+					env: { TOKEN: { env: "MCP_TOKEN" } },
+				},
+			},
+			auth,
+			{},
+		);
+
+		const linear = connections.find((row) => row.name === "linear");
+		const docs = connections.find((row) => row.name === "docs");
+		const shell = connections.find((row) => row.name === "shell");
+		expect(linear).toMatchObject({
+			source: "builtin",
+			transport: "http",
+			usesOAuth: true,
+			enabled: true,
+			status: "connected",
+		});
+		expect(docs).toMatchObject({
+			source: "user",
+			url: "https://mcp.example.test/mcp",
+			usesOAuth: true,
+			status: "needs_auth",
+			enabled: false,
+		});
+		expect(JSON.stringify(docs)).not.toContain("super-secret-token");
+		expect(JSON.stringify(docs)).not.toContain("Authorization");
+		expect(shell).toMatchObject({
+			transport: "stdio",
+			commandPreview: "uvx mcp-server",
+			enabled: true,
+			status: "connected",
+			envBindings: [{ child: "TOKEN", source: "MCP_TOKEN" }],
+		});
+		expect(JSON.stringify(shell)).not.toContain("secret-value");
+	});
+
+	it("treats anonymous HTTP and bearer env as connected without storing tokens", () => {
+		const auth = { get: () => undefined, removeVerified: () => undefined };
+		const connections = listMcpConnections(
+			{
+				public: { type: "http", url: "https://mcp.example.test/anon" },
+				tokened: {
+					type: "http",
+					url: "https://mcp.example.test/token",
+					bearerTokenEnvVar: "DOCS_MCP_TOKEN",
+				},
+			},
+			auth,
+			{ DOCS_MCP_TOKEN: "env-secret" },
+		);
+		expect(connections.find((row) => row.name === "public")).toMatchObject({
+			status: "anonymous",
+			enabled: true,
+		});
+		expect(connections.find((row) => row.name === "tokened")).toMatchObject({
+			status: "connected",
+			enabled: true,
+			bearerTokenEnvVar: "DOCS_MCP_TOKEN",
+		});
+		expect(JSON.stringify(connections)).not.toContain("env-secret");
+	});
+});
+
+describe("dropMcpServerCredentials", () => {
+	it("does not drop catalog-named built-in credentials", () => {
+		const removed: Array<string> = [];
+		dropMcpServerCredentials("linear", {
+			get: () => undefined,
+			removeVerified: (provider) => {
+				removed.push(provider);
+			},
+		});
+		expect(removed).toEqual([]);
+	});
+});
+
+describe("confineMcpStdioCwd", () => {
+	it("rejects a cwd that escapes the workspace", async () => {
+		const root = mkdtempSync(join(tmpdir(), "mcp-cwd-"));
+		try {
+			await expect(confineMcpStdioCwd("../escape", root)).rejects.toBeInstanceOf(McpRequestError);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("accepts a workspace-relative cwd", async () => {
+		const root = mkdtempSync(join(tmpdir(), "mcp-cwd-ok-"));
+		try {
+			const confined = await confineMcpStdioCwd("tools", root);
+			expect(confined).toBe(join(root, "tools"));
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/web/server/src/__tests__/session-list-handlers.test.ts
+++ b/web/server/src/__tests__/session-list-handlers.test.ts
@@ -141,4 +141,53 @@ describe("session list handlers", () => {
 		expect(body.message).toBe("The Prime Agent session listing returned an invalid session entry");
 		expect(body.message).not.toContain(process.cwd());
 	});
+
+	it("titles a command-only session from live Fleet presentation", async () => {
+		setBridgeForTests({
+			listSessions: vi.fn(async () => [
+				{
+					sessionId: "refine-session",
+					cwd: process.cwd(),
+					firstMessage: "(no messages)",
+					messageCount: 0,
+					created: "2026-09-12T00:00:00.000Z",
+					modified: "2026-09-12T00:01:00.000Z",
+				},
+			]),
+			getSession: vi.fn(
+				() =>
+					({
+						sessionId: "refine-session",
+						mapperState: {
+							presentation: {
+								revision: 1,
+								userBash: [],
+								rlmChildren: [],
+								refinements: [
+									{
+										id: "ref-1",
+										summary: "Tighten the plan",
+										rationale: "Clearer steps",
+										expectedOutcome: "A better plan",
+										edits: [],
+										status: "success",
+										timestamp: 1,
+									},
+								],
+								artifactRuns: [],
+							},
+						},
+					}) as unknown as BridgeSession,
+			),
+			resetForTests: vi.fn(),
+		} as unknown as PrimeBridge);
+
+		const response = await handleChatSessionsGet(new Request("http://localhost/api/chat/sessions"));
+		expect(ChatSessionsResponseSchema.parse(await response.json()).sessions[0]).toMatchObject({
+			sessionId: "refine-session",
+			title: "Tighten the plan",
+			firstMessage: "Tighten the plan",
+			messageCount: 1,
+		});
+	});
 });

--- a/web/server/src/__tests__/session-list.test.ts
+++ b/web/server/src/__tests__/session-list.test.ts
@@ -1,0 +1,112 @@
+import type { PrimeAgentSessionPresentation } from "@prime-agent/web-protocol/chat-protocol";
+import { EMPTY_SESSION_FIRST_MESSAGE } from "@prime-agent/web-protocol/session-label";
+import { describe, expect, it } from "vitest";
+import {
+	applyPresentationToSessionRow,
+	normalizeSessionListRow,
+	presentationListActivity,
+	type SessionListSource,
+	sessionNeedsPresentationJoin,
+} from "../session-list";
+
+function listSource(row: {
+	sessionId: string;
+	cwd: string;
+	sessionName?: string;
+	firstMessage: string;
+	messageCount: number;
+	created: string;
+	modified: string;
+}): SessionListSource {
+	return row as SessionListSource;
+}
+
+const refinementPresentation: PrimeAgentSessionPresentation = {
+	revision: 1,
+	userBash: [],
+	rlmChildren: [],
+	refinements: [
+		{
+			id: "ref-1",
+			summary: "Tighten the plan",
+			rationale: "Clearer steps",
+			expectedOutcome: "A better plan",
+			edits: [],
+			status: "success",
+			timestamp: 2,
+		},
+	],
+	artifactRuns: [],
+};
+
+describe("normalizeSessionListRow", () => {
+	it("strips the upstream empty-session placeholder", () => {
+		const row = normalizeSessionListRow(
+			listSource({
+				sessionId: "refine-session",
+				cwd: "/workspace",
+				sessionName: EMPTY_SESSION_FIRST_MESSAGE,
+				firstMessage: EMPTY_SESSION_FIRST_MESSAGE,
+				messageCount: 0,
+				created: "2026-09-12T00:00:00.000Z",
+				modified: "2026-09-12T00:01:00.000Z",
+			}),
+		);
+		expect(row.title).toBeUndefined();
+		expect(row.firstMessage).toBe("");
+		expect(row.messageCount).toBe(0);
+		expect(sessionNeedsPresentationJoin(row)).toBe(true);
+	});
+});
+
+describe("applyPresentationToSessionRow", () => {
+	it("titles command-only activity from a refinement sidecar", () => {
+		const row = normalizeSessionListRow(
+			listSource({
+				sessionId: "refine-session",
+				cwd: "/workspace",
+				firstMessage: EMPTY_SESSION_FIRST_MESSAGE,
+				messageCount: 0,
+				created: "2026-09-12T00:00:00.000Z",
+				modified: "2026-09-12T00:01:00.000Z",
+			}),
+		);
+		const fields = applyPresentationToSessionRow(row, refinementPresentation);
+		expect(fields.title).toBe("Tighten the plan");
+		expect(fields.firstMessage).toBe("Tighten the plan");
+		expect(fields.messageCount).toBe(1);
+	});
+
+	it("keeps a true empty draft at zero messages", () => {
+		const row = normalizeSessionListRow(
+			listSource({
+				sessionId: "draft-session",
+				cwd: "/workspace",
+				firstMessage: EMPTY_SESSION_FIRST_MESSAGE,
+				messageCount: 0,
+				created: "2026-09-12T00:00:00.000Z",
+				modified: "2026-09-12T00:01:00.000Z",
+			}),
+		);
+		const fields = applyPresentationToSessionRow(row, undefined);
+		expect(fields.title).toBe("draft-se");
+		expect(fields.firstMessage).toBe("");
+		expect(fields.messageCount).toBe(0);
+	});
+
+	it("prefers a saved session name over a later refinement summary", () => {
+		expect(presentationListActivity({ ...refinementPresentation, sessionName: "Plan v2" }).title).toBe("Plan v2");
+		const row = normalizeSessionListRow(
+			listSource({
+				sessionId: "named-session",
+				cwd: "/workspace",
+				sessionName: "Plan v2",
+				firstMessage: EMPTY_SESSION_FIRST_MESSAGE,
+				messageCount: 0,
+				created: "2026-09-12T00:00:00.000Z",
+				modified: "2026-09-12T00:01:00.000Z",
+			}),
+		);
+		expect(applyPresentationToSessionRow(row, refinementPresentation).title).toBe("Plan v2");
+	});
+});

--- a/web/server/src/handlers/chat-mcp.ts
+++ b/web/server/src/handlers/chat-mcp.ts
@@ -1,0 +1,277 @@
+import {
+	BUILTIN_MCP_CATALOG,
+	createMcpOAuthProvider,
+	getCatalogEntry,
+	registerBuiltinMcpOAuthProviders,
+} from "@earendil-works/pi-ai/mcp";
+import type { OAuthLoginCallbacks } from "@earendil-works/pi-ai/oauth";
+import { getOAuthProvider, registerOAuthProvider } from "@earendil-works/pi-ai/oauth";
+import {
+	ChatMcpDeleteRequestSchema,
+	ChatMcpOAuthLoginRequestSchema,
+	ChatMcpUpsertRequestSchema,
+} from "@prime-agent/web-protocol/chat-protocol.zod";
+import type { ChatMcpListResponse, ChatMcpOAuthLoginResponse, McpConnectionInfo } from "@prime-agent/web-protocol/mcp";
+import {
+	confineMcpStdioCwd,
+	dropMcpServerCredentials,
+	type FleetMcpServerConfig,
+	listMcpConnections,
+	McpRequestError,
+	mcpProviderId,
+	validateHttpMcpUrl,
+} from "../mcp-connections";
+import { getPrimeConfig } from "../prime-config";
+import { getBridge } from "../singleton";
+import { wrapApiHandler } from "../wrap-api-handler";
+import {
+	cancelOAuthLogin,
+	continueOAuthLogin,
+	type OAuthLoginDeps,
+	pollOAuthLogin,
+	startOAuthLogin,
+} from "./chat-providers-oauth";
+
+export type McpHandlerDeps = {
+	getUserServers: () => Record<string, FleetMcpServerConfig> | undefined;
+	setUserServer: (name: string, config: FleetMcpServerConfig, force: boolean) => void;
+	removeUserServer: (name: string) => boolean;
+	flushSettings: () => Promise<void>;
+	auth: {
+		get: (provider: string) => { type?: string; endpoint?: unknown } | undefined;
+		removeVerified: (provider: string) => void;
+		login: (providerId: string, callbacks: OAuthLoginCallbacks) => Promise<void>;
+	};
+	workspaceRoot: string;
+	env: NodeJS.Dict<string>;
+	reloadAuth: () => void;
+	reloadResources: () => Promise<void>;
+};
+
+function defaultMcpDeps(): McpHandlerDeps {
+	const config = getPrimeConfig();
+	const settings = config.defaultSettings;
+	return {
+		getUserServers: () => settings.getGlobalMcpServers() as Record<string, FleetMcpServerConfig> | undefined,
+		setUserServer: (name, serverConfig, force) => {
+			settings.setGlobalMcpServer(name, serverConfig, force);
+		},
+		removeUserServer: (name) => settings.removeGlobalMcpServer(name),
+		flushSettings: async () => {
+			await settings.flush();
+			const error = settings.drainErrors("global")[0];
+			if (error) throw error.error;
+		},
+		auth: config.authStorage,
+		workspaceRoot: config.defaultCwd,
+		env: process.env,
+		reloadAuth: () => {
+			config.reloadAuth();
+		},
+		reloadResources: async () => {
+			await getBridge().reloadResources();
+		},
+	};
+}
+
+function listedConnections(deps: McpHandlerDeps): Array<McpConnectionInfo> {
+	return listMcpConnections(deps.getUserServers(), deps.auth, deps.env);
+}
+
+function listResponse(deps: McpHandlerDeps): ChatMcpListResponse {
+	return { connections: listedConnections(deps) };
+}
+
+function toMcpOAuthResponse(
+	snapshot: {
+		status: ChatMcpOAuthLoginResponse["status"];
+		loginId?: string;
+		authUrl?: string;
+		userCode?: string;
+		instructions?: string;
+		prompt?: ChatMcpOAuthLoginResponse["prompt"];
+		error?: string;
+	},
+	connections?: Array<McpConnectionInfo>,
+): ChatMcpOAuthLoginResponse {
+	return {
+		status: snapshot.status,
+		...(snapshot.loginId ? { loginId: snapshot.loginId } : {}),
+		...(snapshot.authUrl ? { authUrl: snapshot.authUrl } : {}),
+		...(snapshot.userCode ? { userCode: snapshot.userCode } : {}),
+		...(snapshot.instructions ? { instructions: snapshot.instructions } : {}),
+		...(snapshot.prompt ? { prompt: snapshot.prompt } : {}),
+		...(snapshot.error ? { error: snapshot.error } : {}),
+		...(connections ? { connections } : {}),
+	};
+}
+
+function ensureMcpOAuthProvider(name: string, deps: McpHandlerDeps): void {
+	registerBuiltinMcpOAuthProviders();
+	if (getCatalogEntry(name)) return;
+	const config = deps.getUserServers()?.[name];
+	if (!config || config.type !== "http" || config.oauth !== true) {
+		throw new McpRequestError("This MCP server does not use OAuth.");
+	}
+	registerOAuthProvider(
+		createMcpOAuthProvider({
+			server: name,
+			label: name,
+			url: config.url,
+		}),
+	);
+}
+
+function oauthDeps(deps: McpHandlerDeps): OAuthLoginDeps {
+	return {
+		login: (providerId, callbacks) => deps.auth.login(providerId, callbacks),
+		reloadAuth: () => {
+			deps.reloadAuth();
+			void deps.reloadResources();
+		},
+		listProviders: () => [],
+	};
+}
+
+async function logoutMcp(name: string, deps: McpHandlerDeps): Promise<ChatMcpOAuthLoginResponse> {
+	try {
+		deps.auth.removeVerified(mcpProviderId(name));
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new McpRequestError(`Could not remove stored credentials: ${message}`);
+	}
+	deps.reloadAuth();
+	await deps.reloadResources();
+	return { status: "success", connections: listedConnections(deps) };
+}
+
+export function handleChatMcpGet(_request: Request, deps: McpHandlerDeps = defaultMcpDeps()): Promise<Response> {
+	return wrapApiHandler(async () => Response.json(listResponse(deps)), _request);
+}
+
+export function handleChatMcpPost(request: Request, deps: McpHandlerDeps = defaultMcpDeps()): Promise<Response> {
+	return wrapApiHandler(async () => {
+		const body = ChatMcpUpsertRequestSchema.parse(await request.json().catch(() => ({})));
+		if (getCatalogEntry(body.name)) {
+			throw new McpRequestError(`MCP server name "${body.name}" is reserved for a built-in integration.`);
+		}
+		const existing = deps.getUserServers()?.[body.name];
+		if (existing && body.force !== true) {
+			throw new McpRequestError(`MCP server "${body.name}" already exists. Replace it to continue.`);
+		}
+
+		let config: FleetMcpServerConfig;
+		switch (body.transport) {
+			case "http": {
+				if (body.bearerTokenEnvVar && body.oauth) {
+					throw new McpRequestError("OAuth and a bearer-token environment variable cannot be combined.");
+				}
+				config = {
+					type: "http",
+					url: validateHttpMcpUrl(body.url),
+					...(body.bearerTokenEnvVar ? { bearerTokenEnvVar: body.bearerTokenEnvVar } : {}),
+					...(body.oauth ? { oauth: true } : {}),
+				};
+				break;
+			}
+			case "stdio": {
+				if (body.command.includes("\0") || body.args?.some((part) => part.includes("\0"))) {
+					throw new McpRequestError("MCP command arguments cannot contain NUL.");
+				}
+				const env = Object.fromEntries((body.env ?? []).map((binding) => [binding.child, { env: binding.source }]));
+				const cwd = await confineMcpStdioCwd(body.cwd, deps.workspaceRoot);
+				config = {
+					type: "stdio",
+					command: body.command,
+					...(body.args && body.args.length > 0 ? { args: body.args } : {}),
+					...(cwd ? { cwd } : {}),
+					...(Object.keys(env).length > 0 ? { env } : {}),
+				};
+				break;
+			}
+			default: {
+				const unexpected: never = body;
+				throw new McpRequestError(`Unsupported MCP transport: ${String(unexpected)}`);
+			}
+		}
+
+		dropMcpServerCredentials(body.name, deps.auth);
+		deps.setUserServer(body.name, config, true);
+		await deps.flushSettings();
+		deps.reloadAuth();
+		await deps.reloadResources();
+		return Response.json(listResponse(deps));
+	}, request);
+}
+
+export function handleChatMcpDelete(request: Request, deps: McpHandlerDeps = defaultMcpDeps()): Promise<Response> {
+	return wrapApiHandler(async () => {
+		const body = ChatMcpDeleteRequestSchema.parse(await request.json().catch(() => ({})));
+		if (!deps.removeUserServer(body.name)) {
+			throw new McpRequestError(`MCP server "${body.name}" was not found.`);
+		}
+		await deps.flushSettings();
+		dropMcpServerCredentials(body.name, deps.auth);
+		deps.reloadAuth();
+		await deps.reloadResources();
+		return Response.json(listResponse(deps));
+	}, request);
+}
+
+export function handleChatMcpOAuthPost(request: Request, deps: McpHandlerDeps = defaultMcpDeps()): Promise<Response> {
+	return wrapApiHandler(async () => {
+		const body = ChatMcpOAuthLoginRequestSchema.parse(await request.json().catch(() => ({})));
+		const known = [...BUILTIN_MCP_CATALOG.map((entry) => entry.server), ...Object.keys(deps.getUserServers() ?? {})];
+		if (!known.includes(body.name) && !body.loginId) {
+			throw new McpRequestError(`Unknown MCP server: ${body.name}`);
+		}
+
+		if (body.cancel) {
+			if (!body.loginId) {
+				return Response.json(
+					{ status: "error", error: "loginId is required to cancel" } satisfies ChatMcpOAuthLoginResponse,
+					{ status: 400 },
+				);
+			}
+			return Response.json(toMcpOAuthResponse(cancelOAuthLogin(body.loginId)));
+		}
+		if (body.loginId && body.promptAnswer !== undefined) {
+			return Response.json(toMcpOAuthResponse(continueOAuthLogin(body.loginId, body.promptAnswer)));
+		}
+		if (body.loginId) {
+			const snapshot = pollOAuthLogin(body.loginId);
+			return Response.json(
+				toMcpOAuthResponse(snapshot, snapshot.status === "success" ? listedConnections(deps) : undefined),
+			);
+		}
+
+		const action = body.action ?? "login";
+		switch (action) {
+			case "logout":
+				return Response.json(await logoutMcp(body.name, deps));
+			case "reconnect":
+				await logoutMcp(body.name, deps);
+				break;
+			case "login":
+				break;
+			default: {
+				const unexpected: never = action;
+				throw new McpRequestError(`Unsupported MCP OAuth action: ${String(unexpected)}`);
+			}
+		}
+
+		ensureMcpOAuthProvider(body.name, deps);
+		const providerId = mcpProviderId(body.name);
+		if (!getOAuthProvider(providerId)) {
+			return Response.json(
+				{
+					status: "error",
+					error: `Unknown OAuth provider: ${providerId}`,
+				} satisfies ChatMcpOAuthLoginResponse,
+				{ status: 400 },
+			);
+		}
+
+		return Response.json(toMcpOAuthResponse(startOAuthLogin(providerId, oauthDeps(deps))));
+	}, request);
+}

--- a/web/server/src/handlers/chat-sessions.ts
+++ b/web/server/src/handlers/chat-sessions.ts
@@ -1,6 +1,6 @@
 import { ProjectIdSchema } from "@prime-agent/web-protocol";
 import { getPrimeConfig } from "../prime-config";
-import { normalizeSessionListRow } from "../session-list";
+import { applyPresentationToSessionRow, loadSessionListPresentation, normalizeSessionListRow } from "../session-list";
 import { getBridge } from "../singleton";
 import { wrapApiHandler } from "../wrap-api-handler";
 import { sessionStatus } from "./projects";
@@ -20,18 +20,22 @@ export function handleChatSessionsGet(_request: Request): Promise<Response> {
 			sessions.map(async (s) => {
 				const session = normalizeSessionListRow(s);
 				const liveSession = bridge.getSession(session.sessionId);
+				const fields = applyPresentationToSessionRow(
+					session,
+					await loadSessionListPresentation(session, s, liveSession?.mapperState?.presentation),
+				);
 				return {
 					sessionId: session.sessionId,
 					projectId: await getPrimeConfig().projectRegistry.projectIdForSession(
 						session.sessionId,
 						liveSession?.cwd ?? session.cwd,
 					),
-					title: session.title || session.firstMessage || session.sessionId.slice(0, 8),
+					title: fields.title,
 					createdAt: session.createdAt,
 					updatedAt: session.updatedAt,
 					status: sessionStatus(session.source, liveSession),
-					messageCount: session.messageCount,
-					firstMessage: session.firstMessage,
+					messageCount: fields.messageCount,
+					firstMessage: fields.firstMessage,
 					...(session.isSubagent ? { isSubagent: true } : {}),
 				};
 			}),

--- a/web/server/src/handlers/projects.ts
+++ b/web/server/src/handlers/projects.ts
@@ -8,7 +8,7 @@ import {
 import type { SessionSummary } from "prime-agent";
 import type { BridgeSession } from "../prime-bridge";
 import { getPrimeConfig } from "../prime-config";
-import { normalizeSessionListRow } from "../session-list";
+import { applyPresentationToSessionRow, loadSessionListPresentation, normalizeSessionListRow } from "../session-list";
 import { getBridge } from "../singleton";
 import { wrapApiHandler } from "../wrap-api-handler";
 
@@ -65,20 +65,27 @@ export function handleProjectsGet(_request: Request): Promise<Response> {
 		}
 		return Response.json({
 			projects: await getPrimeConfig().projectRegistry.list(counts),
-			sessions: sessions.map((source) => {
-				const session = normalizeSessionListRow(source);
-				return {
-					sessionId: session.sessionId,
-					projectId: assignments.get(session.sessionId) ?? null,
-					title: redactSessionLabelSecrets(session.title || session.firstMessage || session.sessionId.slice(0, 8)),
-					createdAt: session.createdAt,
-					updatedAt: session.updatedAt,
-					status: sessionStatus(session.source, getBridge().getSession(session.sessionId)),
-					messageCount: session.messageCount,
-					firstMessage: session.firstMessage ? redactSessionLabelSecrets(session.firstMessage) : "",
-					...(session.isSubagent ? { isSubagent: true } : {}),
-				};
-			}),
+			sessions: await Promise.all(
+				sessions.map(async (source) => {
+					const session = normalizeSessionListRow(source);
+					const liveSession = getBridge().getSession(session.sessionId);
+					const fields = applyPresentationToSessionRow(
+						session,
+						await loadSessionListPresentation(session, source, liveSession?.mapperState?.presentation),
+					);
+					return {
+						sessionId: session.sessionId,
+						projectId: assignments.get(session.sessionId) ?? null,
+						title: redactSessionLabelSecrets(fields.title),
+						createdAt: session.createdAt,
+						updatedAt: session.updatedAt,
+						status: sessionStatus(session.source, liveSession),
+						messageCount: fields.messageCount,
+						firstMessage: fields.firstMessage ? redactSessionLabelSecrets(fields.firstMessage) : "",
+						...(session.isSubagent ? { isSubagent: true } : {}),
+					};
+				}),
+			),
 		});
 	}, _request);
 }

--- a/web/server/src/index.ts
+++ b/web/server/src/index.ts
@@ -4,6 +4,7 @@ export { handleChatAttachmentGet, handleChatAttachmentsPost } from "./handlers/c
 export { handleChatCommandPost } from "./handlers/chat-command";
 export { handleChatCommandsGet } from "./handlers/chat-commands";
 export { handleChatEventsGet } from "./handlers/chat-events";
+export { handleChatMcpDelete, handleChatMcpGet, handleChatMcpOAuthPost, handleChatMcpPost } from "./handlers/chat-mcp";
 export { handleChatModelPost } from "./handlers/chat-model";
 export { handleChatModelsGet } from "./handlers/chat-models";
 export { handleChatModelsDiscoverPost } from "./handlers/chat-models-discover";

--- a/web/server/src/mcp-connections.ts
+++ b/web/server/src/mcp-connections.ts
@@ -1,0 +1,206 @@
+import { realpath } from "node:fs/promises";
+import { dirname, resolve, sep } from "node:path";
+import { BUILTIN_MCP_CATALOG, getCatalogEntry } from "@earendil-works/pi-ai/mcp";
+import type { McpConnectionInfo, McpConnectionStatus, McpEnvBinding } from "@prime-agent/web-protocol/mcp";
+import { safePathLabel } from "./project-registry";
+
+export type FleetMcpHttpConfig = {
+	type: "http";
+	url: string;
+	bearerTokenEnvVar?: string;
+	oauth?: boolean;
+	enabled?: boolean;
+};
+
+export type FleetMcpStdioConfig = {
+	type: "stdio";
+	command: string;
+	args?: Array<string>;
+	cwd?: string;
+	env?: Record<string, { env: string }>;
+	enabled?: boolean;
+};
+
+export type FleetMcpServerConfig = FleetMcpHttpConfig | FleetMcpStdioConfig;
+
+export const MCP_AUTH_PREFIX = "mcp:";
+
+export function mcpProviderId(name: string): string {
+	return `${MCP_AUTH_PREFIX}${name}`;
+}
+
+export class McpRequestError extends Error {
+	readonly status: 400 = 400;
+	constructor(message: string) {
+		super(message);
+		this.name = "McpRequestError";
+	}
+}
+
+export type McpAuthRecord = {
+	type?: string;
+	endpoint?: unknown;
+};
+
+export type McpAuthStore = {
+	get(provider: string): McpAuthRecord | undefined;
+	removeVerified(provider: string): void;
+};
+
+export type McpListedServer = {
+	name: string;
+	label: string;
+	source: McpConnectionInfo["source"];
+	config: FleetMcpServerConfig;
+	userDeclared: boolean;
+};
+
+export function validateHttpMcpUrl(value: string): string {
+	let url: URL;
+	try {
+		url = new URL(value);
+	} catch {
+		throw new McpRequestError("Invalid MCP URL.");
+	}
+	if ((url.protocol !== "http:" && url.protocol !== "https:") || !url.hostname || url.username || url.password) {
+		throw new McpRequestError("MCP URL must be an http(s) URL without embedded credentials.");
+	}
+	return url.toString();
+}
+
+export function stdioCommandPreview(config: FleetMcpStdioConfig): string {
+	return [config.command, ...(config.args ?? [])].join(" ");
+}
+
+export function mcpEnvBindings(config: FleetMcpServerConfig): Array<McpEnvBinding> | undefined {
+	if (config.type !== "stdio" || !config.env) return undefined;
+	const bindings = Object.entries(config.env).map(([child, mapping]) => ({ child, source: mapping.env }));
+	return bindings.length > 0 ? bindings : undefined;
+}
+
+export function isMcpAuthed(server: McpListedServer, auth: McpAuthStore, env: NodeJS.Dict<string>): boolean {
+	if (server.config.enabled === false) return false;
+	if (server.userDeclared && getCatalogEntry(server.name)) return false;
+	if (server.config.type === "stdio") return true;
+	const usesOAuth = server.config.type === "http" && server.config.oauth === true;
+	const bearerTokenEnvVar = server.config.type === "http" ? server.config.bearerTokenEnvVar : undefined;
+	if (!usesOAuth && !bearerTokenEnvVar) return true;
+	if (bearerTokenEnvVar && env[bearerTokenEnvVar]?.trim()) return true;
+	const cred = auth.get(mcpProviderId(server.name));
+	if (cred === undefined) return false;
+	if (!server.userDeclared) return true;
+	const endpoint = cred.endpoint;
+	return typeof endpoint === "string" && server.config.type === "http" && endpoint === server.config.url;
+}
+
+export function mcpConnectionStatus(server: McpListedServer, authed: boolean): McpConnectionStatus {
+	if (server.config.enabled === false) return "disabled";
+	if (authed) {
+		const anonymousHttp =
+			server.config.type === "http" && server.config.oauth !== true && !server.config.bearerTokenEnvVar;
+		return anonymousHttp ? "anonymous" : "connected";
+	}
+	return "needs_auth";
+}
+
+export function toMcpConnectionInfo(
+	server: McpListedServer,
+	auth: McpAuthStore,
+	env: NodeJS.Dict<string>,
+): McpConnectionInfo {
+	const usesOAuth = server.config.type === "http" && server.config.oauth === true;
+	const catalogShadow = server.userDeclared && Boolean(getCatalogEntry(server.name));
+	const authed = isMcpAuthed(server, auth, env);
+	const envBindings = mcpEnvBindings(server.config);
+	return {
+		name: server.name,
+		label: server.label,
+		source: server.source,
+		transport: server.config.type,
+		usesOAuth,
+		enabled: authed,
+		status: mcpConnectionStatus(server, authed),
+		...(server.config.type === "http" ? { url: server.config.url } : {}),
+		...(server.config.type === "stdio" ? { commandPreview: stdioCommandPreview(server.config) } : {}),
+		...(server.config.type === "stdio" && server.config.cwd ? { cwdPreview: safePathLabel(server.config.cwd) } : {}),
+		...(server.config.type === "http" && server.config.bearerTokenEnvVar
+			? { bearerTokenEnvVar: server.config.bearerTokenEnvVar }
+			: {}),
+		...(envBindings ? { envBindings } : {}),
+		...(catalogShadow ? { error: "This name is reserved for a built-in integration." } : {}),
+	};
+}
+
+export function listMcpServers(userServers: Record<string, FleetMcpServerConfig> | undefined): Array<McpListedServer> {
+	const listed: Array<McpListedServer> = [];
+	for (const entry of BUILTIN_MCP_CATALOG) {
+		listed.push({
+			name: entry.server,
+			label: entry.label,
+			source: "builtin",
+			userDeclared: false,
+			config: { type: "http", url: entry.url, oauth: true },
+		});
+	}
+	for (const [name, config] of Object.entries(userServers ?? {}).sort(([left], [right]) =>
+		left.localeCompare(right),
+	)) {
+		listed.push({
+			name,
+			label: name,
+			source: "user",
+			userDeclared: true,
+			config,
+		});
+	}
+	return listed;
+}
+
+export function listMcpConnections(
+	userServers: Record<string, FleetMcpServerConfig> | undefined,
+	auth: McpAuthStore,
+	env: NodeJS.Dict<string> = process.env,
+): Array<McpConnectionInfo> {
+	return listMcpServers(userServers).map((server) => toMcpConnectionInfo(server, auth, env));
+}
+
+export function dropMcpServerCredentials(name: string, auth: McpAuthStore): void {
+	if (getCatalogEntry(name)) return;
+	try {
+		auth.removeVerified(mcpProviderId(name));
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new McpRequestError(`Could not remove stored credentials for this MCP server: ${message}`);
+	}
+}
+
+export async function confineMcpStdioCwd(cwd: string | undefined, workspaceRoot: string): Promise<string | undefined> {
+	if (cwd === undefined || cwd.trim() === "") return undefined;
+	const root = resolve(workspaceRoot);
+	const canonicalRoot = await realpath(root).catch(() => root);
+	const candidate = resolve(root, cwd);
+	const existingCandidate = await realpath(candidate).catch(() => undefined);
+	if (
+		existingCandidate &&
+		existingCandidate !== canonicalRoot &&
+		!existingCandidate.startsWith(`${canonicalRoot}${sep}`)
+	) {
+		throw new McpRequestError("MCP stdio working directory must stay inside the workspace.");
+	}
+	let ancestor = dirname(candidate);
+	while (true) {
+		const resolvedAncestor = await realpath(ancestor).catch(() => undefined);
+		if (resolvedAncestor) {
+			if (resolvedAncestor !== canonicalRoot && !resolvedAncestor.startsWith(`${canonicalRoot}${sep}`)) {
+				throw new McpRequestError("MCP stdio working directory must stay inside the workspace.");
+			}
+			break;
+		}
+		const parent = dirname(ancestor);
+		if (parent === ancestor) {
+			throw new McpRequestError("MCP stdio working directory must stay inside the workspace.");
+		}
+		ancestor = parent;
+	}
+	return candidate;
+}

--- a/web/server/src/session-list.ts
+++ b/web/server/src/session-list.ts
@@ -1,4 +1,7 @@
+import type { PrimeAgentSessionPresentation } from "@prime-agent/web-protocol/chat-protocol";
+import { fallbackSessionLabel, meaningfulSessionLabel } from "@prime-agent/web-protocol/session-label";
 import type { SessionInfo, SessionSummary } from "prime-agent";
+import { loadManagedPrimePresentation } from "./prime-agent-presentation";
 
 export type SessionListSource = SessionInfo | SessionSummary;
 
@@ -12,6 +15,12 @@ export interface NormalizedSessionListRow {
 	readonly messageCount: number;
 	readonly firstMessage: string;
 	readonly isSubagent: boolean;
+}
+
+export interface SessionListDisplayFields {
+	readonly title: string;
+	readonly firstMessage: string;
+	readonly messageCount: number;
 }
 
 /**
@@ -65,11 +74,73 @@ export function normalizeSessionListRow(source: SessionListSource): NormalizedSe
 		source,
 		sessionId,
 		cwd,
-		title: stringValue(raw.sessionName) ?? stringValue(raw.name),
+		title: meaningfulSessionLabel(stringValue(raw.sessionName) ?? stringValue(raw.name)),
 		createdAt,
 		updatedAt,
 		messageCount: messageCountValue(raw.messageCount),
-		firstMessage: typeof raw.firstMessage === "string" ? raw.firstMessage : "",
+		firstMessage: meaningfulSessionLabel(typeof raw.firstMessage === "string" ? raw.firstMessage : undefined) ?? "",
 		isSubagent,
 	};
+}
+
+export function sessionSourcePath(source: SessionListSource): string | undefined {
+	const raw = source as unknown as Record<string, unknown>;
+	return stringValue(raw.sessionFile) ?? stringValue(raw.path);
+}
+
+function latestBy<T>(entries: ReadonlyArray<T>, time: (entry: T) => number): T | undefined {
+	if (entries.length === 0) return undefined;
+	return entries.reduce((latest, entry) => (time(entry) >= time(latest) ? entry : latest));
+}
+
+export function presentationListActivity(presentation: PrimeAgentSessionPresentation | undefined): {
+	title?: string;
+	activityCount: number;
+} {
+	if (!presentation) return { activityCount: 0 };
+	const artifacts = presentation.artifactRuns.flatMap((run) => run.artifacts);
+	const latestRefinement = latestBy(presentation.refinements, (entry) => entry.timestamp);
+	const latestArtifact = latestBy(artifacts, (entry) => entry.timestamp);
+	const latestBash = latestBy(presentation.userBash, (entry) => entry.startedAt);
+	const title =
+		meaningfulSessionLabel(presentation.sessionName) ??
+		meaningfulSessionLabel(latestRefinement?.summary) ??
+		meaningfulSessionLabel(latestArtifact?.title) ??
+		meaningfulSessionLabel(latestBash?.command);
+	return {
+		title,
+		activityCount: presentation.refinements.length + artifacts.length + presentation.userBash.length,
+	};
+}
+
+export function applyPresentationToSessionRow(
+	row: NormalizedSessionListRow,
+	presentation: PrimeAgentSessionPresentation | undefined,
+): SessionListDisplayFields {
+	const { title: presentationTitle, activityCount } = presentationListActivity(presentation);
+	const firstMessage = row.firstMessage || presentationTitle || "";
+	const title =
+		row.title ?? meaningfulSessionLabel(firstMessage) ?? presentationTitle ?? fallbackSessionLabel(row.sessionId);
+	return {
+		title,
+		firstMessage,
+		messageCount: row.messageCount > 0 ? row.messageCount : activityCount > 0 ? 1 : 0,
+	};
+}
+
+export function sessionNeedsPresentationJoin(row: NormalizedSessionListRow): boolean {
+	return row.messageCount === 0 || !row.title || !row.firstMessage;
+}
+
+export async function loadSessionListPresentation(
+	row: NormalizedSessionListRow,
+	source: SessionListSource,
+	livePresentation: PrimeAgentSessionPresentation | undefined,
+): Promise<PrimeAgentSessionPresentation | undefined> {
+	const liveActivity = presentationListActivity(livePresentation);
+	if (liveActivity.activityCount > 0 || liveActivity.title) return livePresentation;
+	if (!sessionNeedsPresentationJoin(row)) return livePresentation;
+	const path = sessionSourcePath(source);
+	if (!path) return livePresentation;
+	return (await loadManagedPrimePresentation({ sessionPath: path })) ?? livePresentation;
 }


### PR DESCRIPTION
## Summary
- Slash command hints insert `/{cmd} ` into the composer instead of executing immediately; `/mcp` submit opens Settings → MCP.
- Session sidebar labels use Fleet sidecars and disambiguation instead of `(no messages)` for command-only sessions.
- MCP connections are manageable from Settings via a browser-safe protocol, server adapter, and OAuth callback route.

## Closes
- Closes #73
- Closes #74
- Closes #128

## Test plan
- [x] `pnpm run check`
- [x] Focused vitest for slash commands, session labels, MCP handlers
- [x] `pnpm run test:web`
- [x] Browser: `/name` and `/mcp` insert with trailing space; `/mcp` submit opens MCP settings; session list shows real titles; MCP list + Add server form work
- [ ] Live `/refine` title update
- [ ] Live MCP OAuth sign-in
- [ ] Search dialog session titles