### PR TITLE
fix(web): resolve live QA chrome regressions in panels and previews

### DIFF
--- a/.changeset/live-qa-ui-fixes.md
+++ b/.changeset/live-qa-ui-fixes.md
@@ -1,0 +1,5 @@
+---
+"@qredence/fleet": patch
+---
+
+Fix clipped right-panel tabs, low-contrast chrome menus, header New chat, and hung workspace Markdown previews.

--- a/docs/proposals/session-tree-rewind.md
+++ b/docs/proposals/session-tree-rewind.md
@@ -1,4 +1,6 @@
-# Session tree and rewind (web) — architecture plan
+# Session tree and rewind (web) — product proposal
+
+This is a planning artifact, not a runbook. See [docs/README.md](../README.md) for current guides.
 
 Issue: [#124](https://github.com/Qredence/fleet-prime-agent/issues/124)
 

--- a/web/app/src/lib/pi/agent-tab-bar.test.tsx
+++ b/web/app/src/lib/pi/agent-tab-bar.test.tsx
@@ -1,67 +1,72 @@
-import { fireEvent, render, screen } from "@testing-library/react"
-import { useState } from "react"
-import { describe, expect, it, vi } from "vitest"
 import {
-  AgentTabBar,
-  type AgentTabItem,
-} from "@prime-agent/web-design/components/product/fleet-pi/layout/agent-tab-bar"
+	AgentTabBar,
+	type AgentTabItem,
+} from "@prime-agent/web-design/components/product/fleet-pi/layout/agent-tab-bar";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
 
 const initialTabs: Array<AgentTabItem> = [
-  { id: "main", label: "Main agent", kind: "main" },
-  { id: "research", label: "Research worker", kind: "subagent", status: "running" },
-  { id: "writer", label: "Writer worker", kind: "subagent", status: "done" },
-]
+	{ id: "main", label: "Main agent", kind: "main" },
+	{ id: "research", label: "Research worker", kind: "subagent", status: "running" },
+	{ id: "writer", label: "Writer worker", kind: "subagent", status: "done" },
+];
 
 function ControlledTabBar({ onClose, onNewSession }: { onClose: (id: string) => void; onNewSession: () => void }) {
-  const [tabs, setTabs] = useState(initialTabs)
-  const [value, setValue] = useState("main")
-  return (
-    <AgentTabBar
-      tabs={tabs}
-      value={value}
-      onValueChange={setValue}
-      onClose={(id) => {
-        onClose(id)
-        setTabs((current) => current.filter((tab) => tab.id !== id))
-        setValue((current) => (current === id ? "main" : current))
-      }}
-      onNewSession={onNewSession}
-    />
-  )
+	const [tabs, setTabs] = useState(initialTabs);
+	const [value, setValue] = useState("main");
+	return (
+		<AgentTabBar
+			tabs={tabs}
+			value={value}
+			onValueChange={setValue}
+			onClose={(id) => {
+				onClose(id);
+				setTabs((current) => current.filter((tab) => tab.id !== id));
+				setValue((current) => (current === id ? "main" : current));
+			}}
+			onNewSession={onNewSession}
+		/>
+	);
 }
 
 describe("AgentTabBar", () => {
-  it("keeps tree order, exposes tab state, and roves focus with arrows", () => {
-    render(<ControlledTabBar onClose={vi.fn()} onNewSession={vi.fn()} />)
+	it("keeps tree order, exposes tab state, and roves focus with arrows", () => {
+		render(<ControlledTabBar onClose={vi.fn()} onNewSession={vi.fn()} />);
 
-    expect(screen.getAllByRole("tab").map((tab) => tab.textContent?.trim())).toEqual([
-      "Main agent",
-      "Research worker",
-      "Writer worker",
-    ])
-    expect(screen.getByRole("tab", { name: "Main agent, ready" }).getAttribute("aria-selected")).toBe("true")
-    expect(screen.getByRole("tab", { name: "Research worker, streaming" }).getAttribute("aria-selected")).toBe("false")
-    expect(screen.getByRole("tab", { name: "Main agent, ready" }).className).toContain("bg-surface-4")
-    expect(screen.getByRole("tab", { name: "Research worker, streaming" }).className).toContain("bg-transparent")
+		expect(screen.getAllByRole("tab").map((tab) => tab.textContent?.trim())).toEqual([
+			"Main agent",
+			"Research worker",
+			"Writer worker",
+		]);
+		expect(screen.getByRole("tab", { name: "Main agent, ready" }).getAttribute("aria-selected")).toBe("true");
+		expect(screen.getByRole("tab", { name: "Research worker, streaming" }).getAttribute("aria-selected")).toBe(
+			"false",
+		);
+		expect(screen.getByRole("tab", { name: "Main agent, ready" }).className).toContain("bg-surface-4");
+		expect(screen.getByRole("tab", { name: "Research worker, streaming" }).className).toContain("bg-transparent");
 
-    fireEvent.keyDown(screen.getByRole("tab", { name: "Main agent, ready" }), { key: "ArrowRight" })
+		fireEvent.keyDown(screen.getByRole("tab", { name: "Main agent, ready" }), { key: "ArrowRight" });
 
-    expect(screen.getByRole("tab", { name: "Research worker, streaming" }).getAttribute("aria-selected")).toBe("true")
-    expect(document.activeElement).toBe(screen.getByRole("tab", { name: "Research worker, streaming" }))
-  })
+		expect(screen.getByRole("tab", { name: "Research worker, streaming" }).getAttribute("aria-selected")).toBe(
+			"true",
+		);
+		expect(document.activeElement).toBe(screen.getByRole("tab", { name: "Research worker, streaming" }));
+	});
 
-  it("dismisses only child tabs and keeps the main tab permanent", () => {
-    const onClose = vi.fn()
-    const onNewSession = vi.fn()
-    render(<ControlledTabBar onClose={onClose} onNewSession={onNewSession} />)
+	it("dismisses only child tabs and keeps the main tab permanent", () => {
+		const onClose = vi.fn();
+		const onNewSession = vi.fn();
+		render(<ControlledTabBar onClose={onClose} onNewSession={onNewSession} />);
 
-    expect(screen.queryByRole("button", { name: "Close Main agent tab" })).toBeNull()
-    fireEvent.click(screen.getByRole("button", { name: "Close Research worker tab" }))
-    fireEvent.click(screen.getByRole("button", { name: "New chat" }))
+		expect(screen.queryByRole("button", { name: "Close Main agent tab" })).toBeNull();
+		fireEvent.click(screen.getByRole("button", { name: "Close Research worker tab" }));
+		fireEvent.click(screen.getByRole("button", { name: "New chat" }));
 
-    expect(onClose).toHaveBeenCalledWith("research")
-    expect(screen.queryByRole("tab", { name: "Research worker, streaming" })).toBeNull()
-    expect(screen.getByRole("tab", { name: "Main agent, ready" })).toBeTruthy()
-    expect(onNewSession).toHaveBeenCalledOnce()
-  })
-})
+		expect(onClose).toHaveBeenCalledWith("research");
+		expect(screen.queryByRole("tab", { name: "Research worker, streaming" })).toBeNull();
+		expect(screen.getByRole("tab", { name: "Main agent, ready" })).toBeTruthy();
+		expect(onNewSession).toHaveBeenCalledOnce();
+		expect(screen.getByTestId("new-chat-tab").className).toContain("after:inset-x-0");
+	});
+});

--- a/web/app/src/lib/pi/chat-client.ts
+++ b/web/app/src/lib/pi/chat-client.ts
@@ -108,7 +108,7 @@ export type ChatClient = {
 	getCommands: (projectId?: ProjectId) => Promise<ChatCommandsResponse>;
 	getSettings: (projectId?: ProjectId) => Promise<ChatSettingsResponse>;
 	getWorkspaceTree: (projectId?: ProjectId) => Promise<WorkspaceTreeResponse>;
-	getWorkspaceFile: (path: string, projectId?: ProjectId) => Promise<WorkspaceFileResponse>;
+	getWorkspaceFile: (path: string, projectId?: ProjectId, signal?: AbortSignal) => Promise<WorkspaceFileResponse>;
 	listSessions: (projectId?: ProjectId) => Promise<Array<ChatSessionInfo>>;
 	renameSession: (sessionId: string, title: string) => Promise<void>;
 	deleteSession: (sessionId: string) => Promise<void>;
@@ -283,10 +283,14 @@ export const chatClient: ChatClient = {
 		return fetchValidatedJson(`/api/workspace/tree${query}`, WorkspaceTreeResponseSchema);
 	},
 
-	async getWorkspaceFile(path, projectId) {
+	async getWorkspaceFile(path, projectId, signal) {
 		const params = new URLSearchParams({ path });
 		if (projectId) params.set("projectId", projectId);
-		return fetchValidatedJson(`/api/workspace/file?${params}`, WorkspaceFileResponseSchema);
+		return fetchValidatedJson(
+			`/api/workspace/file?${params}`,
+			WorkspaceFileResponseSchema,
+			signal ? { signal } : undefined,
+		);
 	},
 
 	async listSessions(projectId) {

--- a/web/app/src/lib/pi/chat-error-notify.test.ts
+++ b/web/app/src/lib/pi/chat-error-notify.test.ts
@@ -1,7 +1,7 @@
 import { notify } from "@prime-agent/web-design/lib/notify";
 import { NETWORK_DISCONNECTED_MESSAGE } from "@prime-agent/web-protocol/chat-protocol";
 import { describe, expect, it, vi } from "vitest";
-import { notifyChatError } from "./chat-error-notify";
+import { notifyChatError, runWorkspaceAction } from "./chat-error-notify";
 import { ChatRequestError, chatErrorFromStreamEvent, isDaemonDisconnectError } from "./chat-fetch";
 
 vi.mock("@prime-agent/web-design/lib/notify", () => ({
@@ -55,5 +55,12 @@ describe("notifyChatError", () => {
 	it("toasts ordinary failures with their message", () => {
 		notifyChatError(new Error("Project no longer exists"));
 		expect(notifyError).toHaveBeenCalledWith("Project no longer exists");
+	});
+
+	it("surfaces rejected workspace chrome actions", async () => {
+		runWorkspaceAction(async () => {
+			throw new Error("Unable to create session");
+		});
+		await vi.waitFor(() => expect(notifyError).toHaveBeenCalledWith("Unable to create session"));
 	});
 });

--- a/web/app/src/lib/pi/chat-error-notify.test.ts
+++ b/web/app/src/lib/pi/chat-error-notify.test.ts
@@ -63,4 +63,11 @@ describe("notifyChatError", () => {
 		});
 		await vi.waitFor(() => expect(notifyError).toHaveBeenCalledWith("Unable to create session"));
 	});
+
+	it("surfaces synchronous workspace chrome action failures", async () => {
+		runWorkspaceAction(() => {
+			throw new Error("Unable to open workspace");
+		});
+		await vi.waitFor(() => expect(notifyError).toHaveBeenCalledWith("Unable to open workspace"));
+	});
 });

--- a/web/app/src/lib/pi/chat-error-notify.ts
+++ b/web/app/src/lib/pi/chat-error-notify.ts
@@ -14,5 +14,5 @@ export function notifyChatError(error: unknown): void {
  * Runs a workspace chrome action and surfaces failures instead of a silent no-op.
  */
 export function runWorkspaceAction(action: () => Promise<unknown>): void {
-	void Promise.resolve(action()).catch(notifyChatError);
+	void Promise.resolve().then(action).catch(notifyChatError);
 }

--- a/web/app/src/lib/pi/chat-error-notify.ts
+++ b/web/app/src/lib/pi/chat-error-notify.ts
@@ -9,3 +9,10 @@ export function notifyChatError(error: unknown): void {
 	if (isDaemonDisconnectError(error)) return;
 	notify.error(error instanceof Error ? error.message : String(error));
 }
+
+/**
+ * Runs a workspace chrome action and surfaces failures instead of a silent no-op.
+ */
+export function runWorkspaceAction(action: () => Promise<unknown>): void {
+	void Promise.resolve(action()).catch(notifyChatError);
+}

--- a/web/app/src/lib/pi/chat-workspace-dialogs.tsx
+++ b/web/app/src/lib/pi/chat-workspace-dialogs.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense, useCallback, useEffect, useState } from "react";
+import { runWorkspaceAction } from "./chat-error-notify";
 import type { useChatWorkspaceData } from "./use-chat-workspace-data";
 
 type WorkspaceData = ReturnType<typeof useChatWorkspaceData>;
@@ -9,9 +10,9 @@ const LazyChatCommandPalette = lazy(() =>
 	),
 );
 const LazySettingsDialog = lazy(() =>
-	import("@prime-agent/web-design/components/product/fleet-pi/pi/settings-dialog").then(
-		({ SettingsDialog }) => ({ default: SettingsDialog }),
-	),
+	import("@prime-agent/web-design/components/product/fleet-pi/pi/settings-dialog").then(({ SettingsDialog }) => ({
+		default: SettingsDialog,
+	})),
 );
 const LazyForkPickerDialog = lazy(() =>
 	import("@prime-agent/web-design/components/product/fleet-pi/chat/fork-picker-dialog").then(
@@ -48,7 +49,7 @@ export function ChatCommandPaletteOverlay({
 					<LazyChatCommandPalette
 						open
 						onOpenChange={dialogs.setCommandPaletteOpen}
-						onNewSession={() => void session.startNewSession()}
+						onNewSession={() => runWorkspaceAction(() => session.startNewSession())}
 						onStop={conversation.stop}
 						onResumeSession={(sessionToResume) =>
 							void session.resumeSession({ sessionId: sessionToResume.sessionId })

--- a/web/app/src/lib/pi/chat-workspace-shell.test.tsx
+++ b/web/app/src/lib/pi/chat-workspace-shell.test.tsx
@@ -1,0 +1,251 @@
+import { AgentTabBar } from "@prime-agent/web-design/components/product/fleet-pi/layout/agent-tab-bar";
+import { notify } from "@prime-agent/web-design/lib/notify";
+import type { PrimeAgentSessionPresentation } from "@prime-agent/web-protocol/chat-protocol";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runWorkspaceAction } from "./chat-error-notify";
+import { ChatWorkspaceShell } from "./chat-workspace-shell";
+import type { useChatWorkspaceData } from "./use-chat-workspace-data";
+
+vi.mock("@prime-agent/web-design/lib/notify", () => ({
+	notify: {
+		error: vi.fn(),
+		message: vi.fn(),
+		success: vi.fn(),
+	},
+}));
+
+vi.mock("./chat-panel", () => ({
+	ChatPanel: () => <div data-testid="chat-panel" />,
+}));
+
+vi.mock("./chat-workspace-dialogs", () => ({
+	ChatCommandPaletteOverlay: () => null,
+	ChatWorkspaceOverlayDialogs: () => null,
+}));
+
+vi.mock("@prime-agent/web-design/components/product/fleet-pi/layout/right-panel-shell", () => ({
+	RightPanelShell: () => null,
+}));
+
+vi.mock("./panel-keybindings", () => ({
+	focusChatComposer: vi.fn(),
+	usePanelKeybindings: vi.fn(),
+}));
+
+const { useChatWorkspaceDataMock } = vi.hoisted(() => ({
+	useChatWorkspaceDataMock: vi.fn(),
+}));
+
+vi.mock("./use-chat-workspace-data", () => ({
+	useChatWorkspaceData: () => useChatWorkspaceDataMock(),
+}));
+
+const emptyPresentation: PrimeAgentSessionPresentation = {
+	revision: 0,
+	userBash: [],
+	rlmChildren: [],
+	refinements: [],
+	artifactRuns: [],
+};
+
+type WorkspaceData = ReturnType<typeof useChatWorkspaceData>;
+
+function createWorkspaceData(startNewSession: () => Promise<unknown>): WorkspaceData {
+	const composer = {
+		answerQuestion: vi.fn(),
+		chatMode: "agent" as const,
+		clearUploadedAttachments: vi.fn(),
+		clearWorkspaceAttachments: vi.fn(),
+		effortPickerOpen: false,
+		handleAttach: vi.fn(),
+		handleLocalSlashSubmit: vi.fn(),
+		handleQuestionAnswer: vi.fn(),
+		handleSlashCommandSelect: vi.fn(),
+		infoDescription: undefined,
+		inputSuggestionItems: [],
+		workspaceReferenceSuggestions: [],
+		modelKey: undefined,
+		modelPickerOpen: false,
+		models: [],
+		pendingQuestionBar: undefined,
+		removeUploadedAttachment: vi.fn(),
+		removeWorkspaceAttachment: vi.fn(),
+		addWorkspaceAttachment: vi.fn(),
+		restoreAttachments: vi.fn(),
+		setChatMode: vi.fn(),
+		setEffortPickerOpen: vi.fn(),
+		setModelKey: vi.fn(),
+		setModelPickerOpen: vi.fn(),
+		setThinkingLevel: vi.fn(),
+		slashCommands: [],
+		thinkingLevel: "off",
+		uploadedAttachments: [],
+		workspaceAttachments: [],
+	} satisfies WorkspaceData["composer"];
+
+	return {
+		session: {
+			activeSessionId: "session-1",
+			activeProjectId: undefined,
+			openPanelAction: vi.fn(),
+			projects: [],
+			projectSessions: [],
+			sessions: [],
+			browseProjectDirectories: vi.fn(),
+			createProject: vi.fn(),
+			deleteSession: vi.fn(),
+			forkSessionIntoProject: vi.fn(),
+			renameProject: vi.fn(),
+			renameSession: vi.fn(),
+			resumeSession: vi.fn(),
+			selectProject: vi.fn(),
+			startNewSession,
+			startNewSessionInProject: vi.fn(),
+			unregisterProject: vi.fn(),
+		},
+		conversation: {
+			activityLabel: undefined,
+			artifactRuns: [],
+			deleteQueuedMessage: vi.fn(),
+			editQueuedMessage: vi.fn(),
+			error: null,
+			messages: [],
+			openArtifact: vi.fn(),
+			openPanelAction: vi.fn(),
+			persistOpenUIArtifact: vi.fn(),
+			presentation: emptyPresentation,
+			queue: { steering: [], followUp: [] },
+			sendMessage: vi.fn(),
+			status: "ready",
+			stop: vi.fn(),
+		},
+		agentTabs: {
+			activeTabId: "main",
+			closeTab: vi.fn(),
+			conversation: {
+				status: "ready",
+				loading: false,
+				messages: [],
+				presentation: emptyPresentation,
+				refresh: vi.fn(),
+				sendMessage: vi.fn(),
+				sending: false,
+				stop: vi.fn(),
+			},
+			openChildTab: vi.fn(),
+			selectedChild: undefined,
+			selectTab: vi.fn(),
+			tabs: [{ id: "main", label: "Main agent", kind: "main" }],
+		},
+		composer,
+		panels: {
+			chatPanelData: {
+				artifactRuns: [],
+				chatMode: "agent",
+				loadSession: vi.fn(),
+				loadSubagentSession: vi.fn(),
+				messages: [],
+				models: [],
+				presentation: emptyPresentation,
+				queue: { steering: [], followUp: [] },
+				refreshResources: vi.fn(),
+				resources: null,
+				resourcesError: null,
+				resourcesLoading: false,
+				reopenRightPanel: vi.fn(),
+				rightPanel: null,
+				selectedArtifactId: null,
+				sessionId: "session-1",
+				setRightPanel: vi.fn(),
+				status: "ready",
+			},
+			handleResourceCanvasResizeStart: vi.fn(),
+			resourceCanvasWidth: 360,
+			rightPanel: null,
+			setRightPanel: vi.fn(),
+			settingsActions: {
+				onThemePreferenceChange: vi.fn(),
+				saveSettings: vi.fn(),
+				settings: null,
+				settingsError: null,
+				settingsLoading: false,
+				themePreference: "system",
+			},
+			workspaceTreeContext: {
+				loadWorkspaceFile: vi.fn(),
+				openWorkspacePath: vi.fn(),
+				refreshWorkspace: vi.fn(),
+				selectedWorkspacePath: null,
+				setSelectedWorkspacePath: vi.fn(),
+				workspaceError: null,
+				workspaceLoading: false,
+				workspaceTree: null,
+			},
+		},
+		dialogs: {
+			commandPaletteOpen: false,
+			forkFromEntry: null,
+			forkPickerEntries: null,
+			setCommandPaletteOpen: vi.fn(),
+			setForkPickerEntries: vi.fn(),
+			setSettingsDialogOpen: vi.fn(),
+			setSettingsInitialTab: vi.fn(),
+			settingsDialogOpen: false,
+			settingsInitialTab: undefined,
+		},
+		chrome: {
+			handleThemePreferenceChange: vi.fn(),
+			header: {
+				left: <div />,
+				accountMenu: <div />,
+				center: (
+					<AgentTabBar
+						tabs={[{ id: "main", label: "Main agent", kind: "main" }]}
+						value="main"
+						onValueChange={vi.fn()}
+						onNewSession={() => runWorkspaceAction(() => startNewSession())}
+					/>
+				),
+				right: <div />,
+			},
+			themePreference: "system",
+		},
+	} as unknown as WorkspaceData;
+}
+
+describe("ChatWorkspaceShell new session chrome", () => {
+	beforeEach(() => {
+		vi.mocked(notify.error).mockClear();
+		window.localStorage.clear();
+	});
+
+	it("starts a session from the header control and the sidebar New chat action", async () => {
+		const startNewSession = vi.fn().mockResolvedValue({ sessionId: "session-2" });
+		useChatWorkspaceDataMock.mockReturnValue(createWorkspaceData(startNewSession));
+
+		render(<ChatWorkspaceShell />);
+
+		const newChatButtons = screen.getAllByRole("button", { name: "New chat" });
+		const headerNewChat = newChatButtons.find((button) => button.getAttribute("data-testid") === "new-chat-tab");
+		const sidebarNewChat = newChatButtons.find((button) => button.getAttribute("data-testid") !== "new-chat-tab");
+		expect(headerNewChat).toBeTruthy();
+		expect(sidebarNewChat).toBeTruthy();
+
+		fireEvent.click(headerNewChat!);
+		await waitFor(() => expect(startNewSession).toHaveBeenCalledTimes(1));
+
+		fireEvent.click(sidebarNewChat!);
+		await waitFor(() => expect(startNewSession).toHaveBeenCalledTimes(2));
+	});
+
+	it("surfaces create failures from the header New chat control", async () => {
+		const startNewSession = vi.fn().mockRejectedValue(new Error("Unable to create session"));
+		useChatWorkspaceDataMock.mockReturnValue(createWorkspaceData(startNewSession));
+
+		render(<ChatWorkspaceShell />);
+		fireEvent.click(screen.getByTestId("new-chat-tab"));
+
+		await waitFor(() => expect(notify.error).toHaveBeenCalledWith("Unable to create session"));
+	});
+});

--- a/web/app/src/lib/pi/chat-workspace-shell.tsx
+++ b/web/app/src/lib/pi/chat-workspace-shell.tsx
@@ -1,25 +1,22 @@
-import { UiErrorBoundary } from "@prime-agent/web-design/components/product/fleet-pi/ui-error-boundary";
+import type { OpenUIArtifactCandidate } from "@prime-agent/web-design/components/openui/html-artifact";
+import { decodeOpenPanelActionMessage } from "@prime-agent/web-design/components/openui/open-panel-action-message";
 import {
 	agentTabPanelId,
 	agentTabTriggerId,
 } from "@prime-agent/web-design/components/product/fleet-pi/layout/agent-tab-ids";
-import { RightPanelShell } from "@prime-agent/web-design/components/product/fleet-pi/layout/right-panel-shell";
-import { RightPanelProvider } from "@prime-agent/web-design/components/product/fleet-pi/layout/right-panel-context";
 import { ChatWorkspaceLayout } from "@prime-agent/web-design/components/product/fleet-pi/layout/chat-workspace-layout";
-import { ChatApp } from "@prime-agent/web-design/components/registry/beui/agents/chat-app";
+import { RightPanelProvider } from "@prime-agent/web-design/components/product/fleet-pi/layout/right-panel-context";
+import { RightPanelShell } from "@prime-agent/web-design/components/product/fleet-pi/layout/right-panel-shell";
 import { FleetSessionSidebar } from "@prime-agent/web-design/components/product/fleet-pi/session-sidebar";
+import { UiErrorBoundary } from "@prime-agent/web-design/components/product/fleet-pi/ui-error-boundary";
+import { ChatApp } from "@prime-agent/web-design/components/registry/beui/agents/chat-app";
 import { AnimatedSidebarInset } from "@prime-agent/web-design/components/registry/beui/motion/animated-sidebar";
-import { decodeOpenPanelActionMessage } from "@prime-agent/web-design/components/openui/open-panel-action-message";
-import type { OpenUIArtifactCandidate } from "@prime-agent/web-design/components/openui/html-artifact";
 import { notify } from "@prime-agent/web-design/lib/notify";
 import { lazy, Suspense, useCallback } from "react";
-import { ChatPanel } from "@/lib/pi/chat-panel";
+import { notifyChatError, runWorkspaceAction } from "@/lib/pi/chat-error-notify";
 import { buildChatInputBarProps } from "@/lib/pi/chat-input-bar-props";
-import { notifyChatError } from "@/lib/pi/chat-error-notify";
-import {
-	ChatCommandPaletteOverlay,
-	ChatWorkspaceOverlayDialogs,
-} from "@/lib/pi/chat-workspace-dialogs";
+import { ChatPanel } from "@/lib/pi/chat-panel";
+import { ChatCommandPaletteOverlay, ChatWorkspaceOverlayDialogs } from "@/lib/pi/chat-workspace-dialogs";
 import { focusChatComposer, usePanelKeybindings } from "@/lib/pi/panel-keybindings";
 import { useChatWorkspaceData } from "@/lib/pi/use-chat-workspace-data";
 
@@ -47,9 +44,7 @@ export function ChatWorkspaceShell() {
 		rightPanel: panels.rightPanel,
 		setRightPanel: panels.setRightPanel,
 	});
-	const activeProjectName = session.projects.find(
-		(project) => project.projectId === session.activeProjectId,
-	)?.name;
+	const activeProjectName = session.projects.find((project) => project.projectId === session.activeProjectId)?.name;
 	const handleSend = useCallback(
 		(text: string, altKey?: boolean) => {
 			const uploaded = [...composer.uploadedAttachments];
@@ -168,7 +163,7 @@ export function ChatWorkspaceShell() {
 							activeSessionId: session.activeSessionId,
 						}}
 						sessionActions={{
-							onNewSession: () => void session.startNewSession(),
+							onNewSession: () => runWorkspaceAction(() => session.startNewSession()),
 							onNewSessionInProject: session.startNewSessionInProject,
 							onResumeSession: (sessionToResume) =>
 								void session.resumeSession({ sessionId: sessionToResume.sessionId }),

--- a/web/app/src/lib/pi/react-doctor-regressions.test.tsx
+++ b/web/app/src/lib/pi/react-doctor-regressions.test.tsx
@@ -1,185 +1,181 @@
-import { render, renderHook, act, fireEvent } from "@testing-library/react"
-import { useRef } from "react"
-import { afterEach, describe, expect, it, vi } from "vitest"
-import { Popover } from "@prime-agent/web-design/components/registry/beui/agents/input/input-popover"
-import { ChromePillButton } from "@prime-agent/web-design/components/product/fleet-pi/primitives/chrome-pill"
-import { useProximityHover } from "@prime-agent/web-design/hooks/use-proximity-hover"
-import type { ChatProviderOAuthLoginRequest, ChatProviderOAuthLoginResponse, ChatSessionMetadata } from "@prime-agent/web-protocol/chat-protocol"
-import type { ChatClient } from "./chat-client"
-import { useOAuthLoginFlow } from "@prime-agent/web-design/components/product/fleet-pi/pi/config-panel/sections/use-oauth-login-flow"
-import { usePiChat } from "./use-pi-chat"
+import { useOAuthLoginFlow } from "@prime-agent/web-design/components/product/fleet-pi/pi/config-panel/sections/use-oauth-login-flow";
+import { ChromePillButton } from "@prime-agent/web-design/components/product/fleet-pi/primitives/chrome-pill";
+import { Popover } from "@prime-agent/web-design/components/registry/beui/agents/input/input-popover";
+import { useProximityHover } from "@prime-agent/web-design/hooks/use-proximity-hover";
+import type {
+	ChatProviderOAuthLoginRequest,
+	ChatProviderOAuthLoginResponse,
+	ChatSessionMetadata,
+} from "@prime-agent/web-protocol/chat-protocol";
+import { act, fireEvent, render, renderHook } from "@testing-library/react";
+import { useRef } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChatClient } from "./chat-client";
+import { usePiChat } from "./use-pi-chat";
 
 describe("React Doctor lifecycle and accessibility regressions", () => {
-  afterEach(() => {
-    vi.unstubAllGlobals()
-  })
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
 
-  it("connects a Popover trigger to its popup with aria-controls", () => {
-    const { getByRole } = render(
-      <Popover trigger={<button type="button">Choose model</button>} defaultOpen>
-        <div>Models</div>
-      </Popover>,
-    )
+	it("connects a Popover trigger to its popup with aria-controls", () => {
+		const { getByRole } = render(
+			<Popover trigger={<button type="button">Choose model</button>} defaultOpen>
+				<div>Models</div>
+			</Popover>,
+		);
 
-    const trigger = getByRole("button", { name: "Choose model" })
-    const popupId = trigger.getAttribute("aria-controls")
+		const trigger = getByRole("button", { name: "Choose model" });
+		const popupId = trigger.getAttribute("aria-controls");
 
-    expect(popupId).toBeTruthy()
-    expect(document.getElementById(popupId ?? "")).not.toBeNull()
-  })
+		expect(popupId).toBeTruthy();
+		const popup = document.getElementById(popupId ?? "");
+		expect(popup).not.toBeNull();
+		expect(popup?.className).toContain("bg-popover");
+		expect(popup?.className).toContain("border");
+		expect(popup?.className).toContain("shadow-lg");
+	});
 
-  it("opens a Popover from a shared product button", () => {
-    const { container, getByRole, queryByText } = render(
-      <Popover
-        overlay
-        trigger={
-          <ChromePillButton ariaLabel="Open account menu">
-            Account
-          </ChromePillButton>
-        }
-      >
-        <div>Account settings</div>
-      </Popover>,
-    )
+	it("opens a Popover from a shared product button", () => {
+		const { container, getByRole, queryByText } = render(
+			<Popover overlay trigger={<ChromePillButton ariaLabel="Open account menu">Account</ChromePillButton>}>
+				<div>Account settings</div>
+			</Popover>,
+		);
 
-    expect(queryByText("Account settings")).toBeNull()
-    expect(container.querySelector(".fixed.inset-0.z-40")).toBeNull()
-    fireEvent.click(getByRole("button", { name: "Open account menu" }))
-    expect(getByRole("dialog").textContent).toContain("Account settings")
-    expect(container.querySelector(".fixed.inset-0.z-40")).not.toBeNull()
-    fireEvent.click(getByRole("button", { name: "Open account menu" }))
-    expect(container.querySelector(".fixed.inset-0.z-40")).toBeNull()
-  })
+		expect(queryByText("Account settings")).toBeNull();
+		expect(container.querySelector(".fixed.inset-0.z-40")).toBeNull();
+		fireEvent.click(getByRole("button", { name: "Open account menu" }));
+		expect(getByRole("dialog").textContent).toContain("Account settings");
+		expect(container.querySelector(".fixed.inset-0.z-40")).not.toBeNull();
+		fireEvent.click(getByRole("button", { name: "Open account menu" }));
+		expect(container.querySelector(".fixed.inset-0.z-40")).toBeNull();
+	});
 
-  it("uses the latest provider id after OAuth callback props change", async () => {
-    const requests: ChatProviderOAuthLoginRequest[] = []
-    const onOAuthLogin = vi.fn(
-      async (request: ChatProviderOAuthLoginRequest): Promise<ChatProviderOAuthLoginResponse> => {
-        requests.push(request)
-        return { status: "success" }
-      },
-    )
+	it("uses the latest provider id after OAuth callback props change", async () => {
+		const requests: ChatProviderOAuthLoginRequest[] = [];
+		const onOAuthLogin = vi.fn(
+			async (request: ChatProviderOAuthLoginRequest): Promise<ChatProviderOAuthLoginResponse> => {
+				requests.push(request);
+				return { status: "success" };
+			},
+		);
 
-    const { result, rerender } = renderHook(
-      ({ providerId }: { providerId: string }) =>
-        useOAuthLoginFlow({ providerId, onOAuthLogin }),
-      { initialProps: { providerId: "provider-a" } },
-    )
+		const { result, rerender } = renderHook(
+			({ providerId }: { providerId: string }) => useOAuthLoginFlow({ providerId, onOAuthLogin }),
+			{ initialProps: { providerId: "provider-a" } },
+		);
 
-    rerender({ providerId: "provider-b" })
-    await act(async () => {
-      await result.current.start()
-    })
+		rerender({ providerId: "provider-b" });
+		await act(async () => {
+			await result.current.start();
+		});
 
-    expect(requests).toEqual([{ providerId: "provider-b" }])
-  })
+		expect(requests).toEqual([{ providerId: "provider-b" }]);
+	});
 
-  it("keeps busy when a stale OAuth attempt resolves after a restart", async () => {
-    const pending: Array<(value: ChatProviderOAuthLoginResponse) => void> = []
-    const onOAuthLogin = vi.fn((request: ChatProviderOAuthLoginRequest) => {
-      if (request.cancel) return Promise.resolve({ status: "success" } as ChatProviderOAuthLoginResponse)
-      return new Promise<ChatProviderOAuthLoginResponse>((resolve) => pending.push(resolve))
-    })
+	it("keeps busy when a stale OAuth attempt resolves after a restart", async () => {
+		const pending: Array<(value: ChatProviderOAuthLoginResponse) => void> = [];
+		const onOAuthLogin = vi.fn((request: ChatProviderOAuthLoginRequest) => {
+			if (request.cancel) return Promise.resolve({ status: "success" } as ChatProviderOAuthLoginResponse);
+			return new Promise<ChatProviderOAuthLoginResponse>((resolve) => pending.push(resolve));
+		});
 
-    const { result } = renderHook(() => useOAuthLoginFlow({ providerId: "provider-a", onOAuthLogin }))
+		const { result } = renderHook(() => useOAuthLoginFlow({ providerId: "provider-a", onOAuthLogin }));
 
-    // Attempt A: leave the start request in flight.
-    await act(async () => {
-      void result.current.start()
-    })
-    expect(result.current.busy).toBe(true)
+		// Attempt A: leave the start request in flight.
+		await act(async () => {
+			void result.current.start();
+		});
+		expect(result.current.busy).toBe(true);
 
-    // Cancel, then immediately restart; attempt B also stays in flight.
-    await act(async () => {
-      await result.current.cancel()
-    })
-    await act(async () => {
-      void result.current.start()
-    })
-    expect(result.current.busy).toBe(true)
+		// Cancel, then immediately restart; attempt B also stays in flight.
+		await act(async () => {
+			await result.current.cancel();
+		});
+		await act(async () => {
+			void result.current.start();
+		});
+		expect(result.current.busy).toBe(true);
 
-    // Attempt A resolves late: its stale finally must not clear attempt B's busy.
-    await act(async () => {
-      pending[0]?.({ status: "waiting", loginId: "login-a" } as ChatProviderOAuthLoginResponse)
-      await Promise.resolve()
-    })
-    expect(result.current.busy).toBe(true)
+		// Attempt A resolves late: its stale finally must not clear attempt B's busy.
+		await act(async () => {
+			pending[0]?.({ status: "waiting", loginId: "login-a" } as ChatProviderOAuthLoginResponse);
+			await Promise.resolve();
+		});
+		expect(result.current.busy).toBe(true);
 
-    await act(async () => {
-      pending[1]?.({ status: "success" })
-      await Promise.resolve()
-    })
-    expect(result.current.busy).toBe(false)
-  })
+		await act(async () => {
+			pending[1]?.({ status: "success" });
+			await Promise.resolve();
+		});
+		expect(result.current.busy).toBe(false);
+	});
 
-  it("disconnects every registered ResizeObserver on unmount", () => {
-    class TestResizeObserver {
-      static instances: TestResizeObserver[] = []
-      readonly disconnect = vi.fn()
-      readonly observe = vi.fn()
+	it("disconnects every registered ResizeObserver on unmount", () => {
+		class TestResizeObserver {
+			static instances: TestResizeObserver[] = [];
+			readonly disconnect = vi.fn();
+			readonly observe = vi.fn();
 
-      constructor() {
-        TestResizeObserver.instances.push(this)
-      }
-    }
-    vi.stubGlobal("ResizeObserver", TestResizeObserver)
+			constructor() {
+				TestResizeObserver.instances.push(this);
+			}
+		}
+		vi.stubGlobal("ResizeObserver", TestResizeObserver);
 
-    function Harness() {
-      const containerRef = useRef<HTMLDivElement>(null)
-      const { registerItem } = useProximityHover(containerRef)
-      return (
-        <div ref={containerRef} data-testid="container">
-          <div ref={(node) => registerItem(0, node)} />
-        </div>
-      )
-    }
+		function Harness() {
+			const containerRef = useRef<HTMLDivElement>(null);
+			const { registerItem } = useProximityHover(containerRef);
+			return (
+				<div ref={containerRef} data-testid="container">
+					<div ref={(node) => registerItem(0, node)} />
+				</div>
+			);
+		}
 
-    const { unmount } = render(<Harness />)
-    unmount()
+		const { unmount } = render(<Harness />);
+		unmount();
 
-    expect(TestResizeObserver.instances.length).toBeGreaterThan(0)
-    expect(
-      TestResizeObserver.instances.every((observer) => observer.disconnect.mock.calls.length > 0),
-    ).toBe(true)
-  })
+		expect(TestResizeObserver.instances.length).toBeGreaterThan(0);
+		expect(TestResizeObserver.instances.every((observer) => observer.disconnect.mock.calls.length > 0)).toBe(true);
+	});
 
-  it("closes the EventSource owned by the visible session on unmount", async () => {
-    class TestEventSource {
-      static instances: TestEventSource[] = []
-      readonly close = vi.fn()
-      onmessage: ((event: MessageEvent<string>) => void) | null = null
-      onerror: (() => void) | null = null
+	it("closes the EventSource owned by the visible session on unmount", async () => {
+		class TestEventSource {
+			static instances: TestEventSource[] = [];
+			readonly close = vi.fn();
+			onmessage: ((event: MessageEvent<string>) => void) | null = null;
+			onerror: (() => void) | null = null;
 
-      constructor(readonly url: string) {
-        TestEventSource.instances.push(this)
-      }
-    }
-    vi.stubGlobal("EventSource", TestEventSource)
+			constructor(readonly url: string) {
+				TestEventSource.instances.push(this);
+			}
+		}
+		vi.stubGlobal("EventSource", TestEventSource);
 
-    const metadata: ChatSessionMetadata = { sessionId: "session-1" }
-    const client = {
-      listSessions: vi.fn().mockResolvedValue([]),
-      loadSession: vi.fn().mockResolvedValue({ session: metadata, messages: [] }),
-    } as unknown as ChatClient
-    const persistSession = vi.fn()
+		const metadata: ChatSessionMetadata = { sessionId: "session-1" };
+		const client = {
+			listSessions: vi.fn().mockResolvedValue([]),
+			loadSession: vi.fn().mockResolvedValue({ session: metadata, messages: [] }),
+		} as unknown as ChatClient;
+		const persistSession = vi.fn();
 
-    const { unmount } = renderHook(() =>
-      usePiChat(undefined, {
-        client,
-        initialSessionMetadata: metadata,
-        persistSession,
-      }),
-    )
+		const { unmount } = renderHook(() =>
+			usePiChat(undefined, {
+				client,
+				initialSessionMetadata: metadata,
+				persistSession,
+			}),
+		);
 
-    await act(async () => {
-      await Promise.resolve()
-      await Promise.resolve()
-    })
+		await act(async () => {
+			await Promise.resolve();
+			await Promise.resolve();
+		});
 
-    expect(TestEventSource.instances.length).toBeGreaterThan(0)
-    unmount()
-    expect(
-      TestEventSource.instances.every((source) => source.close.mock.calls.length > 0),
-    ).toBe(true)
-  })
-})
+		expect(TestEventSource.instances.length).toBeGreaterThan(0);
+		unmount();
+		expect(TestEventSource.instances.every((source) => source.close.mock.calls.length > 0)).toBe(true);
+	});
+});

--- a/web/app/src/lib/pi/right-panels.test.tsx
+++ b/web/app/src/lib/pi/right-panels.test.tsx
@@ -1,46 +1,46 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { RightPanelProvider } from "@prime-agent/web-design/components/product/fleet-pi/layout/right-panel-context";
+import { RightPanelShell } from "@prime-agent/web-design/components/product/fleet-pi/layout/right-panel-shell";
+import { ArtifactsPanelContent } from "@prime-agent/web-design/components/product/fleet-pi/pi/artifacts-panel";
+import { ReplPanelContent } from "@prime-agent/web-design/components/product/fleet-pi/pi/repl-panel";
+import { RightPanelLauncher } from "@prime-agent/web-design/components/product/fleet-pi/pi/right-panel-launcher";
+import { SubagentsPanelContent } from "@prime-agent/web-design/components/product/fleet-pi/pi/subagents-panel";
 import type {
 	ChatSessionResponse,
 	PrimeAgentArtifactRun,
 	PrimeAgentRlmChild,
 	PrimeAgentSessionPresentation,
-} from "@prime-agent/web-protocol/chat-protocol"
-import type { ChatMessage } from "@prime-agent/web-protocol/chat-types"
-import { afterEach, describe, expect, it, vi } from "vitest"
-import { ArtifactsPanelContent } from "@prime-agent/web-design/components/product/fleet-pi/pi/artifacts-panel"
-import { RightPanelLauncher } from "@prime-agent/web-design/components/product/fleet-pi/pi/right-panel-launcher"
-import { ReplPanelContent } from "@prime-agent/web-design/components/product/fleet-pi/pi/repl-panel"
-import { SubagentsPanelContent } from "@prime-agent/web-design/components/product/fleet-pi/pi/subagents-panel"
-import { RightPanelShell } from "@prime-agent/web-design/components/product/fleet-pi/layout/right-panel-shell"
-import { RightPanelProvider } from "@prime-agent/web-design/components/product/fleet-pi/layout/right-panel-context"
-import { SubagentChatPanel } from "./subagent-chat-panel"
-import { useChatShellState } from "./use-chat-shell-state"
+} from "@prime-agent/web-protocol/chat-protocol";
+import type { ChatMessage } from "@prime-agent/web-protocol/chat-types";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SubagentChatPanel } from "./subagent-chat-panel";
+import { useChatShellState } from "./use-chat-shell-state";
 
 vi.mock("@prime-agent/web-design/components/product/fleet-pi/chat/generative-text-renderer", () => ({
 	FleetGenerativeTextRenderer: ({ content }: { content: string }) => <div>{content}</div>,
-}))
+}));
 vi.mock("@prime-agent/web-design/components/product/fleet-pi/chat/fleet-pi-tool-renderer", () => ({
-  FleetPiToolRenderer: () => null,
-}))
+	FleetPiToolRenderer: () => null,
+}));
 vi.mock("@prime-agent/web-design/components/openui/inline-renderer", () => ({
-  GenerativeTextRenderer: ({ content }: { content: string }) => <div>{content}</div>,
-}))
+	GenerativeTextRenderer: ({ content }: { content: string }) => <div>{content}</div>,
+}));
 
 const emptyPresentation: PrimeAgentSessionPresentation = {
 	revision: 0,
 	userBash: [],
 	rlmChildren: [],
 	refinements: [],
-  artifactRuns: [],
-}
+	artifactRuns: [],
+};
 
-let notifyResize: (() => void) | undefined
+let notifyResize: (() => void) | undefined;
 
 function ChatShellStateProbe() {
 	const { openArtifact, rightPanel, selectedArtifactId } = useChatShellState(undefined, {
 		sessionMetadata: {},
 		setSessionMetadata: vi.fn(),
-	})
+	});
 
 	return (
 		<div>
@@ -50,287 +50,300 @@ function ChatShellStateProbe() {
 			<span data-testid="probe-panel">{rightPanel ?? "closed"}</span>
 			<span data-testid="probe-selection">{selectedArtifactId ?? "none"}</span>
 		</div>
-	)
+	);
 }
 
-function mockLauncherLayout(availableWidth: number, requiredWidth: number) {
-  const observers = new Set<TestResizeObserver>()
+function mockLauncherLayout(availableWidth: number, requiredWidth: number, options?: { clipBoundingRect?: boolean }) {
+	const observers = new Set<TestResizeObserver>();
 
-  class TestResizeObserver {
-    readonly callback: ResizeObserverCallback
+	class TestResizeObserver {
+		readonly callback: ResizeObserverCallback;
 
-    constructor(callback: ResizeObserverCallback) {
-      this.callback = callback
-      observers.add(this)
-    }
+		constructor(callback: ResizeObserverCallback) {
+			this.callback = callback;
+			observers.add(this);
+		}
 
-    observe() {}
+		observe() {}
 
-    unobserve() {}
+		unobserve() {}
 
-    disconnect() {
-      observers.delete(this)
-    }
-  }
+		disconnect() {
+			observers.delete(this);
+		}
+	}
 
-  vi.stubGlobal("ResizeObserver", TestResizeObserver)
-  notifyResize = () => {
-    for (const observer of observers) observer.callback([], observer)
-  }
+	vi.stubGlobal("ResizeObserver", TestResizeObserver);
+	notifyResize = () => {
+		for (const observer of observers) observer.callback([], observer);
+	};
 
-  return (launcher: HTMLElement) => {
-    const measurement = launcher.querySelector<HTMLElement>("[data-panel-launcher-measurement]")
-    expect(measurement).not.toBeNull()
-    Object.defineProperty(launcher, "clientWidth", {
-      configurable: true,
-      value: availableWidth,
-    })
-    if (launcher.parentElement) {
-      Object.defineProperty(launcher.parentElement, "clientWidth", {
-        configurable: true,
-        value: availableWidth,
-      })
-    }
-    if (measurement) {
-      vi.spyOn(measurement, "getBoundingClientRect").mockReturnValue({
-        width: requiredWidth,
-      } as DOMRect)
-    }
-    act(() => notifyResize?.())
-  }
+	return (launcher: HTMLElement) => {
+		const measurement = launcher.querySelector<HTMLElement>("[data-panel-launcher-measurement]");
+		expect(measurement).not.toBeNull();
+		Object.defineProperty(launcher, "clientWidth", {
+			configurable: true,
+			value: availableWidth,
+		});
+		if (launcher.parentElement) {
+			Object.defineProperty(launcher.parentElement, "clientWidth", {
+				configurable: true,
+				value: availableWidth,
+			});
+		}
+		if (measurement) {
+			const reportedBoxWidth = options?.clipBoundingRect ? availableWidth : requiredWidth;
+			Object.defineProperty(measurement, "scrollWidth", {
+				configurable: true,
+				value: requiredWidth,
+			});
+			const inner = measurement.firstElementChild;
+			if (inner instanceof HTMLElement) {
+				Object.defineProperty(inner, "scrollWidth", {
+					configurable: true,
+					value: requiredWidth,
+				});
+				vi.spyOn(inner, "getBoundingClientRect").mockReturnValue({
+					width: reportedBoxWidth,
+				} as DOMRect);
+			}
+			vi.spyOn(measurement, "getBoundingClientRect").mockReturnValue({
+				width: reportedBoxWidth,
+			} as DOMRect);
+		}
+		act(() => notifyResize?.());
+	};
 }
 
 afterEach(() => {
-  notifyResize = undefined
-  vi.restoreAllMocks()
-  vi.unstubAllGlobals()
-})
+	notifyResize = undefined;
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+});
 
 describe("right-panel execution tabs", () => {
-  function renderPanelShell(matchesDesktop: boolean) {
-    vi.stubGlobal(
-      "matchMedia",
-      vi.fn((query: string) => ({
-        matches: matchesDesktop && query === "(min-width: 960px)",
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-      })),
-    )
+	function renderPanelShell(matchesDesktop: boolean) {
+		vi.stubGlobal(
+			"matchMedia",
+			vi.fn((query: string) => ({
+				matches: matchesDesktop && query === "(min-width: 960px)",
+				addEventListener: vi.fn(),
+				removeEventListener: vi.fn(),
+			})),
+		);
 
-    return render(
-      <RightPanelProvider
-        chatPanelData={
-          {
-            artifactRuns: [],
-            chatMode: "agent",
-            loadSession: vi.fn(),
-            loadSubagentSession: vi.fn(),
-            messages: [],
-            models: [],
-            presentation: emptyPresentation,
-            queue: { steering: [], followUp: [] },
-            refreshResources: vi.fn(),
-            resources: null,
-            resourcesError: null,
-            resourcesLoading: false,
-            reopenRightPanel: vi.fn(),
-            rightPanel: "resources",
-            selectedArtifactId: null,
-            sessionId: "session-1",
-            setRightPanel: vi.fn(),
-            status: "ready",
-          } as never
-        }
-        onOpenUIAction={vi.fn()}
-        settingsActions={{
-          onThemePreferenceChange: vi.fn(),
-          saveSettings: vi.fn(),
-          settings: null,
-          settingsError: null,
-          settingsLoading: false,
-          themePreference: "system",
-        }}
-        workspaceTree={{
-          loadWorkspaceFile: vi.fn(),
-          openWorkspacePath: vi.fn(),
-          refreshWorkspace: vi.fn(),
-          selectedWorkspacePath: null,
-          setSelectedWorkspacePath: vi.fn(),
-          workspaceError: null,
-          workspaceLoading: false,
-          workspaceTree: null,
-        }}
-      >
-        <RightPanelShell
-          handleResourceCanvasResizeStart={vi.fn()}
-          onClose={vi.fn()}
-          resourceCanvasWidth={400}
-        />
-      </RightPanelProvider>,
-    )
-  }
+		return render(
+			<RightPanelProvider
+				chatPanelData={
+					{
+						artifactRuns: [],
+						chatMode: "agent",
+						loadSession: vi.fn(),
+						loadSubagentSession: vi.fn(),
+						messages: [],
+						models: [],
+						presentation: emptyPresentation,
+						queue: { steering: [], followUp: [] },
+						refreshResources: vi.fn(),
+						resources: null,
+						resourcesError: null,
+						resourcesLoading: false,
+						reopenRightPanel: vi.fn(),
+						rightPanel: "resources",
+						selectedArtifactId: null,
+						sessionId: "session-1",
+						setRightPanel: vi.fn(),
+						status: "ready",
+					} as never
+				}
+				onOpenUIAction={vi.fn()}
+				settingsActions={{
+					onThemePreferenceChange: vi.fn(),
+					saveSettings: vi.fn(),
+					settings: null,
+					settingsError: null,
+					settingsLoading: false,
+					themePreference: "system",
+				}}
+				workspaceTree={{
+					loadWorkspaceFile: vi.fn(),
+					openWorkspacePath: vi.fn(),
+					refreshWorkspace: vi.fn(),
+					selectedWorkspacePath: null,
+					setSelectedWorkspacePath: vi.fn(),
+					workspaceError: null,
+					workspaceLoading: false,
+					workspaceTree: null,
+				}}
+			>
+				<RightPanelShell handleResourceCanvasResizeStart={vi.fn()} onClose={vi.fn()} resourceCanvasWidth={400} />
+			</RightPanelProvider>,
+		);
+	}
 
-  it("mounts only the desktop panel tree on desktop", () => {
-    const { getByTestId, queryByTestId } = renderPanelShell(true)
+	it("mounts only the desktop panel tree on desktop", () => {
+		const { getByTestId, queryByTestId } = renderPanelShell(true);
 
-    expect(getByTestId("pi-resources-canvas")).toBeTruthy()
-    expect(queryByTestId("pi-resources-mobile-panel")).toBeNull()
-  })
+		expect(getByTestId("pi-resources-canvas")).toBeTruthy();
+		expect(queryByTestId("pi-resources-mobile-panel")).toBeNull();
+	});
 
-  it("mounts only the mobile panel tree below the desktop breakpoint", () => {
-    const { getByTestId, queryByTestId } = renderPanelShell(false)
+	it("mounts only the mobile panel tree below the desktop breakpoint", () => {
+		const { getByTestId, queryByTestId } = renderPanelShell(false);
 
-    expect(getByTestId("pi-resources-mobile-panel")).toBeTruthy()
-    expect(queryByTestId("pi-resources-canvas")).toBeNull()
-  })
+		expect(getByTestId("pi-resources-mobile-panel")).toBeTruthy();
+		expect(queryByTestId("pi-resources-canvas")).toBeNull();
+	});
 
-  it("exposes launcher panels in fit-mode tabs without a redundant Subagents tab", () => {
-    const onPanelChange = vi.fn()
-    const layout = mockLauncherLayout(500, 400)
-    const { getByTestId, rerender } = render(
-      <RightPanelLauncher
-        activePanel={null}
-        onPanelChange={onPanelChange}
-        resources={null}
-        replRuns={2}
-        sessionBlocks={1}
-        openUIArtifacts={2}
-        workspace={null}
-      />,
-    )
-    layout(getByTestId("right-panel-inline-launcher"))
+	it("exposes launcher panels in fit-mode tabs without a redundant Subagents tab", () => {
+		const onPanelChange = vi.fn();
+		const layout = mockLauncherLayout(500, 400);
+		const { getByTestId, rerender } = render(
+			<RightPanelLauncher
+				activePanel={null}
+				onPanelChange={onPanelChange}
+				resources={null}
+				replRuns={2}
+				sessionBlocks={1}
+				openUIArtifacts={2}
+				workspace={null}
+			/>,
+		);
+		layout(getByTestId("right-panel-inline-launcher"));
 
-    expect(getByTestId("right-panel-inline-launcher").getAttribute("data-panel-launcher-mode")).toBe("tabs")
-    expect(screen.getAllByRole("tab")).toHaveLength(5)
+		expect(getByTestId("right-panel-inline-launcher").getAttribute("data-panel-launcher-mode")).toBe("tabs");
+		expect(screen.getAllByRole("tab")).toHaveLength(5);
 
-    const repl = screen.getByRole("tab", { name: "REPL runs" })
-    expect(repl).toBeTruthy()
-    expect(repl.textContent).toContain("2")
-    expect(screen.queryByRole("tab", { name: "Subagents" })).toBeNull()
-    expect(screen.getByRole("tab", { name: "Artifacts" }).textContent).toContain("3")
+		const repl = screen.getByRole("tab", { name: "REPL runs" });
+		expect(repl).toBeTruthy();
+		expect(repl.textContent).toContain("2");
+		expect(screen.queryByRole("tab", { name: "Subagents" })).toBeNull();
+		expect(screen.getByRole("tab", { name: "Artifacts" }).textContent).toContain("3");
 
-    fireEvent.click(repl)
-    expect(onPanelChange).toHaveBeenCalledWith("repl")
+		fireEvent.click(repl);
+		expect(onPanelChange).toHaveBeenCalledWith("repl");
 
-    rerender(
-      <RightPanelLauncher
-        activePanel="subagents"
-        onPanelChange={onPanelChange}
-        resources={null}
-        workspace={null}
-      />,
-    )
-    layout(getByTestId("right-panel-inline-launcher"))
-    expect(screen.queryByRole("tab", { name: "Subagents" })).toBeNull()
-  })
+		rerender(
+			<RightPanelLauncher activePanel="subagents" onPanelChange={onPanelChange} resources={null} workspace={null} />,
+		);
+		layout(getByTestId("right-panel-inline-launcher"));
+		expect(screen.queryByRole("tab", { name: "Subagents" })).toBeNull();
+	});
 
-  it("exposes launcher panels in overflow-mode dropdown without a redundant Subagents option", async () => {
-    const onPanelChange = vi.fn()
-    const layout = mockLauncherLayout(120, 400)
-    const { getByRole, getByTestId, rerender } = render(
-      <RightPanelLauncher
-        activePanel="subagents"
-        onPanelChange={onPanelChange}
-        resources={null}
-        workspace={null}
-      />,
-    )
-    layout(getByTestId("right-panel-inline-launcher"))
-    await waitFor(() =>
-      expect(getByTestId("right-panel-inline-launcher").getAttribute("data-panel-launcher-mode")).toBe("dropdown"),
-    )
+	it("exposes launcher panels in overflow-mode dropdown without a redundant Subagents option", async () => {
+		const onPanelChange = vi.fn();
+		const layout = mockLauncherLayout(120, 400);
+		const { getByRole, getByTestId, rerender } = render(
+			<RightPanelLauncher activePanel="subagents" onPanelChange={onPanelChange} resources={null} workspace={null} />,
+		);
+		layout(getByTestId("right-panel-inline-launcher"));
+		await waitFor(() =>
+			expect(getByTestId("right-panel-inline-launcher").getAttribute("data-panel-launcher-mode")).toBe("dropdown"),
+		);
 
-    const select = getByRole("combobox", { name: "Select panel" })
-    fireEvent.click(select)
-    const options = await screen.findAllByRole("option")
-    expect(options).toHaveLength(5)
-    expect(options.map((option) => option.textContent?.trim())).toEqual([
-      "Resources",
-      "Workspace",
-      "Artifacts",
-      "REPL",
-      "Session insights",
-    ])
+		const select = getByRole("combobox", { name: "Select panel" });
+		fireEvent.click(select);
+		const options = await screen.findAllByRole("option");
+		expect(options).toHaveLength(5);
+		expect(options.map((option) => option.textContent?.trim())).toEqual([
+			"Resources",
+			"Workspace",
+			"Artifacts",
+			"REPL",
+			"Session insights",
+		]);
 
-    const replOption = getByRole("option", { name: "REPL" })
-    fireEvent.pointerDown(replOption, { pointerType: "mouse" })
-    fireEvent.click(replOption)
-    expect(onPanelChange).toHaveBeenCalledWith("repl")
+		const replOption = getByRole("option", { name: "REPL" });
+		fireEvent.pointerDown(replOption, { pointerType: "mouse" });
+		fireEvent.click(replOption);
+		expect(onPanelChange).toHaveBeenCalledWith("repl");
 
-    rerender(
-      <RightPanelLauncher
-        activePanel="subagents"
-        onPanelChange={onPanelChange}
-        resources={null}
-        workspace={null}
-      />,
-    )
-    layout(getByTestId("right-panel-inline-launcher"))
-    fireEvent.click(getByRole("combobox", { name: "Select panel" }))
-    expect(screen.queryByRole("option", { name: "Subagents" })).toBeNull()
-  })
+		rerender(
+			<RightPanelLauncher activePanel="subagents" onPanelChange={onPanelChange} resources={null} workspace={null} />,
+		);
+		layout(getByTestId("right-panel-inline-launcher"));
+		fireEvent.click(getByRole("combobox", { name: "Select panel" }));
+		expect(screen.queryByRole("option", { name: "Subagents" })).toBeNull();
+	});
 
-  it("counts and renders OpenUI and technical artifacts with session UI blocks", () => {
-    const artifactRuns: Array<PrimeAgentArtifactRun> = [
-      {
-        id: "run-1",
-        runId: "run-1",
-        artifacts: [
-          {
-            id: "openui-1",
-            runId: "run-1",
-            kind: "openui-html",
-            title: "Generated dashboard",
-            status: "success",
-            output: { title: "Generated dashboard", document: "<div>Dashboard</div>" },
-            timestamp: 1,
-          },
-          {
-            id: "ipython-1",
-            runId: "run-1",
-            kind: "ipython",
-            title: "IPython",
-            status: "success",
-            input: { code: "print('hello')" },
-            output: { stdout: "hello" },
-            timestamp: 2,
-          },
-          {
-            id: "diff-1",
-            runId: "run-1",
-            kind: "diff",
-            title: "Edit",
-            status: "error",
-            output: { error: "permission denied" },
-            timestamp: 3,
-          },
-        ],
-      },
-    ]
-    const messages: Array<ChatMessage> = [
-      {
-        id: "assistant-ui",
-        role: "assistant",
-        parts: [{ type: "text", text: "```openui\nroot = Card\n```" }],
-      },
-    ]
+	it("switches to a dropdown when a narrow canvas header cannot fit badged tab labels", async () => {
+		const onPanelChange = vi.fn();
+		const layout = mockLauncherLayout(360, 520, { clipBoundingRect: true });
+		const { getByRole, getByTestId } = render(
+			<RightPanelLauncher
+				activePanel="session-insights"
+				onPanelChange={onPanelChange}
+				resources={null}
+				replRuns={7}
+				sessionBlocks={0}
+				openUIArtifacts={0}
+				workspace={null}
+			/>,
+		);
+		layout(getByTestId("right-panel-inline-launcher"));
 
-    render(
-      <ArtifactsPanelContent
-        artifactRuns={artifactRuns}
-        messages={messages}
-        status="ready"
-      />,
-    )
+		await waitFor(() =>
+			expect(getByTestId("right-panel-inline-launcher").getAttribute("data-panel-launcher-mode")).toBe("dropdown"),
+		);
+		expect(getByRole("combobox", { name: "Select panel" })).toBeTruthy();
+		expect(screen.queryByRole("tab", { name: "Session insights" })).toBeNull();
+	});
 
-    expect(screen.getByText("OpenUI artifacts")).toBeTruthy()
-    expect(screen.getByText("Generated dashboard")).toBeTruthy()
-    expect(screen.getByText("Generative UI")).toBeTruthy()
-    expect(screen.getByText("Card")).toBeTruthy()
-    expect(screen.getByText("Technical artifacts")).toBeTruthy()
-    expect(screen.queryByText("print('hello')")).toBeNull()
-    expect(screen.getByText("permission denied")).toBeTruthy()
-  })
+	it("counts and renders OpenUI and technical artifacts with session UI blocks", () => {
+		const artifactRuns: Array<PrimeAgentArtifactRun> = [
+			{
+				id: "run-1",
+				runId: "run-1",
+				artifacts: [
+					{
+						id: "openui-1",
+						runId: "run-1",
+						kind: "openui-html",
+						title: "Generated dashboard",
+						status: "success",
+						output: { title: "Generated dashboard", document: "<div>Dashboard</div>" },
+						timestamp: 1,
+					},
+					{
+						id: "ipython-1",
+						runId: "run-1",
+						kind: "ipython",
+						title: "IPython",
+						status: "success",
+						input: { code: "print('hello')" },
+						output: { stdout: "hello" },
+						timestamp: 2,
+					},
+					{
+						id: "diff-1",
+						runId: "run-1",
+						kind: "diff",
+						title: "Edit",
+						status: "error",
+						output: { error: "permission denied" },
+						timestamp: 3,
+					},
+				],
+			},
+		];
+		const messages: Array<ChatMessage> = [
+			{
+				id: "assistant-ui",
+				role: "assistant",
+				parts: [{ type: "text", text: "```openui\nroot = Card\n```" }],
+			},
+		];
+
+		render(<ArtifactsPanelContent artifactRuns={artifactRuns} messages={messages} status="ready" />);
+
+		expect(screen.getByText("OpenUI artifacts")).toBeTruthy();
+		expect(screen.getByText("Generated dashboard")).toBeTruthy();
+		expect(screen.getByText("Generative UI")).toBeTruthy();
+		expect(screen.getByText("Card")).toBeTruthy();
+		expect(screen.getByText("Technical artifacts")).toBeTruthy();
+		expect(screen.queryByText("print('hello')")).toBeNull();
+		expect(screen.getByText("permission denied")).toBeTruthy();
+	});
 
 	it("renders recorded IPython cells in the REPL panel", () => {
 		const artifactRuns: Array<PrimeAgentArtifactRun> = [
@@ -350,31 +363,31 @@ describe("right-panel execution tabs", () => {
 					},
 				],
 			},
-		]
+		];
 
-		render(<ReplPanelContent artifactRuns={artifactRuns} />)
+		render(<ReplPanelContent artifactRuns={artifactRuns} />);
 
-		expect(screen.getByTestId("repl-run-list")).toBeTruthy()
-		expect(screen.getByText("Cell 1")).toBeTruthy()
-		expect(screen.getByText("print('hello')")).toBeTruthy()
-		expect(screen.getByText("hello")).toBeTruthy()
-	})
+		expect(screen.getByTestId("repl-run-list")).toBeTruthy();
+		expect(screen.getByText("Cell 1")).toBeTruthy();
+		expect(screen.getByText("print('hello')")).toBeTruthy();
+		expect(screen.getByText("hello")).toBeTruthy();
+	});
 
 	it("shows kernel diagnostics in the REPL panel when present", () => {
 		const { rerender } = render(
 			<ReplPanelContent artifactRuns={[]} kernelDiagnostics={{ truncated: true, tail: "Traceback: boom" }} />,
-		)
+		);
 
-		expect(screen.getByText("Kernel diagnostics")).toBeTruthy()
-		expect(screen.getByText("Traceback: boom")).toBeTruthy()
+		expect(screen.getByText("Kernel diagnostics")).toBeTruthy();
+		expect(screen.getByText("Traceback: boom")).toBeTruthy();
 
-		rerender(<ReplPanelContent artifactRuns={[]} />)
-		expect(screen.queryByText("Kernel diagnostics")).toBeNull()
-	})
+		rerender(<ReplPanelContent artifactRuns={[]} />);
+		expect(screen.queryByText("Kernel diagnostics")).toBeNull();
+	});
 
 	it("sends subagent messages from the pinned composer and stops the turn", async () => {
-		const sendMessage = vi.fn(async () => undefined)
-		const stop = vi.fn()
+		const sendMessage = vi.fn(async () => undefined);
+		const stop = vi.fn();
 		const state = {
 			status: "ready" as const,
 			loading: false,
@@ -384,29 +397,23 @@ describe("right-panel execution tabs", () => {
 			sendMessage,
 			sending: false,
 			stop,
-		}
-		const child: PrimeAgentRlmChild = { id: "child-1", label: "Research worker", status: "done", timestamp: 1 }
+		};
+		const child: PrimeAgentRlmChild = { id: "child-1", label: "Research worker", status: "done", timestamp: 1 };
 
-		const { rerender } = render(
-			<SubagentChatPanel child={child} parentSessionId="parent-session" state={state} />,
-		)
+		const { rerender } = render(<SubagentChatPanel child={child} parentSessionId="parent-session" state={state} />);
 
-		const input = screen.getByLabelText("Message subagent")
-		expect(input).toBeTruthy()
-		fireEvent.change(input, { target: { value: "go deeper" } })
-		fireEvent.keyDown(input, { key: "Enter", shiftKey: false })
-		await waitFor(() => expect(sendMessage).toHaveBeenCalledWith("go deeper"))
+		const input = screen.getByLabelText("Message subagent");
+		expect(input).toBeTruthy();
+		fireEvent.change(input, { target: { value: "go deeper" } });
+		fireEvent.keyDown(input, { key: "Enter", shiftKey: false });
+		await waitFor(() => expect(sendMessage).toHaveBeenCalledWith("go deeper"));
 
 		rerender(
-			<SubagentChatPanel
-				child={child}
-				parentSessionId="parent-session"
-				state={{ ...state, sending: true }}
-			/>,
-		)
-		fireEvent.click(screen.getByLabelText("Stop generating"))
-		expect(stop).toHaveBeenCalledOnce()
-	})
+			<SubagentChatPanel child={child} parentSessionId="parent-session" state={{ ...state, sending: true }} />,
+		);
+		fireEvent.click(screen.getByLabelText("Stop generating"));
+		expect(stop).toHaveBeenCalledOnce();
+	});
 
 	it("focuses and scrolls to the selected REPL cell", async () => {
 		const artifactRuns: Array<PrimeAgentArtifactRun> = [
@@ -426,32 +433,32 @@ describe("right-panel execution tabs", () => {
 					},
 				],
 			},
-		]
-		const scrollIntoView = vi.fn()
+		];
+		const scrollIntoView = vi.fn();
 		Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
 			configurable: true,
 			value: scrollIntoView,
-		})
+		});
 
-		render(<ReplPanelContent artifactRuns={artifactRuns} selectedArtifactId="repl-1" />)
+		render(<ReplPanelContent artifactRuns={artifactRuns} selectedArtifactId="repl-1" />);
 
 		const selectedCell = await waitFor(() => {
-			const cell = document.querySelector<HTMLElement>('[data-repl-run-id="repl-1"]')
-			expect(document.activeElement).toBe(cell)
-			return cell
-		})
-		expect(selectedCell).not.toBeNull()
-		expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" })
-	})
+			const cell = document.querySelector<HTMLElement>('[data-repl-run-id="repl-1"]');
+			expect(document.activeElement).toBe(cell);
+			return cell;
+		});
+		expect(selectedCell).not.toBeNull();
+		expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+	});
 
 	it("preserves the selected cell when opening the REPL panel", () => {
-		render(<ChatShellStateProbe />)
+		render(<ChatShellStateProbe />);
 
-		fireEvent.click(screen.getByRole("button", { name: "Open REPL cell" }))
+		fireEvent.click(screen.getByRole("button", { name: "Open REPL cell" }));
 
-		expect(screen.getByTestId("probe-panel").textContent).toBe("repl")
-		expect(screen.getByTestId("probe-selection").textContent).toBe("repl-1")
-	})
+		expect(screen.getByTestId("probe-panel").textContent).toBe("repl");
+		expect(screen.getByTestId("probe-selection").textContent).toBe("repl-1");
+	});
 
 	it("loads and renders the selected subagent's own transcript", async () => {
 		const messages: Array<ChatMessage> = [
@@ -465,14 +472,14 @@ describe("right-panel execution tabs", () => {
 				role: "assistant",
 				parts: [{ type: "text", text: "Worker transcript loaded" }],
 			},
-		]
+		];
 		const response: ChatSessionResponse = {
 			session: { sessionId: "child-session" },
 			messages,
 			planPresentations: [],
 			presentation: emptyPresentation,
-		}
-		const loadSession = vi.fn(async () => response)
+		};
+		const loadSession = vi.fn(async () => response);
 
 		render(
 			<SubagentsPanelContent
@@ -487,25 +494,29 @@ describe("right-panel execution tabs", () => {
 				parentSessionId="parent-session"
 				loadSession={loadSession}
 			/>,
-		)
+		);
 
-		await waitFor(() => expect(loadSession).toHaveBeenCalledWith("parent-session", "child-1"))
-		expect(await screen.findByText("Worker transcript loaded")).toBeTruthy()
-		expect(screen.getByRole("region", { name: "Subagent thread: Research worker" })).toBeTruthy()
-	})
+		await waitFor(() => expect(loadSession).toHaveBeenCalledWith("parent-session", "child-1"));
+		expect(await screen.findByText("Worker transcript loaded")).toBeTruthy();
+		expect(screen.getByRole("region", { name: "Subagent thread: Research worker" })).toBeTruthy();
+	});
 
 	it("reloads the selected transcript when a child advances", async () => {
 		const loadSession = vi
 			.fn<() => Promise<ChatSessionResponse>>()
 			.mockResolvedValueOnce({
 				session: { sessionId: "child-session" },
-				messages: [{ id: "child-assistant-1", role: "assistant", parts: [{ type: "text", text: "Running snapshot" }] }],
+				messages: [
+					{ id: "child-assistant-1", role: "assistant", parts: [{ type: "text", text: "Running snapshot" }] },
+				],
 				planPresentations: [],
 				presentation: emptyPresentation,
 			})
 			.mockResolvedValueOnce({
 				session: { sessionId: "child-session" },
-				messages: [{ id: "child-assistant-2", role: "assistant", parts: [{ type: "text", text: "Completed snapshot" }] }],
+				messages: [
+					{ id: "child-assistant-2", role: "assistant", parts: [{ type: "text", text: "Completed snapshot" }] },
+				],
 				planPresentations: [],
 				presentation: emptyPresentation,
 			});
@@ -530,7 +541,7 @@ describe("right-panel execution tabs", () => {
 
 		await waitFor(() => expect(loadSession).toHaveBeenCalledTimes(2));
 		expect(await screen.findByText("Completed snapshot")).toBeTruthy();
-	})
+	});
 
 	it("retains error transcripts and renders a fallback error banner", async () => {
 		const child: PrimeAgentRlmChild = {
@@ -538,21 +549,27 @@ describe("right-panel execution tabs", () => {
 			label: "Research worker",
 			status: "failed",
 			timestamp: 1,
-		}
+		};
 		const state = {
 			status: "error" as const,
 			loading: false,
-			messages: [{ id: "child-assistant", role: "assistant" as const, parts: [{ type: "text" as const, text: "Last known answer" }] }],
+			messages: [
+				{
+					id: "child-assistant",
+					role: "assistant" as const,
+					parts: [{ type: "text" as const, text: "Last known answer" }],
+				},
+			],
 			presentation: emptyPresentation,
 			refresh: vi.fn(),
 			sendMessage: vi.fn(),
 			sending: false,
 			stop: vi.fn(),
-		}
+		};
 
-		render(<SubagentChatPanel child={child} parentSessionId="parent-session" state={state} />)
+		render(<SubagentChatPanel child={child} parentSessionId="parent-session" state={state} />);
 
-		expect(await screen.findByText("Last known answer")).toBeTruthy()
-		expect(screen.getByRole("alert").textContent).toContain("ended with an error")
-	})
-})
+		expect(await screen.findByText("Last known answer")).toBeTruthy();
+		expect(screen.getByRole("alert").textContent).toContain("ended with an error");
+	});
+});

--- a/web/app/src/lib/pi/session-sidebar.test.tsx
+++ b/web/app/src/lib/pi/session-sidebar.test.tsx
@@ -1,475 +1,489 @@
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
-import type {
-  ChatSessionInfo,
-  ProjectDirectoryBrowseResponse,
-  ProjectSummary,
-} from "@prime-agent/web-protocol"
-import { beforeEach, describe, expect, it, vi } from "vitest"
-import { FleetSessionSidebar } from "@prime-agent/web-design/components/product/fleet-pi/session-sidebar"
-import type { FleetSessionSidebarDependencies } from "@prime-agent/web-design/components/product/fleet-pi/session-sidebar/types"
-import { AnimatedSidebarProvider } from "@prime-agent/web-design/components/registry/beui/motion/animated-sidebar"
+import { FleetSessionSidebar } from "@prime-agent/web-design/components/product/fleet-pi/session-sidebar";
+import type { FleetSessionSidebarDependencies } from "@prime-agent/web-design/components/product/fleet-pi/session-sidebar/types";
+import { AnimatedSidebarProvider } from "@prime-agent/web-design/components/registry/beui/motion/animated-sidebar";
+import type { ChatSessionInfo, ProjectDirectoryBrowseResponse, ProjectSummary } from "@prime-agent/web-protocol";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 function SidebarHarness({
-  sessions,
-  projects,
-  projectSessions,
-  activeProjectId,
-  activeSessionId,
-  onNewSession,
-  onNewSessionInProject,
-  onResumeSession,
-  onRenameSession,
-  onDeleteSession,
-  onProjectSelect,
-  onCreateProject,
-  onRenameProject,
-  onUnregisterProject,
-  onForkSessionIntoProject,
-  onOpenPanelAction,
-  onBrowseDirectories,
-  onOpenSettings,
-  accountMenu,
+	sessions,
+	projects,
+	projectSessions,
+	activeProjectId,
+	activeSessionId,
+	onNewSession,
+	onNewSessionInProject,
+	onResumeSession,
+	onRenameSession,
+	onDeleteSession,
+	onProjectSelect,
+	onCreateProject,
+	onRenameProject,
+	onUnregisterProject,
+	onForkSessionIntoProject,
+	onOpenPanelAction,
+	onBrowseDirectories,
+	onOpenSettings,
+	accountMenu,
 }: FleetSessionSidebarDependencies) {
-  return (
-    <FleetSessionSidebar
-      data={{ sessions, projects, projectSessions, activeProjectId, activeSessionId }}
-      sessionActions={{
-        onNewSession,
-        onNewSessionInProject,
-        onResumeSession,
-        onRenameSession,
-        onDeleteSession,
-      }}
-      projectActions={{
-        onProjectSelect,
-        onCreateProject,
-        onRenameProject,
-        onUnregisterProject,
-        onForkSessionIntoProject,
-      }}
-      navigationActions={{ onOpenPanelAction, onBrowseDirectories, onOpenSettings }}
-      slots={{ accountMenu }}
-    />
-  )
+	return (
+		<FleetSessionSidebar
+			data={{ sessions, projects, projectSessions, activeProjectId, activeSessionId }}
+			sessionActions={{
+				onNewSession,
+				onNewSessionInProject,
+				onResumeSession,
+				onRenameSession,
+				onDeleteSession,
+			}}
+			projectActions={{
+				onProjectSelect,
+				onCreateProject,
+				onRenameProject,
+				onUnregisterProject,
+				onForkSessionIntoProject,
+			}}
+			navigationActions={{ onOpenPanelAction, onBrowseDirectories, onOpenSettings }}
+			slots={{ accountMenu }}
+		/>
+	);
 }
 
 function project(projectId: string): ProjectSummary {
-  return {
-    projectId,
-    name: projectId,
-    pathLabel: `/workspace/${projectId}`,
-    createdAt: "2026-01-01T00:00:00.000Z",
-    updatedAt: "2026-01-01T00:00:00.000Z",
-    sessionCount: 1,
-    status: "active",
-  }
+	return {
+		projectId,
+		name: projectId,
+		pathLabel: `/workspace/${projectId}`,
+		createdAt: "2026-01-01T00:00:00.000Z",
+		updatedAt: "2026-01-01T00:00:00.000Z",
+		sessionCount: 1,
+		status: "active",
+	};
 }
 
 function session(sessionId: string, projectId: string): ChatSessionInfo {
-  return {
-    sessionId,
-    projectId,
-    title: sessionId,
-    firstMessage: sessionId,
-    createdAt: "2026-01-01T00:00:00.000Z",
-    updatedAt: "2026-01-01T00:00:00.000Z",
-    status: "idle",
-    messageCount: 1,
-  }
+	return {
+		sessionId,
+		projectId,
+		title: sessionId,
+		firstMessage: sessionId,
+		createdAt: "2026-01-01T00:00:00.000Z",
+		updatedAt: "2026-01-01T00:00:00.000Z",
+		status: "idle",
+		messageCount: 1,
+	};
 }
 
 describe("FleetSessionSidebar project rows", () => {
-  beforeEach(() => {
-    window.localStorage.clear()
-  })
+	beforeEach(() => {
+		window.localStorage.clear();
+	});
 
-  it("toggles a project without selecting it or opening a session", () => {
-    const onNewSession = vi.fn()
-    const onNewSessionInProject = vi.fn()
-    const onProjectSelect = vi.fn()
-    const { getByRole } = render(
-      <AnimatedSidebarProvider>
-        <SidebarHarness
-          sessions={[]}
-          projects={[project("alpha"), project("beta")]}
-          projectSessions={[session("alpha-session", "alpha"), session("beta-session", "beta")]}
-          activeProjectId="alpha"
-          onNewSession={onNewSession}
-          onNewSessionInProject={onNewSessionInProject}
-          onResumeSession={vi.fn()}
-          onRenameSession={vi.fn()}
-          onDeleteSession={vi.fn()}
-          onProjectSelect={onProjectSelect}
-        />
-      </AnimatedSidebarProvider>,
-    )
+	it("toggles a project without selecting it or opening a session", () => {
+		const onNewSession = vi.fn();
+		const onNewSessionInProject = vi.fn();
+		const onProjectSelect = vi.fn();
+		const { getByRole } = render(
+			<AnimatedSidebarProvider>
+				<SidebarHarness
+					sessions={[]}
+					projects={[project("alpha"), project("beta")]}
+					projectSessions={[session("alpha-session", "alpha"), session("beta-session", "beta")]}
+					activeProjectId="alpha"
+					onNewSession={onNewSession}
+					onNewSessionInProject={onNewSessionInProject}
+					onResumeSession={vi.fn()}
+					onRenameSession={vi.fn()}
+					onDeleteSession={vi.fn()}
+					onProjectSelect={onProjectSelect}
+				/>
+			</AnimatedSidebarProvider>,
+		);
 
-    const beta = getByRole("treeitem", { name: /beta/i })
-    expect(beta.getAttribute("aria-expanded")).toBe("false")
+		const beta = getByRole("treeitem", { name: /beta/i });
+		expect(beta.getAttribute("aria-expanded")).toBe("false");
 
-    fireEvent.click(beta)
+		fireEvent.click(beta);
 
-    expect(beta.getAttribute("aria-expanded")).toBe("true")
-    expect(onNewSession.mock.calls.length).toBe(0)
-    expect(onNewSessionInProject.mock.calls.length).toBe(0)
-    expect(onProjectSelect.mock.calls.length).toBe(0)
-  })
+		expect(beta.getAttribute("aria-expanded")).toBe("true");
+		expect(onNewSession.mock.calls.length).toBe(0);
+		expect(onNewSessionInProject.mock.calls.length).toBe(0);
+		expect(onProjectSelect.mock.calls.length).toBe(0);
+	});
 
-  it("redacts credentials from session labels and accessible names", () => {
-    const exposedSecret = "sk-examplecredential123456789"
-    const sensitiveSession = session("sensitive-session", "alpha")
-    sensitiveSession.title = `Configure API key ${exposedSecret}`
-    sensitiveSession.firstMessage = sensitiveSession.title
+	it("redacts credentials from session labels and accessible names", () => {
+		const exposedSecret = "sk-examplecredential123456789";
+		const sensitiveSession = session("sensitive-session", "alpha");
+		sensitiveSession.title = `Configure API key ${exposedSecret}`;
+		sensitiveSession.firstMessage = sensitiveSession.title;
 
-    const { container, getByRole } = render(
-      <AnimatedSidebarProvider>
-        <SidebarHarness
-          sessions={[sensitiveSession]}
-          projects={[project("alpha")]}
-          projectSessions={[sensitiveSession]}
-          activeProjectId="alpha"
-          onNewSession={vi.fn()}
-          onResumeSession={vi.fn()}
-          onRenameSession={vi.fn()}
-          onDeleteSession={vi.fn()}
-        />
-      </AnimatedSidebarProvider>,
-    )
+		const { container, getByRole } = render(
+			<AnimatedSidebarProvider>
+				<SidebarHarness
+					sessions={[sensitiveSession]}
+					projects={[project("alpha")]}
+					projectSessions={[sensitiveSession]}
+					activeProjectId="alpha"
+					onNewSession={vi.fn()}
+					onResumeSession={vi.fn()}
+					onRenameSession={vi.fn()}
+					onDeleteSession={vi.fn()}
+				/>
+			</AnimatedSidebarProvider>,
+		);
 
-    expect(container.textContent).not.toContain(exposedSecret)
-    expect(container.innerHTML).not.toContain(exposedSecret)
-    expect(getByRole("treeitem", { name: /Configure API key \[redacted\]/i })).toBeTruthy()
-  })
+		expect(container.textContent).not.toContain(exposedSecret);
+		expect(container.innerHTML).not.toContain(exposedSecret);
+		expect(getByRole("treeitem", { name: /Configure API key \[redacted\]/i })).toBeTruthy();
+	});
 
-  it("indents subagent sessions without changing their selectable flat list", () => {
-    const root = session("root-session", "alpha")
-    const child = { ...session("child-session", "alpha"), isSubagent: true }
-    const { getByRole } = render(
-      <AnimatedSidebarProvider>
-        <SidebarHarness
-          sessions={[root, child]}
-          projects={[project("alpha")]}
-          projectSessions={[root, child]}
-          activeProjectId="alpha"
-          activeSessionId="root-session"
-          onNewSession={vi.fn()}
-          onResumeSession={vi.fn()}
-          onRenameSession={vi.fn()}
-          onDeleteSession={vi.fn()}
-        />
-      </AnimatedSidebarProvider>,
-    )
+	it("indents subagent sessions without changing their selectable flat list", () => {
+		const root = session("root-session", "alpha");
+		const child = { ...session("child-session", "alpha"), isSubagent: true };
+		const { getByRole } = render(
+			<AnimatedSidebarProvider>
+				<SidebarHarness
+					sessions={[root, child]}
+					projects={[project("alpha")]}
+					projectSessions={[root, child]}
+					activeProjectId="alpha"
+					activeSessionId="root-session"
+					onNewSession={vi.fn()}
+					onResumeSession={vi.fn()}
+					onRenameSession={vi.fn()}
+					onDeleteSession={vi.fn()}
+				/>
+			</AnimatedSidebarProvider>,
+		);
 
-    const rootRow = getByRole("treeitem", { name: /root-session/i })
-    const childRow = getByRole("treeitem", { name: /child-session/i })
-    expect(rootRow.style.paddingLeft).toBe("22px")
-    expect(childRow.style.paddingLeft).toBe("36px")
-    expect(childRow.getAttribute("aria-level")).toBe("2")
-  })
+		const rootRow = getByRole("treeitem", { name: /root-session/i });
+		const childRow = getByRole("treeitem", { name: /child-session/i });
+		expect(rootRow.style.paddingLeft).toBe("22px");
+		expect(childRow.style.paddingLeft).toBe("36px");
+		expect(childRow.getAttribute("aria-level")).toBe("2");
+	});
 
-  it("makes the selected directory and child paths explicit", async () => {
-    const root: ProjectDirectoryBrowseResponse = {
-      pathLabel: "~/workspace",
-      directoryToken: "root-token",
-      parentToken: null,
-      entries: [
-        {
-          directoryToken: "child-token",
-          name: "prime-agent",
-          pathLabel: "~/workspace/prime-agent",
-          hasChildren: true,
-        },
-      ],
-    }
-    const child: ProjectDirectoryBrowseResponse = {
-      pathLabel: "~/workspace/prime-agent",
-      directoryToken: "child-token",
-      parentToken: "root-token",
-      entries: [],
-    }
-    const browseDirectories = vi.fn(async (input: { token?: string }) =>
-      input.token ? child : root,
-    )
+	it("makes the selected directory and child paths explicit", async () => {
+		const root: ProjectDirectoryBrowseResponse = {
+			pathLabel: "~/workspace",
+			directoryToken: "root-token",
+			parentToken: null,
+			entries: [
+				{
+					directoryToken: "child-token",
+					name: "prime-agent",
+					pathLabel: "~/workspace/prime-agent",
+					hasChildren: true,
+				},
+			],
+		};
+		const child: ProjectDirectoryBrowseResponse = {
+			pathLabel: "~/workspace/prime-agent",
+			directoryToken: "child-token",
+			parentToken: "root-token",
+			entries: [],
+		};
+		const browseDirectories = vi.fn(async (input: { token?: string }) => (input.token ? child : root));
 
-    const { getByRole, getByText } = render(
-      <AnimatedSidebarProvider>
-        <SidebarHarness
-          sessions={[]}
-          projects={[project("alpha")]}
-          projectSessions={[]}
-          activeProjectId="alpha"
-          onNewSession={vi.fn()}
-          onResumeSession={vi.fn()}
-          onRenameSession={vi.fn()}
-          onDeleteSession={vi.fn()}
-          onCreateProject={vi.fn()}
-          onBrowseDirectories={browseDirectories}
-        />
-      </AnimatedSidebarProvider>,
-    )
+		const { getByRole, getByText } = render(
+			<AnimatedSidebarProvider>
+				<SidebarHarness
+					sessions={[]}
+					projects={[project("alpha")]}
+					projectSessions={[]}
+					activeProjectId="alpha"
+					onNewSession={vi.fn()}
+					onResumeSession={vi.fn()}
+					onRenameSession={vi.fn()}
+					onDeleteSession={vi.fn()}
+					onCreateProject={vi.fn()}
+					onBrowseDirectories={browseDirectories}
+				/>
+			</AnimatedSidebarProvider>,
+		);
 
-    fireEvent.click(getByRole("button", { name: /^Add project$/ }))
-    await waitFor(() => expect(browseDirectories).toHaveBeenCalledWith({}))
-    expect(getByText("Selected directory")).toBeTruthy()
-    expect(getByText("~/workspace", { exact: true })).toBeTruthy()
+		fireEvent.click(getByRole("button", { name: /^Add project$/ }));
+		await waitFor(() => expect(browseDirectories).toHaveBeenCalledWith({}));
+		expect(getByText("Selected directory")).toBeTruthy();
+		expect(getByText("~/workspace", { exact: true })).toBeTruthy();
 
-    fireEvent.click(getByRole("combobox", { name: "Search child directories" }))
-    fireEvent.click(getByRole("option", { name: /prime-agent/ }))
-    await waitFor(() =>
-      expect(browseDirectories).toHaveBeenLastCalledWith({ token: "child-token" }),
-    )
-    expect(getByText("~/workspace/prime-agent", { exact: true })).toBeTruthy()
-  })
+		fireEvent.click(getByRole("combobox", { name: "Search child directories" }));
+		fireEvent.click(getByRole("option", { name: /prime-agent/ }));
+		await waitFor(() => expect(browseDirectories).toHaveBeenLastCalledWith({ token: "child-token" }));
+		expect(getByText("~/workspace/prime-agent", { exact: true })).toBeTruthy();
+	});
 
-  it("keeps browse failures visible and offers a retry", async () => {
-    const browseDirectories = vi
-      .fn()
-      .mockRejectedValue(new Error("Directory service unavailable"))
+	it("keeps browse failures visible and offers a retry", async () => {
+		const browseDirectories = vi.fn().mockRejectedValue(new Error("Directory service unavailable"));
 
-    const { getByRole, getByText } = render(
-      <AnimatedSidebarProvider>
-        <SidebarHarness
-          sessions={[]}
-          projects={[project("alpha")]}
-          projectSessions={[]}
-          activeProjectId="alpha"
-          onNewSession={vi.fn()}
-          onResumeSession={vi.fn()}
-          onRenameSession={vi.fn()}
-          onDeleteSession={vi.fn()}
-          onCreateProject={vi.fn()}
-          onBrowseDirectories={browseDirectories}
-        />
-      </AnimatedSidebarProvider>,
-    )
+		const { getByRole, getByText } = render(
+			<AnimatedSidebarProvider>
+				<SidebarHarness
+					sessions={[]}
+					projects={[project("alpha")]}
+					projectSessions={[]}
+					activeProjectId="alpha"
+					onNewSession={vi.fn()}
+					onResumeSession={vi.fn()}
+					onRenameSession={vi.fn()}
+					onDeleteSession={vi.fn()}
+					onCreateProject={vi.fn()}
+					onBrowseDirectories={browseDirectories}
+				/>
+			</AnimatedSidebarProvider>,
+		);
 
-    fireEvent.click(getByRole("button", { name: /^Add project$/ }))
-    await waitFor(() => expect(getByText("Directory service unavailable")).toBeTruthy())
-    expect(getByRole("button", { name: "Try again" })).toBeTruthy()
+		fireEvent.click(getByRole("button", { name: /^Add project$/ }));
+		await waitFor(() => expect(getByText("Directory service unavailable")).toBeTruthy());
+		expect(getByRole("button", { name: "Try again" })).toBeTruthy();
 
-    fireEvent.click(getByRole("button", { name: "Try again" }))
-    await waitFor(() => expect(browseDirectories).toHaveBeenCalledTimes(2))
-  })
+		fireEvent.click(getByRole("button", { name: "Try again" }));
+		await waitFor(() => expect(browseDirectories).toHaveBeenCalledTimes(2));
+	});
 
-  it("keeps the dialog open when project registration fails", async () => {
-    const createProject = vi
-      .fn()
-      .mockRejectedValue(new Error("Project is already registered"))
+	it("keeps the dialog open when project registration fails", async () => {
+		const createProject = vi.fn().mockRejectedValue(new Error("Project is already registered"));
 
-    const { getByRole, getByText } = render(
-      <AnimatedSidebarProvider>
-        <SidebarHarness
-          sessions={[]}
-          projects={[project("alpha")]}
-          projectSessions={[]}
-          activeProjectId="alpha"
-          onNewSession={vi.fn()}
-          onResumeSession={vi.fn()}
-          onRenameSession={vi.fn()}
-          onDeleteSession={vi.fn()}
-          onCreateProject={createProject}
-        />
-      </AnimatedSidebarProvider>,
-    )
+		const { getByRole, getByText } = render(
+			<AnimatedSidebarProvider>
+				<SidebarHarness
+					sessions={[]}
+					projects={[project("alpha")]}
+					projectSessions={[]}
+					activeProjectId="alpha"
+					onNewSession={vi.fn()}
+					onResumeSession={vi.fn()}
+					onRenameSession={vi.fn()}
+					onDeleteSession={vi.fn()}
+					onCreateProject={createProject}
+				/>
+			</AnimatedSidebarProvider>,
+		);
 
-    fireEvent.click(getByRole("button", { name: /^Add project$/ }))
-    fireEvent.change(getByRole("textbox", { name: "Project directory" }), {
-      target: { value: "/workspace/alpha" },
-    })
-    const dialog = getByRole("dialog", { name: "Add project" })
-    fireEvent.click(within(dialog).getByRole("button", { name: /^Add project$/ }))
+		fireEvent.click(getByRole("button", { name: /^Add project$/ }));
+		fireEvent.change(getByRole("textbox", { name: "Project directory" }), {
+			target: { value: "/workspace/alpha" },
+		});
+		const dialog = getByRole("dialog", { name: "Add project" });
+		fireEvent.click(within(dialog).getByRole("button", { name: /^Add project$/ }));
 
-    await waitFor(() => expect(getByText("Project is already registered")).toBeTruthy())
-    expect(getByRole("dialog", { name: "Add project" })).toBeTruthy()
-    expect(createProject).toHaveBeenCalledTimes(1)
-  })
-})
+		await waitFor(() => expect(getByText("Project is already registered")).toBeTruthy());
+		expect(getByRole("dialog", { name: "Add project" })).toBeTruthy();
+		expect(createProject).toHaveBeenCalledTimes(1);
+	});
+});
 
 describe("FleetSessionSidebar empty projects", () => {
-  beforeEach(() => {
-    window.localStorage.clear()
-  })
+	beforeEach(() => {
+		window.localStorage.clear();
+	});
 
-  it("offers a Start first chat action for projects without sessions", () => {
-    const onNewSessionInProject = vi.fn()
-    const { getByRole } = render(
-      <AnimatedSidebarProvider>
-        <SidebarHarness
-          sessions={[]}
-          projects={[project("alpha")]}
-          projectSessions={[]}
-          activeProjectId="alpha"
-          onNewSession={vi.fn()}
-          onNewSessionInProject={onNewSessionInProject}
-          onResumeSession={vi.fn()}
-          onRenameSession={vi.fn()}
-          onDeleteSession={vi.fn()}
-        />
-      </AnimatedSidebarProvider>,
-    )
+	it("offers a Start first chat action for projects without sessions", () => {
+		const onNewSessionInProject = vi.fn();
+		const { getByRole } = render(
+			<AnimatedSidebarProvider>
+				<SidebarHarness
+					sessions={[]}
+					projects={[project("alpha")]}
+					projectSessions={[]}
+					activeProjectId="alpha"
+					onNewSession={vi.fn()}
+					onNewSessionInProject={onNewSessionInProject}
+					onResumeSession={vi.fn()}
+					onRenameSession={vi.fn()}
+					onDeleteSession={vi.fn()}
+				/>
+			</AnimatedSidebarProvider>,
+		);
 
-    fireEvent.click(getByRole("treeitem", { name: "Start first chat" }))
-    expect(onNewSessionInProject).toHaveBeenCalledWith("alpha")
-  })
+		fireEvent.click(getByRole("treeitem", { name: "Start first chat" }));
+		expect(onNewSessionInProject).toHaveBeenCalledWith("alpha");
+	});
 
-  it("falls back to selecting the project and opening a new session without onNewSessionInProject", () => {
-    const onNewSession = vi.fn()
-    const onProjectSelect = vi.fn()
-    const { getByRole } = render(
-      <AnimatedSidebarProvider>
-        <SidebarHarness
-          sessions={[]}
-          projects={[project("alpha")]}
-          projectSessions={[]}
-          activeProjectId="alpha"
-          onNewSession={onNewSession}
-          onProjectSelect={onProjectSelect}
-          onResumeSession={vi.fn()}
-          onRenameSession={vi.fn()}
-          onDeleteSession={vi.fn()}
-        />
-      </AnimatedSidebarProvider>,
-    )
+	it("falls back to selecting the project and opening a new session without onNewSessionInProject", () => {
+		const onNewSession = vi.fn();
+		const onProjectSelect = vi.fn();
+		const { getByRole } = render(
+			<AnimatedSidebarProvider>
+				<SidebarHarness
+					sessions={[]}
+					projects={[project("alpha")]}
+					projectSessions={[]}
+					activeProjectId="alpha"
+					onNewSession={onNewSession}
+					onProjectSelect={onProjectSelect}
+					onResumeSession={vi.fn()}
+					onRenameSession={vi.fn()}
+					onDeleteSession={vi.fn()}
+				/>
+			</AnimatedSidebarProvider>,
+		);
 
-    fireEvent.click(getByRole("treeitem", { name: "Start first chat" }))
-    expect(onProjectSelect).toHaveBeenCalledWith("alpha")
-    expect(onNewSession).toHaveBeenCalledTimes(1)
-  })
-})
+		fireEvent.click(getByRole("treeitem", { name: "Start first chat" }));
+		expect(onProjectSelect).toHaveBeenCalledWith("alpha");
+		expect(onNewSession).toHaveBeenCalledTimes(1);
+	});
+});
 
 describe("FleetSessionSidebar fork dialog", () => {
-  beforeEach(() => {
-    window.localStorage.clear()
-  })
+	beforeEach(() => {
+		window.localStorage.clear();
+	});
 
-  it("uses a design-system select and forks into another project", async () => {
-    const onForkSessionIntoProject = vi.fn()
-    render(
-      <AnimatedSidebarProvider>
-        <SidebarHarness
-          sessions={[]}
-          projects={[project("alpha"), project("beta")]}
-          projectSessions={[session("s1", "alpha")]}
-          activeProjectId="alpha"
-          onNewSession={vi.fn()}
-          onResumeSession={vi.fn()}
-          onRenameSession={vi.fn()}
-          onDeleteSession={vi.fn()}
-          onForkSessionIntoProject={onForkSessionIntoProject}
-        />
-      </AnimatedSidebarProvider>,
-    )
+	it("uses a design-system select and forks into another project", async () => {
+		const onForkSessionIntoProject = vi.fn();
+		render(
+			<AnimatedSidebarProvider>
+				<SidebarHarness
+					sessions={[]}
+					projects={[project("alpha"), project("beta")]}
+					projectSessions={[session("s1", "alpha")]}
+					activeProjectId="alpha"
+					onNewSession={vi.fn()}
+					onResumeSession={vi.fn()}
+					onRenameSession={vi.fn()}
+					onDeleteSession={vi.fn()}
+					onForkSessionIntoProject={onForkSessionIntoProject}
+				/>
+			</AnimatedSidebarProvider>,
+		);
 
-    fireEvent.click(screen.getByRole("button", { name: "Actions for s1" }))
-    fireEvent.click(await screen.findByText("Fork into project"))
+		fireEvent.click(screen.getByRole("button", { name: "Actions for s1" }));
+		fireEvent.click(await screen.findByText("Fork into project"));
 
-    const dialog = await screen.findByRole("dialog", { name: "Fork session into project" })
-    // The fork target picker is the design-system Select, not a native element.
-    expect(dialog.querySelector("select")).toBeNull()
-    const targetPicker = within(dialog).getByRole("combobox", { name: "Target project" })
-    expect(targetPicker.textContent).toContain("beta — /workspace/beta")
+		const dialog = await screen.findByRole("dialog", { name: "Fork session into project" });
+		// The fork target picker is the design-system Select, not a native element.
+		expect(dialog.querySelector("select")).toBeNull();
+		const targetPicker = within(dialog).getByRole("combobox", { name: "Target project" });
+		expect(targetPicker.textContent).toContain("beta — /workspace/beta");
 
-    fireEvent.click(within(dialog).getByRole("button", { name: "Fork session" }))
-    expect(onForkSessionIntoProject).toHaveBeenCalledWith("s1", "beta")
-    await waitFor(() =>
-      expect(screen.queryByRole("dialog", { name: "Fork session into project" })).toBeNull(),
-    )
-  })
-})
+		fireEvent.click(within(dialog).getByRole("button", { name: "Fork session" }));
+		expect(onForkSessionIntoProject).toHaveBeenCalledWith("s1", "beta");
+		await waitFor(() => expect(screen.queryByRole("dialog", { name: "Fork session into project" })).toBeNull());
+	});
+});
 
 describe("FleetSessionSidebar draft sessions", () => {
-  beforeEach(() => {
-    window.localStorage.clear()
-  })
+	beforeEach(() => {
+		window.localStorage.clear();
+	});
 
-  function draftSession(sessionId: string, projectId: string): ChatSessionInfo {
-    return {
-      ...session(sessionId, projectId),
-      title: "(no messages)",
-      firstMessage: "",
-      messageCount: 0,
-    }
-  }
+	function draftSession(sessionId: string, projectId: string): ChatSessionInfo {
+		return {
+			...session(sessionId, projectId),
+			title: "(no messages)",
+			firstMessage: "",
+			messageCount: 0,
+		};
+	}
 
-  it("hides message-less sessions from the project tree", () => {
-    const { queryByRole, getByRole } = render(
-      <AnimatedSidebarProvider>
-        <SidebarHarness
-          sessions={[session("messaged-chat", "alpha"), draftSession("draft-chat", "alpha")]}
-          projects={[project("alpha")]}
-          projectSessions={[session("messaged-chat", "alpha"), draftSession("draft-chat", "alpha")]}
-          activeProjectId="alpha"
-          onNewSession={vi.fn()}
-          onResumeSession={vi.fn()}
-          onRenameSession={vi.fn()}
-          onDeleteSession={vi.fn()}
-        />
-      </AnimatedSidebarProvider>,
-    )
+	it("hides message-less sessions from the project tree", () => {
+		const { queryByRole, getByRole } = render(
+			<AnimatedSidebarProvider>
+				<SidebarHarness
+					sessions={[session("messaged-chat", "alpha"), draftSession("draft-chat", "alpha")]}
+					projects={[project("alpha")]}
+					projectSessions={[session("messaged-chat", "alpha"), draftSession("draft-chat", "alpha")]}
+					activeProjectId="alpha"
+					onNewSession={vi.fn()}
+					onResumeSession={vi.fn()}
+					onRenameSession={vi.fn()}
+					onDeleteSession={vi.fn()}
+				/>
+			</AnimatedSidebarProvider>,
+		);
 
-    expect(queryByRole("treeitem", { name: /draft-chat/i })).toBeNull()
-    expect(getByRole("treeitem", { name: /messaged-chat/i })).toBeTruthy()
-  })
+		expect(queryByRole("treeitem", { name: /draft-chat/i })).toBeNull();
+		expect(getByRole("treeitem", { name: /messaged-chat/i })).toBeTruthy();
+	});
 
-  it("keeps the active message-less session visible while composing", () => {
-    const { getByRole, queryByRole } = render(
-      <AnimatedSidebarProvider>
-        <SidebarHarness
-          sessions={[draftSession("draft-chat", "alpha")]}
-          projects={[project("alpha")]}
-          projectSessions={[draftSession("draft-chat", "alpha")]}
-          activeProjectId="alpha"
-          activeSessionId="draft-chat"
-          onNewSession={vi.fn()}
-          onResumeSession={vi.fn()}
-          onRenameSession={vi.fn()}
-          onDeleteSession={vi.fn()}
-        />
-      </AnimatedSidebarProvider>,
-    )
+	it("keeps the active message-less session visible while composing", () => {
+		const { getByRole, queryByRole } = render(
+			<AnimatedSidebarProvider>
+				<SidebarHarness
+					sessions={[draftSession("draft-chat", "alpha")]}
+					projects={[project("alpha")]}
+					projectSessions={[draftSession("draft-chat", "alpha")]}
+					activeProjectId="alpha"
+					activeSessionId="draft-chat"
+					onNewSession={vi.fn()}
+					onResumeSession={vi.fn()}
+					onRenameSession={vi.fn()}
+					onDeleteSession={vi.fn()}
+				/>
+			</AnimatedSidebarProvider>,
+		);
 
-    expect(getByRole("treeitem", { name: /draft-ch/i })).toBeTruthy()
-    expect(queryByRole("treeitem", { name: /\(no messages\)/i })).toBeNull()
-  })
+		expect(getByRole("treeitem", { name: /draft-ch/i })).toBeTruthy();
+		expect(queryByRole("treeitem", { name: /\(no messages\)/i })).toBeNull();
+	});
 
-  it("offers Start first chat when a project only has message-less sessions", () => {
-    const { getByRole } = render(
-      <AnimatedSidebarProvider>
-        <SidebarHarness
-          sessions={[draftSession("draft-chat", "alpha")]}
-          projects={[project("alpha")]}
-          projectSessions={[draftSession("draft-chat", "alpha")]}
-          activeProjectId="alpha"
-          onNewSession={vi.fn()}
-          onResumeSession={vi.fn()}
-          onRenameSession={vi.fn()}
-          onDeleteSession={vi.fn()}
-        />
-      </AnimatedSidebarProvider>,
-    )
+	it("offers Start first chat when a project only has message-less sessions", () => {
+		const { getByRole } = render(
+			<AnimatedSidebarProvider>
+				<SidebarHarness
+					sessions={[draftSession("draft-chat", "alpha")]}
+					projects={[project("alpha")]}
+					projectSessions={[draftSession("draft-chat", "alpha")]}
+					activeProjectId="alpha"
+					onNewSession={vi.fn()}
+					onResumeSession={vi.fn()}
+					onRenameSession={vi.fn()}
+					onDeleteSession={vi.fn()}
+				/>
+			</AnimatedSidebarProvider>,
+		);
 
-    expect(getByRole("treeitem", { name: "Start first chat" })).toBeTruthy()
-  })
+		expect(getByRole("treeitem", { name: "Start first chat" })).toBeTruthy();
+	});
 
-  it("distinguishes duplicate session titles with a short id suffix", () => {
-    const first = { ...session("refine-aaaa", "alpha"), title: "Tighten the plan", firstMessage: "Tighten the plan" }
-    const second = { ...session("refine-bbbb", "alpha"), title: "Tighten the plan", firstMessage: "Tighten the plan" }
-    const { getByRole } = render(
-      <AnimatedSidebarProvider>
-        <SidebarHarness
-          sessions={[first, second]}
-          projects={[project("alpha")]}
-          projectSessions={[first, second]}
-          activeProjectId="alpha"
-          onNewSession={vi.fn()}
-          onResumeSession={vi.fn()}
-          onRenameSession={vi.fn()}
-          onDeleteSession={vi.fn()}
-        />
-      </AnimatedSidebarProvider>,
-    )
+	it("distinguishes duplicate session titles with a short id suffix", () => {
+		const first = { ...session("refine-aaaa", "alpha"), title: "Tighten the plan", firstMessage: "Tighten the plan" };
+		const second = {
+			...session("refine-bbbb", "alpha"),
+			title: "Tighten the plan",
+			firstMessage: "Tighten the plan",
+		};
+		const { getByRole } = render(
+			<AnimatedSidebarProvider>
+				<SidebarHarness
+					sessions={[first, second]}
+					projects={[project("alpha")]}
+					projectSessions={[first, second]}
+					activeProjectId="alpha"
+					onNewSession={vi.fn()}
+					onResumeSession={vi.fn()}
+					onRenameSession={vi.fn()}
+					onDeleteSession={vi.fn()}
+				/>
+			</AnimatedSidebarProvider>,
+		);
 
-    expect(getByRole("treeitem", { name: /Tighten the plan · aaaa/i })).toBeTruthy()
-    expect(getByRole("treeitem", { name: /Tighten the plan · bbbb/i })).toBeTruthy()
-  })
-})
+		expect(getByRole("treeitem", { name: /Tighten the plan · aaaa/i })).toBeTruthy();
+		expect(getByRole("treeitem", { name: /Tighten the plan · bbbb/i })).toBeTruthy();
+	});
+
+	it("opens search on an opaque elevated surface", () => {
+		const { getByRole } = render(
+			<AnimatedSidebarProvider>
+				<SidebarHarness
+					sessions={[session("alpha-session", "alpha")]}
+					projects={[project("alpha")]}
+					projectSessions={[session("alpha-session", "alpha")]}
+					activeProjectId="alpha"
+					onNewSession={vi.fn()}
+					onResumeSession={vi.fn()}
+					onRenameSession={vi.fn()}
+					onDeleteSession={vi.fn()}
+				/>
+			</AnimatedSidebarProvider>,
+		);
+
+		fireEvent.click(getByRole("button", { name: "Search projects and sessions" }));
+		const popup = document.querySelector("[data-slot='popover-content']");
+		const search = document.querySelector("[data-slot='thread-search']");
+		expect(popup).not.toBeNull();
+		expect(popup?.className).toContain("bg-popover");
+		expect(search?.className).not.toContain("bg-transparent");
+	});
+});

--- a/web/app/src/lib/pi/use-chat-workspace-data.ts
+++ b/web/app/src/lib/pi/use-chat-workspace-data.ts
@@ -547,7 +547,7 @@ export function useChatWorkspaceData() {
 		[modelCatalogData, models],
 	);
 	const loadProjectWorkspaceFile = useCallback(
-		(path: string) => loadWorkspaceFile(path, activeProjectId),
+		(path: string, signal?: AbortSignal) => loadWorkspaceFile(path, activeProjectId, signal),
 		[activeProjectId],
 	);
 	const loadChatSession = useCallback(

--- a/web/app/src/lib/pi/use-chat-workspace-data.ts
+++ b/web/app/src/lib/pi/use-chat-workspace-data.ts
@@ -49,7 +49,7 @@ import { useResourceInstallRefresh } from "@/lib/pi/use-resource-install-refresh
 import { useRightPanelContextValue } from "@/lib/pi/use-right-panel-context-value";
 import { buildWorkspaceReferenceSuggestions, workspacePathFromSuggestion } from "@/lib/pi/workspace-suggestions";
 import { loadWorkspaceFile } from "@/lib/workspace-file";
-import { notifyChatError } from "./chat-error-notify";
+import { notifyChatError, runWorkspaceAction } from "./chat-error-notify";
 import {
 	shouldClearPendingAttachments,
 	shouldClearPendingAttachmentsForNewSession,
@@ -630,7 +630,7 @@ export function useChatWorkspaceData() {
 		activeTabId: agentTabs.activeTabId,
 		tabs: agentTabs.tabs,
 		onCloseTab: agentTabs.closeTab,
-		onNewSession: () => void startNewSessionForWorkspace(),
+		onNewSession: () => runWorkspaceAction(() => startNewSessionForWorkspace()),
 		onSelectTab: agentTabs.selectTab,
 		onOpenSettings: () => openSettings(),
 	});

--- a/web/app/src/lib/pi/use-local-slash-actions.ts
+++ b/web/app/src/lib/pi/use-local-slash-actions.ts
@@ -11,6 +11,7 @@ import type { ChatMessage } from "@prime-agent/web-protocol/chat-types";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { chatClient } from "./chat-client";
+import { runWorkspaceAction } from "./chat-error-notify";
 import { assistantTextFromMessage } from "./chat-message-helpers";
 import { chatQueryKeys } from "./chat-queries";
 import type { LocalSlashAction, SettingsSlashTab } from "./slash-commands";
@@ -35,7 +36,7 @@ type UseLocalSlashActionsArgs = {
 	setModelKey: (key: string | undefined) => void;
 	setModelPickerOpen: (open: boolean) => void;
 	setThinkingLevel: (level: ChatThinkingLevel) => void;
-	startNewSession: () => void;
+	startNewSession: () => Promise<unknown>;
 };
 
 const MCP_USAGE = "MCP usage: /mcp, /mcp list, /mcp login <name>, /mcp logout <name>.";
@@ -279,7 +280,7 @@ export function useLocalSlashActions({
 					openSettings(action.tab);
 					return true;
 				case "new-session":
-					void startNewSession();
+					runWorkspaceAction(async () => startNewSession());
 					return true;
 				case "openui-request":
 					if (!action.request) {

--- a/web/app/src/lib/pi/use-right-panel-context-value.ts
+++ b/web/app/src/lib/pi/use-right-panel-context-value.ts
@@ -46,7 +46,7 @@ type UseRightPanelContextValueArgs = {
 	isUpdatingProvider?: boolean;
 	loadSession: (metadata: ChatSessionMetadata) => Promise<ChatSessionResponse>;
 	loadSubagentSession: (parentSessionId: string, childId: string) => Promise<ChatSessionResponse>;
-	loadWorkspaceFile: (path: string) => Promise<WorkspaceFileResponse>;
+	loadWorkspaceFile: (path: string, signal?: AbortSignal) => Promise<WorkspaceFileResponse>;
 	messages: Array<ChatMessage>;
 	onOpenSubagentTab?: (childId: string) => void;
 	modelKey?: string;

--- a/web/app/src/lib/pi/workspace-panel.test.tsx
+++ b/web/app/src/lib/pi/workspace-panel.test.tsx
@@ -187,7 +187,9 @@ describe("WorkspacePanelContent file tree", () => {
 		const readme = getByRole("treeitem", { name: "README.md" });
 		fireEvent.click(readme);
 
-		await waitFor(() => expect(loadWorkspaceFile).toHaveBeenCalledWith("docs/README.md"));
+		await waitFor(() =>
+			expect(loadWorkspaceFile).toHaveBeenCalledWith("docs/README.md", expect.any(AbortSignal)),
+		);
 		await waitFor(() => expect(getByText("Preview body", { exact: true })).toBeTruthy());
 		expect(readme.getAttribute("aria-selected")).toBe("true");
 		expect(getByTestId("workspace-preview").textContent).toContain("README.md");
@@ -203,7 +205,9 @@ describe("WorkspacePanelContent file tree", () => {
 		const trace = within(tree).getByRole("treeitem", { name: "trace.md" });
 		fireEvent.click(trace);
 
-		await waitFor(() => expect(loadWorkspaceFile).toHaveBeenCalledWith("artifacts/trace.md"));
+		await waitFor(() =>
+			expect(loadWorkspaceFile).toHaveBeenCalledWith("artifacts/trace.md", expect.any(AbortSignal)),
+		);
 		await waitFor(() => expect(getByTestId("workspace-preview").textContent).toContain("trace.md"));
 	});
 
@@ -236,7 +240,9 @@ describe("WorkspacePanelContent file tree", () => {
 		expect(document.activeElement).toBe(reopenedReadme);
 		fireEvent.keyDown(reopenedReadme, { key: "Enter" });
 
-		await waitFor(() => expect(loadWorkspaceFile).toHaveBeenCalledWith("docs/README.md"));
+		await waitFor(() =>
+			expect(loadWorkspaceFile).toHaveBeenCalledWith("docs/README.md", expect.any(AbortSignal)),
+		);
 	});
 
 	it("renders scoped artifact trees without leaking sibling paths", () => {
@@ -278,7 +284,9 @@ describe("WorkspacePanelContent file tree", () => {
 			selectedPath: "docs/README.md",
 		});
 
-		await waitFor(() => expect(loadWorkspaceFile).toHaveBeenCalledWith("docs/README.md"));
+		await waitFor(() =>
+			expect(loadWorkspaceFile).toHaveBeenCalledWith("docs/README.md", expect.any(AbortSignal)),
+		);
 		expect(getByTestId("workspace-preview").querySelector('[data-slot="skeleton"]')).toBeTruthy();
 		expect(queryByText("Preview body", { exact: true })).toBeNull();
 
@@ -305,19 +313,44 @@ describe("WorkspacePanelContent file tree", () => {
 
 	it("times out a hung preview instead of leaving an infinite skeleton", async () => {
 		vi.useFakeTimers();
-		const loadWorkspaceFile = vi.fn(() => new Promise<WorkspaceFileResponse>(() => undefined));
+		const loadWorkspaceFile = vi.fn(
+			(_path: string, _signal?: AbortSignal) => new Promise<WorkspaceFileResponse>(() => undefined),
+		);
 		const { getByTestId, getByText } = renderPanel({
 			loadWorkspaceFile,
 			onSelectedPathChange: vi.fn(),
 			selectedPath: "docs/README.md",
 		});
 
+		const signal = loadWorkspaceFile.mock.calls[0]?.[1];
+		expect(signal).toBeInstanceOf(AbortSignal);
+		expect(signal?.aborted).toBe(false);
 		expect(getByTestId("workspace-preview").querySelector('[data-slot="skeleton"]')).toBeTruthy();
 		await act(async () => {
 			await vi.advanceTimersByTimeAsync(WORKSPACE_PREVIEW_TIMEOUT_MS);
 		});
+		expect(signal?.aborted).toBe(true);
 		expect(getByText("Unable to load preview")).toBeTruthy();
 		expect(getByText("Preview timed out")).toBeTruthy();
 		expect(getByTestId("workspace-preview").querySelector('[data-slot="skeleton"]')).toBeNull();
+	});
+
+	it("aborts a pending preview when the effect cleans up", () => {
+		const loadWorkspaceFile = vi.fn(
+			(_path: string, _signal?: AbortSignal) => new Promise<WorkspaceFileResponse>(() => undefined),
+		);
+		const { unmount } = renderPanel({
+			loadWorkspaceFile,
+			onSelectedPathChange: vi.fn(),
+			selectedPath: "docs/README.md",
+		});
+
+		const signal = loadWorkspaceFile.mock.calls[0]?.[1];
+		expect(signal).toBeInstanceOf(AbortSignal);
+		expect(signal?.aborted).toBe(false);
+
+		unmount();
+
+		expect(signal?.aborted).toBe(true);
 	});
 });

--- a/web/app/src/lib/pi/workspace-panel.test.tsx
+++ b/web/app/src/lib/pi/workspace-panel.test.tsx
@@ -296,6 +296,37 @@ describe("WorkspacePanelContent file tree", () => {
 		expect(getByTestId("workspace-preview").textContent).toContain("README.md");
 	});
 
+	it("reloads the preview when the workspace tree refreshes with the same file selected", async () => {
+		const loadWorkspaceFile = vi.fn(async (path: string) => fileResponse(path));
+		const { getByText, rerender } = renderPanel({
+			loadWorkspaceFile,
+			onSelectedPathChange: vi.fn(),
+			selectedPath: "docs/README.md",
+		});
+
+		await waitFor(() => expect(loadWorkspaceFile).toHaveBeenCalledTimes(1));
+		await waitFor(() => expect(getByText("Preview body", { exact: true })).toBeTruthy());
+
+		const refreshedWorkspace: WorkspaceTreeResponse = {
+			...workspace,
+			diagnostics: ["refreshed"],
+		};
+
+		rerender(
+			<WorkspacePanelContent
+				error={null}
+				loading={false}
+				workspace={refreshedWorkspace}
+				loadWorkspaceFile={loadWorkspaceFile}
+				onSelectedPathChange={vi.fn()}
+				selectedPath="docs/README.md"
+			/>,
+		);
+
+		await waitFor(() => expect(loadWorkspaceFile).toHaveBeenCalledTimes(2));
+		expect(loadWorkspaceFile).toHaveBeenLastCalledWith("docs/README.md", expect.any(AbortSignal));
+	});
+
 	it("shows an error instead of a skeleton when the preview request is rejected", async () => {
 		const loadWorkspaceFile = vi.fn(async () => {
 			throw new Error("file missing");

--- a/web/app/src/lib/pi/workspace-panel.test.tsx
+++ b/web/app/src/lib/pi/workspace-panel.test.tsx
@@ -1,12 +1,12 @@
-import { fireEvent, render, waitFor, within } from "@testing-library/react"
-import type {
-	WorkspaceFileResponse,
-	WorkspaceTreeResponse,
-} from "@prime-agent/web-protocol/chat-protocol"
-import { beforeEach, describe, expect, it, vi } from "vitest"
-import { WorkspacePanelContent } from "@prime-agent/web-design/components/product/fleet-pi/pi/workspace-panel"
-import type { WorkspacePanelContentProps } from "@prime-agent/web-design/components/product/fleet-pi/pi/workspace-panel"
-import { resolveWorkspacePanelTarget } from "@prime-agent/web-design/lib/workspace-path-nav"
+import {
+	WORKSPACE_PREVIEW_TIMEOUT_MS,
+	WorkspacePanelContent,
+	type WorkspacePanelContentProps,
+} from "@prime-agent/web-design/components/product/fleet-pi/pi/workspace-panel";
+import { resolveWorkspacePanelTarget } from "@prime-agent/web-design/lib/workspace-path-nav";
+import type { WorkspaceFileResponse, WorkspaceTreeResponse } from "@prime-agent/web-protocol/chat-protocol";
+import { act, fireEvent, render, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const workspace: WorkspaceTreeResponse = {
 	root: "/workspace/prime-agent",
@@ -54,7 +54,7 @@ const workspace: WorkspaceTreeResponse = {
 		},
 	],
 	diagnostics: [],
-}
+};
 
 function fileResponse(path: string): WorkspaceFileResponse {
 	return {
@@ -63,12 +63,11 @@ function fileResponse(path: string): WorkspaceFileResponse {
 		content: "# Preview\n\nPreview body",
 		mediaType: "text/markdown",
 		status: "ok",
-	}
+	};
 }
 
 function renderPanel(overrides: Partial<WorkspacePanelContentProps> = {}) {
-	const loadWorkspaceFile =
-		overrides.loadWorkspaceFile ?? vi.fn(async (path: string) => fileResponse(path))
+	const loadWorkspaceFile = overrides.loadWorkspaceFile ?? vi.fn(async (path: string) => fileResponse(path));
 
 	return {
 		loadWorkspaceFile,
@@ -81,11 +80,11 @@ function renderPanel(overrides: Partial<WorkspacePanelContentProps> = {}) {
 				loadWorkspaceFile={loadWorkspaceFile}
 			/>,
 		),
-	}
+	};
 }
 
 beforeEach(() => {
-	window.localStorage.clear()
+	window.localStorage.clear();
 	Object.defineProperty(window, "matchMedia", {
 		configurable: true,
 		value: (query: string) => ({
@@ -98,63 +97,66 @@ beforeEach(() => {
 			removeEventListener: vi.fn(),
 			dispatchEvent: vi.fn(),
 		}),
-	})
+	});
 	Object.defineProperty(Element.prototype, "scrollIntoView", {
 		configurable: true,
 		value: vi.fn(),
-	})
-})
+	});
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
 
 describe("WorkspacePanelContent file tree", () => {
-	it.each([
-		"agent-workspace/artifacts/trace.md",
-		"artifacts/trace.md",
-		"/workspace/artifacts/trace.md",
-	])("routes workspace artifact path %s to the Workspace panel", (path) => {
-		expect(resolveWorkspacePanelTarget(path)).toEqual({
-			panel: "workspace",
-			path: "agent-workspace/artifacts/trace.md",
-		})
-	})
+	it.each(["agent-workspace/artifacts/trace.md", "artifacts/trace.md", "/workspace/artifacts/trace.md"])(
+		"routes workspace artifact path %s to the Workspace panel",
+		(path) => {
+			expect(resolveWorkspacePanelTarget(path)).toEqual({
+				panel: "workspace",
+				path: "agent-workspace/artifacts/trace.md",
+			});
+		},
+	);
 
 	it("renders a semantic nested tree with collapsed folders", () => {
-		const { getByRole, queryByRole } = renderPanel()
+		const { getByRole, queryByRole } = renderPanel();
 
-		expect(getByRole("tree", { name: "Workspace files" })).toBeTruthy()
-		const docs = getByRole("treeitem", { name: "docs" })
-		expect(docs.getAttribute("aria-level")).toBe("1")
-		expect(docs.getAttribute("aria-expanded")).toBe("false")
-		expect(queryByRole("treeitem", { name: "README.md" })).toBeNull()
-		expect(getByRole("treeitem", { name: "notes.md" })).toBeTruthy()
-	})
+		expect(getByRole("tree", { name: "Workspace files" })).toBeTruthy();
+		const docs = getByRole("treeitem", { name: "docs" });
+		expect(docs.getAttribute("aria-level")).toBe("1");
+		expect(docs.getAttribute("aria-expanded")).toBe("false");
+		expect(queryByRole("treeitem", { name: "README.md" })).toBeNull();
+		expect(getByRole("treeitem", { name: "notes.md" })).toBeTruthy();
+	});
 
 	it("expands folders without selecting them", () => {
-		const onSelectedPathChange = vi.fn()
+		const onSelectedPathChange = vi.fn();
 		const { getByRole, queryByRole } = renderPanel({
 			onSelectedPathChange,
 			selectedPath: null,
-		})
-		const docs = getByRole("treeitem", { name: "docs" })
+		});
+		const docs = getByRole("treeitem", { name: "docs" });
 
-		fireEvent.click(docs)
+		fireEvent.click(docs);
 
-		expect(docs.getAttribute("aria-expanded")).toBe("true")
-		expect(docs.getAttribute("aria-selected")).toBe("false")
-		expect(onSelectedPathChange).not.toHaveBeenCalled()
-		expect(queryByRole("treeitem", { name: "README.md" })).toBeTruthy()
+		expect(docs.getAttribute("aria-expanded")).toBe("true");
+		expect(docs.getAttribute("aria-selected")).toBe("false");
+		expect(onSelectedPathChange).not.toHaveBeenCalled();
+		expect(queryByRole("treeitem", { name: "README.md" })).toBeTruthy();
 
-		const guides = getByRole("treeitem", { name: "guides" })
-		fireEvent.click(guides)
+		const guides = getByRole("treeitem", { name: "guides" });
+		fireEvent.click(guides);
 
-		expect(guides.getAttribute("aria-expanded")).toBe("true")
-		expect(guides.getAttribute("aria-selected")).toBe("false")
-		expect(queryByRole("treeitem", { name: "intro.md" })).toBeTruthy()
-		expect(onSelectedPathChange).not.toHaveBeenCalled()
+		expect(guides.getAttribute("aria-expanded")).toBe("true");
+		expect(guides.getAttribute("aria-selected")).toBe("false");
+		expect(queryByRole("treeitem", { name: "intro.md" })).toBeTruthy();
+		expect(onSelectedPathChange).not.toHaveBeenCalled();
 
-		fireEvent.click(docs)
-		expect(docs.getAttribute("aria-expanded")).toBe("false")
-		expect(onSelectedPathChange).not.toHaveBeenCalled()
-	})
+		fireEvent.click(docs);
+		expect(docs.getAttribute("aria-expanded")).toBe("false");
+		expect(onSelectedPathChange).not.toHaveBeenCalled();
+	});
 
 	it("does not make folders without loaded children expandable", () => {
 		const workspaceWithCappedFolder = {
@@ -167,98 +169,155 @@ describe("WorkspacePanelContent file tree", () => {
 					type: "directory" as const,
 				},
 			],
-		}
-		const { getByRole } = renderPanel({ workspace: workspaceWithCappedFolder })
-		const capped = getByRole("treeitem", { name: "capped" })
+		};
+		const { getByRole } = renderPanel({ workspace: workspaceWithCappedFolder });
+		const capped = getByRole("treeitem", { name: "capped" });
 
-		expect(capped.getAttribute("aria-expanded")).toBeNull()
-		fireEvent.click(capped)
-		fireEvent.keyDown(capped, { key: "Enter" })
-		expect(capped.getAttribute("aria-expanded")).toBeNull()
-	})
+		expect(capped.getAttribute("aria-expanded")).toBeNull();
+		fireEvent.click(capped);
+		fireEvent.keyDown(capped, { key: "Enter" });
+		expect(capped.getAttribute("aria-expanded")).toBeNull();
+	});
 
 	it("selects files and renders their Markdown preview", async () => {
-		const loadWorkspaceFile = vi.fn(async (path: string) => fileResponse(path))
-		const { getByRole, getByTestId, getByText } = renderPanel({ loadWorkspaceFile })
+		const loadWorkspaceFile = vi.fn(async (path: string) => fileResponse(path));
+		const { getByRole, getByTestId, getByText } = renderPanel({ loadWorkspaceFile });
 
-		fireEvent.click(getByRole("treeitem", { name: "docs" }))
-		const readme = getByRole("treeitem", { name: "README.md" })
-		fireEvent.click(readme)
+		fireEvent.click(getByRole("treeitem", { name: "docs" }));
+		const readme = getByRole("treeitem", { name: "README.md" });
+		fireEvent.click(readme);
 
-		await waitFor(() => expect(loadWorkspaceFile).toHaveBeenCalledWith("docs/README.md"))
-		await waitFor(() => expect(getByText("Preview body", { exact: true })).toBeTruthy())
-		expect(readme.getAttribute("aria-selected")).toBe("true")
-		expect(getByTestId("workspace-preview").textContent).toContain("README.md")
-	})
+		await waitFor(() => expect(loadWorkspaceFile).toHaveBeenCalledWith("docs/README.md"));
+		await waitFor(() => expect(getByText("Preview body", { exact: true })).toBeTruthy());
+		expect(readme.getAttribute("aria-selected")).toBe("true");
+		expect(getByTestId("workspace-preview").textContent).toContain("README.md");
+	});
 
 	it("keeps workspace artifact files accessible in the main tree", async () => {
-		const loadWorkspaceFile = vi.fn(async (path: string) => fileResponse(path))
-		const { getByRole, getByTestId } = renderPanel({ loadWorkspaceFile })
-		const tree = getByRole("tree", { name: "Workspace files" })
-		const artifacts = within(tree).getByRole("treeitem", { name: "artifacts" })
+		const loadWorkspaceFile = vi.fn(async (path: string) => fileResponse(path));
+		const { getByRole, getByTestId } = renderPanel({ loadWorkspaceFile });
+		const tree = getByRole("tree", { name: "Workspace files" });
+		const artifacts = within(tree).getByRole("treeitem", { name: "artifacts" });
 
-		fireEvent.click(artifacts)
-		const trace = within(tree).getByRole("treeitem", { name: "trace.md" })
-		fireEvent.click(trace)
+		fireEvent.click(artifacts);
+		const trace = within(tree).getByRole("treeitem", { name: "trace.md" });
+		fireEvent.click(trace);
 
-		await waitFor(() => expect(loadWorkspaceFile).toHaveBeenCalledWith("artifacts/trace.md"))
-		await waitFor(() => expect(getByTestId("workspace-preview").textContent).toContain("trace.md"))
-	})
+		await waitFor(() => expect(loadWorkspaceFile).toHaveBeenCalledWith("artifacts/trace.md"));
+		await waitFor(() => expect(getByTestId("workspace-preview").textContent).toContain("trace.md"));
+	});
 
 	it("supports tree keyboard navigation and file activation", async () => {
-		const loadWorkspaceFile = vi.fn(async (path: string) => fileResponse(path))
-		const { getByRole, queryByRole } = renderPanel({ loadWorkspaceFile })
-		const docs = getByRole("treeitem", { name: "docs" })
-		docs.focus()
+		const loadWorkspaceFile = vi.fn(async (path: string) => fileResponse(path));
+		const { getByRole, queryByRole } = renderPanel({ loadWorkspaceFile });
+		const docs = getByRole("treeitem", { name: "docs" });
+		docs.focus();
 
-		fireEvent.keyDown(docs, { key: "ArrowRight" })
-		const readme = getByRole("treeitem", { name: "README.md" })
-		expect(docs.getAttribute("aria-expanded")).toBe("true")
+		fireEvent.keyDown(docs, { key: "ArrowRight" });
+		const readme = getByRole("treeitem", { name: "README.md" });
+		expect(docs.getAttribute("aria-expanded")).toBe("true");
 
-		fireEvent.keyDown(docs, { key: "ArrowDown" })
-		expect(document.activeElement).toBe(readme)
-		fireEvent.keyDown(readme, { key: "ArrowUp" })
-		expect(document.activeElement).toBe(docs)
-		fireEvent.keyDown(docs, { key: "ArrowRight" })
-		expect(document.activeElement).toBe(readme)
-		fireEvent.keyDown(readme, { key: "ArrowLeft" })
-		expect(document.activeElement).toBe(docs)
+		fireEvent.keyDown(docs, { key: "ArrowDown" });
+		expect(document.activeElement).toBe(readme);
+		fireEvent.keyDown(readme, { key: "ArrowUp" });
+		expect(document.activeElement).toBe(docs);
+		fireEvent.keyDown(docs, { key: "ArrowRight" });
+		expect(document.activeElement).toBe(readme);
+		fireEvent.keyDown(readme, { key: "ArrowLeft" });
+		expect(document.activeElement).toBe(docs);
 
-		fireEvent.keyDown(docs, { key: " " })
-		expect(docs.getAttribute("aria-expanded")).toBe("false")
-		expect(queryByRole("treeitem", { name: "README.md" })).toBeNull()
+		fireEvent.keyDown(docs, { key: " " });
+		expect(docs.getAttribute("aria-expanded")).toBe("false");
+		expect(queryByRole("treeitem", { name: "README.md" })).toBeNull();
 
-		fireEvent.keyDown(docs, { key: "ArrowRight" })
-		fireEvent.keyDown(docs, { key: "ArrowRight" })
-		const reopenedReadme = getByRole("treeitem", { name: "README.md" })
-		expect(document.activeElement).toBe(reopenedReadme)
-		fireEvent.keyDown(reopenedReadme, { key: "Enter" })
+		fireEvent.keyDown(docs, { key: "ArrowRight" });
+		fireEvent.keyDown(docs, { key: "ArrowRight" });
+		const reopenedReadme = getByRole("treeitem", { name: "README.md" });
+		expect(document.activeElement).toBe(reopenedReadme);
+		fireEvent.keyDown(reopenedReadme, { key: "Enter" });
 
-		await waitFor(() => expect(loadWorkspaceFile).toHaveBeenCalledWith("docs/README.md"))
-	})
+		await waitFor(() => expect(loadWorkspaceFile).toHaveBeenCalledWith("docs/README.md"));
+	});
 
 	it("renders scoped artifact trees without leaking sibling paths", () => {
 		const { getByRole, queryByRole } = renderPanel({
 			scopeLabel: "artifacts",
 			scopePath: "artifacts",
-		})
+		});
 
-		expect(getByRole("tree", { name: "Files in artifacts" })).toBeTruthy()
-		expect(getByRole("treeitem", { name: "trace.md" })).toBeTruthy()
-		expect(queryByRole("treeitem", { name: "docs" })).toBeNull()
-	})
+		expect(getByRole("tree", { name: "Files in artifacts" })).toBeTruthy();
+		expect(getByRole("treeitem", { name: "trace.md" })).toBeTruthy();
+		expect(queryByRole("treeitem", { name: "docs" })).toBeNull();
+	});
 
 	it("preserves workspace error, loading, and empty states", () => {
-		const errorView = renderPanel({ error: new Error("read failed") })
-		expect(errorView.getByText("Unable to load workspace")).toBeTruthy()
-		expect(errorView.getByText("read failed")).toBeTruthy()
-		errorView.unmount()
+		const errorView = renderPanel({ error: new Error("read failed") });
+		expect(errorView.getByText("Unable to load workspace")).toBeTruthy();
+		expect(errorView.getByText("read failed")).toBeTruthy();
+		errorView.unmount();
 
-		const loadingView = renderPanel({ loading: true, workspace: null })
-		expect(loadingView.container.querySelector('[data-slot="skeleton"]')).toBeTruthy()
-		loadingView.unmount()
+		const loadingView = renderPanel({ loading: true, workspace: null });
+		expect(loadingView.container.querySelector('[data-slot="skeleton"]')).toBeTruthy();
+		loadingView.unmount();
 
-		const emptyView = renderPanel({ workspace: null })
-		expect(emptyView.getByText("Workspace unavailable")).toBeTruthy()
-	})
-})
+		const emptyView = renderPanel({ workspace: null });
+		expect(emptyView.getByText("Workspace unavailable")).toBeTruthy();
+	});
+
+	it("shows a pending skeleton then README Markdown when the preview succeeds", async () => {
+		let resolvePreview: ((value: WorkspaceFileResponse) => void) | undefined;
+		const loadWorkspaceFile = vi.fn(
+			() =>
+				new Promise<WorkspaceFileResponse>((resolve) => {
+					resolvePreview = resolve;
+				}),
+		);
+		const { getByTestId, getByText, queryByText } = renderPanel({
+			loadWorkspaceFile,
+			onSelectedPathChange: vi.fn(),
+			selectedPath: "docs/README.md",
+		});
+
+		await waitFor(() => expect(loadWorkspaceFile).toHaveBeenCalledWith("docs/README.md"));
+		expect(getByTestId("workspace-preview").querySelector('[data-slot="skeleton"]')).toBeTruthy();
+		expect(queryByText("Preview body", { exact: true })).toBeNull();
+
+		resolvePreview?.(fileResponse("docs/README.md"));
+		await waitFor(() => expect(getByText("Preview body", { exact: true })).toBeTruthy());
+		expect(getByTestId("workspace-preview").querySelector('[data-slot="skeleton"]')).toBeNull();
+		expect(getByTestId("workspace-preview").textContent).toContain("README.md");
+	});
+
+	it("shows an error instead of a skeleton when the preview request is rejected", async () => {
+		const loadWorkspaceFile = vi.fn(async () => {
+			throw new Error("file missing");
+		});
+		const { getByTestId, getByText } = renderPanel({
+			loadWorkspaceFile,
+			onSelectedPathChange: vi.fn(),
+			selectedPath: "docs/README.md",
+		});
+
+		await waitFor(() => expect(getByText("Unable to load preview")).toBeTruthy());
+		expect(getByText("file missing")).toBeTruthy();
+		expect(getByTestId("workspace-preview").querySelector('[data-slot="skeleton"]')).toBeNull();
+	});
+
+	it("times out a hung preview instead of leaving an infinite skeleton", async () => {
+		vi.useFakeTimers();
+		const loadWorkspaceFile = vi.fn(() => new Promise<WorkspaceFileResponse>(() => undefined));
+		const { getByTestId, getByText } = renderPanel({
+			loadWorkspaceFile,
+			onSelectedPathChange: vi.fn(),
+			selectedPath: "docs/README.md",
+		});
+
+		expect(getByTestId("workspace-preview").querySelector('[data-slot="skeleton"]')).toBeTruthy();
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(WORKSPACE_PREVIEW_TIMEOUT_MS);
+		});
+		expect(getByText("Unable to load preview")).toBeTruthy();
+		expect(getByText("Preview timed out")).toBeTruthy();
+		expect(getByTestId("workspace-preview").querySelector('[data-slot="skeleton"]')).toBeNull();
+	});
+});

--- a/web/app/src/lib/workspace-file.ts
+++ b/web/app/src/lib/workspace-file.ts
@@ -5,6 +5,18 @@ import type { ProjectId } from "@prime-agent/web-protocol";
 import type { WorkspaceFileResponse } from "@prime-agent/web-protocol/chat-protocol";
 import { chatClient } from "@/lib/pi/chat-client";
 
-export async function loadWorkspaceFile(path: string, projectId?: ProjectId): Promise<WorkspaceFileResponse> {
-	return chatClient.getWorkspaceFile(path, projectId);
+export const WORKSPACE_FILE_REQUEST_TIMEOUT_MS = 15_000;
+
+export async function loadWorkspaceFile(
+	path: string,
+	projectId?: ProjectId,
+	signal?: AbortSignal,
+): Promise<WorkspaceFileResponse> {
+	const timeout =
+		typeof AbortSignal.timeout === "function" ? AbortSignal.timeout(WORKSPACE_FILE_REQUEST_TIMEOUT_MS) : undefined;
+	const requestSignal =
+		signal && timeout && typeof AbortSignal.any === "function"
+			? AbortSignal.any([signal, timeout])
+			: (signal ?? timeout);
+	return chatClient.getWorkspaceFile(path, projectId, requestSignal);
 }

--- a/web/design/src/components/product/fleet-pi/layout/agent-tab-bar.tsx
+++ b/web/design/src/components/product/fleet-pi/layout/agent-tab-bar.tsx
@@ -1,16 +1,17 @@
-import { Bot, Plus, X } from "lucide-react"
-import { useCallback, useEffect, useRef, type KeyboardEvent } from "react"
-import { Button } from "../../../ui/button"
-import type { PrimeAgentRlmChild } from "@prime-agent/web-protocol/chat-protocol"
-import { cn } from "../../../../lib/utils"
-import { agentTabPanelId, agentTabTriggerId } from "./agent-tab-ids"
+import type { PrimeAgentRlmChild } from "@prime-agent/web-protocol/chat-protocol";
+import { Bot, Plus, X } from "lucide-react";
+import { type KeyboardEvent, useCallback, useEffect, useRef } from "react";
+import { cn } from "../../../../lib/utils";
+import { Button } from "../../../ui/button";
+import { HIT_AREA_EXPAND_DENSE_CLASS } from "../styles/tokens";
+import { agentTabPanelId, agentTabTriggerId } from "./agent-tab-ids";
 
 export type AgentTabItem = {
-  id: string
-  label: string
-  kind: "main" | "subagent"
-  status?: PrimeAgentRlmChild["status"]
-}
+	id: string;
+	label: string;
+	kind: "main" | "subagent";
+	status?: PrimeAgentRlmChild["status"];
+};
 
 /**
  * Maps an agent status to its accessible tab label.
@@ -19,22 +20,22 @@ export type AgentTabItem = {
  * @returns The corresponding label: `queued`, `streaming`, `error`, `cancelled`, `complete`, or `ready`
  */
 function statusLabel(status: AgentTabItem["status"]): string {
-  switch (status) {
-    case "queued":
-      return "queued"
-    case "running":
-    case "recovering":
-      return "streaming"
-    case "error":
-    case "failed":
-      return "error"
-    case "cancelled":
-      return "cancelled"
-    case "done":
-      return "complete"
-    default:
-      return "ready"
-  }
+	switch (status) {
+		case "queued":
+			return "queued";
+		case "running":
+		case "recovering":
+			return "streaming";
+		case "error":
+		case "failed":
+			return "error";
+		case "cancelled":
+			return "cancelled";
+		case "done":
+			return "complete";
+		default:
+			return "ready";
+	}
 }
 
 /**
@@ -44,20 +45,20 @@ function statusLabel(status: AgentTabItem["status"]): string {
  * @returns CSS classes for the status indicator
  */
 function statusDotClass(status: AgentTabItem["status"]): string {
-  switch (status) {
-    case "running":
-    case "recovering":
-      return "bg-emerald-400 motion-safe:animate-pulse"
-    case "error":
-    case "failed":
-      return "bg-destructive"
-    case "queued":
-      return "bg-amber-300"
-    case "cancelled":
-      return "bg-foreground/35"
-    default:
-      return "bg-foreground/35"
-  }
+	switch (status) {
+		case "running":
+		case "recovering":
+			return "bg-emerald-400 motion-safe:animate-pulse";
+		case "error":
+		case "failed":
+			return "bg-destructive";
+		case "queued":
+			return "bg-amber-300";
+		case "cancelled":
+			return "bg-foreground/35";
+		default:
+			return "bg-foreground/35";
+	}
 }
 
 /**
@@ -70,141 +71,145 @@ function statusDotClass(status: AgentTabItem["status"]): string {
  * @param onNewSession - Called when the new-chat control is selected
  */
 export function AgentTabBar({
-  tabs,
-  value,
-  onValueChange,
-  onClose,
-  onNewSession,
+	tabs,
+	value,
+	onValueChange,
+	onClose,
+	onNewSession,
 }: {
-  tabs: Array<AgentTabItem>
-  value: string
-  onValueChange: (tabId: string) => void
-  onClose?: (tabId: string) => void
-  onNewSession?: () => void
+	tabs: Array<AgentTabItem>;
+	value: string;
+	onValueChange: (tabId: string) => void;
+	onClose?: (tabId: string) => void;
+	onNewSession?: () => void;
 }) {
-  const tabRefs = useRef(new Map<string, HTMLButtonElement>())
-  const setTabRef = useCallback((tabId: string, node: HTMLButtonElement | null) => {
-    if (node) tabRefs.current.set(tabId, node)
-    else tabRefs.current.delete(tabId)
-  }, [])
+	const tabRefs = useRef(new Map<string, HTMLButtonElement>());
+	const setTabRef = useCallback((tabId: string, node: HTMLButtonElement | null) => {
+		if (node) tabRefs.current.set(tabId, node);
+		else tabRefs.current.delete(tabId);
+	}, []);
 
-  useEffect(() => {
-    for (const tabId of tabRefs.current.keys()) {
-      if (!tabs.some((tab) => tab.id === tabId)) tabRefs.current.delete(tabId)
-    }
-  }, [tabs])
+	useEffect(() => {
+		for (const tabId of tabRefs.current.keys()) {
+			if (!tabs.some((tab) => tab.id === tabId)) tabRefs.current.delete(tabId);
+		}
+	}, [tabs]);
 
-  const focusTab = useCallback(
-    (index: number) => {
-      const tab = tabs[index]
-      if (!tab) return
-      tabRefs.current.get(tab.id)?.focus()
-      onValueChange(tab.id)
-    },
-    [onValueChange, tabs],
-  )
+	const focusTab = useCallback(
+		(index: number) => {
+			const tab = tabs[index];
+			if (!tab) return;
+			tabRefs.current.get(tab.id)?.focus();
+			onValueChange(tab.id);
+		},
+		[onValueChange, tabs],
+	);
 
-  const handleKeyDown = useCallback(
-    (event: KeyboardEvent<HTMLButtonElement>, tabId: string) => {
-      const index = tabs.findIndex((tab) => tab.id === tabId)
-      if (index < 0) return
-      let nextIndex: number | undefined
-      if (event.key === "ArrowRight") nextIndex = (index + 1) % tabs.length
-      if (event.key === "ArrowLeft") nextIndex = (index - 1 + tabs.length) % tabs.length
-      if (event.key === "Home") nextIndex = 0
-      if (event.key === "End") nextIndex = tabs.length - 1
-      if (nextIndex === undefined) return
-      event.preventDefault()
-      focusTab(nextIndex)
-    },
-    [focusTab, tabs],
-  )
+	const handleKeyDown = useCallback(
+		(event: KeyboardEvent<HTMLButtonElement>, tabId: string) => {
+			const index = tabs.findIndex((tab) => tab.id === tabId);
+			if (index < 0) return;
+			let nextIndex: number | undefined;
+			if (event.key === "ArrowRight") nextIndex = (index + 1) % tabs.length;
+			if (event.key === "ArrowLeft") nextIndex = (index - 1 + tabs.length) % tabs.length;
+			if (event.key === "Home") nextIndex = 0;
+			if (event.key === "End") nextIndex = tabs.length - 1;
+			if (nextIndex === undefined) return;
+			event.preventDefault();
+			focusTab(nextIndex);
+		},
+		[focusTab, tabs],
+	);
 
-  return (
-    <div
-      className="flex min-w-0 max-w-full items-center gap-1"
-      data-testid="agent-tab-bar"
-    >
-      <div
-        aria-label="Agent conversations"
-        className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto overscroll-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-        role="tablist"
-      >
-        {tabs.map((tab) => {
-          const active = tab.id === value
-          const status = statusLabel(tab.status)
-          return (
-            <div
-              key={tab.id}
-              className="group/tab relative min-w-0 shrink-0 basis-[164px] sm:max-w-[164px]"
-              data-tab-id={tab.id}
-            >
-              <Button
-                ref={(node) => setTabRef(tab.id, node)}
-                aria-controls={agentTabPanelId(tab.id)}
-                aria-selected={active}
-                aria-label={`${tab.label}, ${status}`}
-                className={cn(
-                  "h-7 w-full min-w-0 justify-start text-left gap-1.5 rounded-[7px] border border-transparent px-2 text-[0.75rem] font-medium leading-none transition-colors motion-reduce:transition-none",
-                  active
-                    ? "bg-surface-4 text-foreground shadow-none"
-                    : "bg-transparent text-foreground/45 hover:bg-foreground/5 hover:text-foreground/75",
-                  tab.kind === "subagent" && onClose && "pr-7",
-                )}
-                data-state={active ? "active" : "inactive"}
-                id={agentTabTriggerId(tab.id)}
-                onClick={() => onValueChange(tab.id)}
-                onKeyDown={(event) => handleKeyDown(event, tab.id)}
-                role="tab"
-                size="sm"
-                tabIndex={active ? 0 : -1}
-                type="button"
-                variant="ghost"
-              >
-                {tab.kind === "main" ? (
-                  <Bot aria-hidden="true" className="size-3.5 shrink-0" />
-                ) : (
-                  <span
-                    aria-hidden="true"
-                    className={cn("size-1.5 shrink-0 rounded-full", statusDotClass(tab.status))}
-                  />
-                )}
-                <span className="min-w-0 flex-1 truncate text-left">{tab.label}</span>
-              </Button>
-              {tab.kind === "subagent" && onClose ? (
-                <Button
-                  aria-label={`Close ${tab.label} tab`}
-                  className="absolute top-1/2 right-1 size-5 -translate-y-1/2 rounded-[5px] p-0 text-foreground/35 opacity-0 transition-opacity motion-reduce:transition-none hover:bg-foreground/10 hover:text-foreground/75 focus-visible:opacity-100 group-hover/tab:opacity-100"
-                  onClick={(event) => {
-                    event.stopPropagation()
-                    onClose(tab.id)
-                  }}
-                  size="icon-xs"
-                  title={`Close ${tab.label} tab`}
-                  type="button"
-                  variant="ghost"
-                >
-                  <X aria-hidden="true" className="size-3" />
-                </Button>
-              ) : null}
-            </div>
-          )
-        })}
-      </div>
-      {onNewSession ? (
-        <Button
-          aria-label="New chat"
-          className="size-7 shrink-0 rounded-[7px] text-foreground/50 hover:bg-foreground/7 hover:text-foreground/85"
-          data-testid="new-chat-tab"
-          onClick={onNewSession}
-          size="icon-sm"
-          title="New chat"
-          type="button"
-          variant="ghost"
-        >
-          <Plus aria-hidden="true" className="size-3.5" />
-        </Button>
-      ) : null}
-    </div>
-  )
+	return (
+		<div className="flex min-w-0 max-w-full items-center gap-1" data-testid="agent-tab-bar">
+			<div
+				aria-label="Agent conversations"
+				className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto overscroll-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+				role="tablist"
+			>
+				{tabs.map((tab) => {
+					const active = tab.id === value;
+					const status = statusLabel(tab.status);
+					return (
+						<div
+							key={tab.id}
+							className="group/tab relative min-w-0 shrink-0 basis-[164px] sm:max-w-[164px]"
+							data-tab-id={tab.id}
+						>
+							<Button
+								ref={(node) => setTabRef(tab.id, node)}
+								aria-controls={agentTabPanelId(tab.id)}
+								aria-selected={active}
+								aria-label={`${tab.label}, ${status}`}
+								className={cn(
+									"h-7 w-full min-w-0 justify-start text-left gap-1.5 rounded-[7px] border border-transparent px-2 text-[0.75rem] font-medium leading-none transition-colors motion-reduce:transition-none",
+									active
+										? "bg-surface-4 text-foreground shadow-none"
+										: "bg-transparent text-foreground/45 hover:bg-foreground/5 hover:text-foreground/75",
+									tab.kind === "subagent" && onClose && "pr-7",
+								)}
+								data-state={active ? "active" : "inactive"}
+								id={agentTabTriggerId(tab.id)}
+								onClick={() => onValueChange(tab.id)}
+								onKeyDown={(event) => handleKeyDown(event, tab.id)}
+								role="tab"
+								size="sm"
+								tabIndex={active ? 0 : -1}
+								type="button"
+								variant="ghost"
+							>
+								{tab.kind === "main" ? (
+									<Bot aria-hidden="true" className="size-3.5 shrink-0" />
+								) : (
+									<span
+										aria-hidden="true"
+										className={cn("size-1.5 shrink-0 rounded-full", statusDotClass(tab.status))}
+									/>
+								)}
+								<span className="min-w-0 flex-1 truncate text-left">{tab.label}</span>
+							</Button>
+							{tab.kind === "subagent" && onClose ? (
+								<Button
+									aria-label={`Close ${tab.label} tab`}
+									className="absolute top-1/2 right-1 size-5 -translate-y-1/2 rounded-[5px] p-0 text-foreground/35 opacity-0 transition-opacity motion-reduce:transition-none hover:bg-foreground/10 hover:text-foreground/75 focus-visible:opacity-100 group-hover/tab:opacity-100"
+									onClick={(event) => {
+										event.stopPropagation();
+										onClose(tab.id);
+									}}
+									size="icon-xs"
+									title={`Close ${tab.label} tab`}
+									type="button"
+									variant="ghost"
+								>
+									<X aria-hidden="true" className="size-3" />
+								</Button>
+							) : null}
+						</div>
+					);
+				})}
+			</div>
+			{onNewSession ? (
+				<Button
+					aria-label="New chat"
+					className={cn(
+						HIT_AREA_EXPAND_DENSE_CLASS,
+						"relative z-10 size-7 shrink-0 rounded-[7px] text-foreground/50 hover:bg-foreground/7 hover:text-foreground/85",
+					)}
+					data-testid="new-chat-tab"
+					onClick={(event) => {
+						event.preventDefault();
+						event.stopPropagation();
+						onNewSession();
+					}}
+					size="icon-sm"
+					title="New chat"
+					type="button"
+					variant="ghost"
+				>
+					<Plus aria-hidden="true" className="size-3.5" />
+				</Button>
+			) : null}
+		</div>
+	);
 }

--- a/web/design/src/components/product/fleet-pi/layout/chat-workspace-layout.tsx
+++ b/web/design/src/components/product/fleet-pi/layout/chat-workspace-layout.tsx
@@ -1,17 +1,13 @@
-import {
-  CHAT_CHROME_TOP_PX,
-  CHAT_HEADER_HEIGHT_PX,
-  CHAT_HEADER_OFFSET_PX,
-} from "../../../../lib/layout-constants"
-import { cn } from "../../../../lib/utils"
-import { CHAT_HEADER_LAYER_CLASS } from "../styles/tokens"
-import type { CSSProperties, ReactNode } from "react"
+import type { CSSProperties, ReactNode } from "react";
+import { CHAT_CHROME_TOP_PX, CHAT_HEADER_HEIGHT_PX, CHAT_HEADER_OFFSET_PX } from "../../../../lib/layout-constants";
+import { cn } from "../../../../lib/utils";
+import { CHAT_HEADER_LAYER_CLASS } from "../styles/tokens";
 
 const layoutStyle = {
-  "--chat-chrome-top": `${CHAT_CHROME_TOP_PX}px`,
-  "--chat-header-height": `${CHAT_HEADER_HEIGHT_PX}px`,
-  "--chat-header-top": `${CHAT_HEADER_OFFSET_PX}px`,
-} as CSSProperties
+	"--chat-chrome-top": `${CHAT_CHROME_TOP_PX}px`,
+	"--chat-header-height": `${CHAT_HEADER_HEIGHT_PX}px`,
+	"--chat-header-top": `${CHAT_HEADER_OFFSET_PX}px`,
+} as CSSProperties;
 
 /**
  * Lays out the chat workspace with header content, main content, and a side panel.
@@ -24,44 +20,37 @@ const layoutStyle = {
  * @returns The chat workspace layout
  */
 export function ChatWorkspaceLayout({
-  children,
-  headerCenter,
-  headerLeft,
-  headerRight,
-  panel,
+	children,
+	headerCenter,
+	headerLeft,
+	headerRight,
+	panel,
 }: {
-  children: ReactNode
-  headerCenter: ReactNode
-  headerLeft: ReactNode
-  headerRight?: ReactNode
-  panel: ReactNode
+	children: ReactNode;
+	headerCenter: ReactNode;
+	headerLeft: ReactNode;
+	headerRight?: ReactNode;
+	panel: ReactNode;
 }) {
-  return (
-    <div
-      className="flex h-svh min-w-0 overflow-hidden"
-      data-testid="chat-shell"
-      style={layoutStyle}
-    >
-      <div
-        className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
-        data-testid="chat-column"
-      >
-        <header
-          className={cn(
-            CHAT_HEADER_LAYER_CLASS,
-            "grid h-[var(--chat-header-height)] min-h-[var(--chat-header-height)] shrink-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-1 border-b border-border/70 px-2 py-2"
-          )}
-          data-testid="chat-header"
-        >
-          <div className="min-w-0 justify-self-start">{headerLeft}</div>
-          <div className="flex min-w-0 items-center justify-start gap-1 overflow-hidden justify-self-stretch">
-            {headerCenter}
-          </div>
-          <div className="min-w-0 justify-self-end">{headerRight}</div>
-        </header>
-        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">{children}</div>
-      </div>
-      {panel}
-    </div>
-  )
+	return (
+		<div className="flex h-svh min-w-0 overflow-hidden" data-testid="chat-shell" style={layoutStyle}>
+			<div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden" data-testid="chat-column">
+				<header
+					className={cn(
+						CHAT_HEADER_LAYER_CLASS,
+						"grid h-[var(--chat-header-height)] min-h-[var(--chat-header-height)] shrink-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-1 border-b border-border/70 px-2 py-2",
+					)}
+					data-testid="chat-header"
+				>
+					<div className="min-w-0 justify-self-start">{headerLeft}</div>
+					<div className="flex min-w-0 items-center justify-start gap-1 overflow-visible justify-self-stretch">
+						{headerCenter}
+					</div>
+					<div className="min-w-0 justify-self-end">{headerRight}</div>
+				</header>
+				<div className="flex min-h-0 flex-1 flex-col overflow-hidden">{children}</div>
+			</div>
+			{panel}
+		</div>
+	);
 }

--- a/web/design/src/components/product/fleet-pi/layout/right-panel-context.tsx
+++ b/web/design/src/components/product/fleet-pi/layout/right-panel-context.tsx
@@ -63,7 +63,10 @@ export type ChatPanelDataContextValue = {
 }
 
 export type WorkspaceTreeContextValue = {
-  loadWorkspaceFile: (path: string) => Promise<WorkspaceFileResponse>
+  loadWorkspaceFile: (
+    path: string,
+    signal?: AbortSignal,
+  ) => Promise<WorkspaceFileResponse>
   openWorkspacePath: (rawPath: string) => void
   refreshWorkspace: () => void
   selectedWorkspacePath: string | null

--- a/web/design/src/components/product/fleet-pi/layout/right-panel-shell.tsx
+++ b/web/design/src/components/product/fleet-pi/layout/right-panel-shell.tsx
@@ -1,53 +1,39 @@
-import { Library } from "lucide-react"
-import { CHAT_PANEL_BREAKPOINT_PX } from "../../../../lib/layout-constants"
-import { ResizableCanvas } from "../pi/resizable-canvas"
-import {
-  MobilePanel,
-  RightPanelTabsFromContext,
-} from "../pi/right-panel-launcher"
-import {
-  getRightPanelDefinition,
-} from "./right-panel-registry"
-import {
-  useChatPanelDataContext,
-  useWorkspaceTreeContext,
-} from "./right-panel-context"
-import { useSyncExternalStore, type PointerEvent as ReactPointerEvent } from "react"
+import { Library } from "lucide-react";
+import { type PointerEvent as ReactPointerEvent, useSyncExternalStore } from "react";
+import { CHAT_PANEL_BREAKPOINT_PX } from "../../../../lib/layout-constants";
+import { ResizableCanvas } from "../pi/resizable-canvas";
+import { MobilePanel, RightPanelTabsFromContext } from "../pi/right-panel-launcher";
+import { useChatPanelDataContext, useWorkspaceTreeContext } from "./right-panel-context";
+import { getRightPanelDefinition } from "./right-panel-registry";
 
-const DESKTOP_PANEL_QUERY = `(min-width: ${CHAT_PANEL_BREAKPOINT_PX}px)`
+const DESKTOP_PANEL_QUERY = `(min-width: ${CHAT_PANEL_BREAKPOINT_PX}px)`;
 
 function subscribeToDesktopPanel(onChange: () => void) {
-  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return () => undefined
-  const media = window.matchMedia(DESKTOP_PANEL_QUERY)
-  media.addEventListener("change", onChange)
-  return () => media.removeEventListener("change", onChange)
+	if (typeof window === "undefined" || typeof window.matchMedia !== "function") return () => undefined;
+	const media = window.matchMedia(DESKTOP_PANEL_QUERY);
+	media.addEventListener("change", onChange);
+	return () => media.removeEventListener("change", onChange);
 }
 
 function getDesktopPanelSnapshot() {
-  return typeof window !== "undefined" && typeof window.matchMedia === "function"
-    ? window.matchMedia(DESKTOP_PANEL_QUERY).matches
-    : false
+	return typeof window !== "undefined" && typeof window.matchMedia === "function"
+		? window.matchMedia(DESKTOP_PANEL_QUERY).matches
+		: false;
 }
 
 function getServerDesktopPanelSnapshot() {
-  return false
+	return false;
 }
 
 function useIsDesktopPanel() {
-  return useSyncExternalStore(
-    subscribeToDesktopPanel,
-    getDesktopPanelSnapshot,
-    getServerDesktopPanelSnapshot,
-  )
+	return useSyncExternalStore(subscribeToDesktopPanel, getDesktopPanelSnapshot, getServerDesktopPanelSnapshot);
 }
 
 export type RightPanelShellProps = {
-  handleResourceCanvasResizeStart: (
-    event: ReactPointerEvent<HTMLButtonElement>
-  ) => void
-  onClose: () => void
-  resourceCanvasWidth: number
-}
+	handleResourceCanvasResizeStart: (event: ReactPointerEvent<HTMLButtonElement>) => void;
+	onClose: () => void;
+	resourceCanvasWidth: number;
+};
 
 /**
  * Renders the selected right-panel content in mobile and desktop layouts.
@@ -57,59 +43,57 @@ export type RightPanelShellProps = {
  * @param resourceCanvasWidth - The desktop panel width.
  */
 export function RightPanelShell({
-  handleResourceCanvasResizeStart,
-  onClose,
-  resourceCanvasWidth,
+	handleResourceCanvasResizeStart,
+	onClose,
+	resourceCanvasWidth,
 }: RightPanelShellProps) {
-  const chat = useChatPanelDataContext()
-  const workspace = useWorkspaceTreeContext()
-  const { rightPanel } = chat
-  const panelOpen = rightPanel !== null
-  const isDesktop = useIsDesktopPanel()
-  const definition = rightPanel ? getRightPanelDefinition(rightPanel) : null
-  const PanelContent = definition?.component
-  const loading =
-    definition?.loadingSource === "resources"
-      ? chat.resourcesLoading
-      : definition?.loadingSource === "workspace"
-        ? workspace.workspaceLoading
-        : false
-  const onRefresh =
-    definition?.refreshSource === "resources"
-      ? chat.refreshResources
-      : definition?.refreshSource === "workspace"
-        ? workspace.refreshWorkspace
-        : undefined
-  return (
-    <>
-      {isDesktop ? (
-        <ResizableCanvas
-          dataTestid={definition?.dataTestid}
-          headerLeading={
-            <RightPanelTabsFromContext idPrefix="right-panel-desktop" />
-          }
-          loading={loading}
-          onClose={onClose}
-          onRefresh={onRefresh}
-          onResizeStart={handleResourceCanvasResizeStart}
-          open={panelOpen}
-          title={definition?.title ?? ""}
-          titleIcon={definition?.icon ?? Library}
-          width={resourceCanvasWidth}
-        >
-          {PanelContent ? <PanelContent /> : null}
-        </ResizableCanvas>
-      ) : (
-        <MobilePanel
-          dataTestid={definition?.mobileDataTestid}
-          icon={definition?.icon}
-          onClose={onClose}
-          open={panelOpen}
-          title={definition?.title ?? ""}
-        >
-          {PanelContent ? <PanelContent /> : null}
-        </MobilePanel>
-      )}
-    </>
-  )
+	const chat = useChatPanelDataContext();
+	const workspace = useWorkspaceTreeContext();
+	const { rightPanel } = chat;
+	const panelOpen = rightPanel !== null;
+	const isDesktop = useIsDesktopPanel();
+	const definition = rightPanel ? getRightPanelDefinition(rightPanel) : null;
+	const PanelContent = definition?.component;
+	const loading =
+		definition?.loadingSource === "resources"
+			? chat.resourcesLoading
+			: definition?.loadingSource === "workspace"
+				? workspace.workspaceLoading
+				: false;
+	const onRefresh =
+		definition?.refreshSource === "resources"
+			? chat.refreshResources
+			: definition?.refreshSource === "workspace"
+				? workspace.refreshWorkspace
+				: undefined;
+	return (
+		<>
+			{isDesktop ? (
+				<ResizableCanvas
+					dataTestid={definition?.dataTestid}
+					headerLeading={<RightPanelTabsFromContext compact idPrefix="right-panel-desktop" />}
+					loading={loading}
+					onClose={onClose}
+					onRefresh={onRefresh}
+					onResizeStart={handleResourceCanvasResizeStart}
+					open={panelOpen}
+					title={definition?.title ?? ""}
+					titleIcon={definition?.icon ?? Library}
+					width={resourceCanvasWidth}
+				>
+					{PanelContent ? <PanelContent /> : null}
+				</ResizableCanvas>
+			) : (
+				<MobilePanel
+					dataTestid={definition?.mobileDataTestid}
+					icon={definition?.icon}
+					onClose={onClose}
+					open={panelOpen}
+					title={definition?.title ?? ""}
+				>
+					{PanelContent ? <PanelContent /> : null}
+				</MobilePanel>
+			)}
+		</>
+	);
 }

--- a/web/design/src/components/product/fleet-pi/pi/right-panel-launcher.tsx
+++ b/web/design/src/components/product/fleet-pi/pi/right-panel-launcher.tsx
@@ -1,50 +1,40 @@
-import { PanelRight, X } from "lucide-react"
-import { useCallback, useEffect, useEffectEvent, useId, useLayoutEffect, useMemo, useRef, useState } from "react"
-import { TabsSubtle, TabsSubtleItem } from "../../tabs-subtle"
-import {
-  CHAT_PANEL_BREAKPOINT_PX,
-  DESKTOP_PANEL_ONLY,
-} from "../../../../lib/layout-constants"
-import {
-  useChatPanelDataContext,
-  useWorkspaceTreeContext,
-} from "../layout/right-panel-context"
-import { RIGHT_PANEL_LAUNCHER_DEFINITIONS } from "../layout/right-panel-registry"
-import { ChromePillButton } from "../primitives/chrome-pill"
-import { Button } from "../../../ui/button"
-import { Select, type SelectOption } from "../../../ui/select"
-import { HIT_AREA_EXPAND_CLASS, PANEL_OVERLAY_CLASS } from "../styles/tokens"
-import { collectSessionOpenUIBlocks } from "./artifacts-utils"
-import { getResourceGroups } from "./resource-helpers"
-import type { HTMLAttributes, ReactNode } from "react"
-import type { LucideIcon } from "lucide-react"
-import type { RightPanel } from "../../../../lib/canvas-utils"
-import type {
-  ChatResourcesResponse,
-  WorkspaceTreeResponse,
-} from "@prime-agent/web-protocol/chat-protocol"
+import type { ChatResourcesResponse, WorkspaceTreeResponse } from "@prime-agent/web-protocol/chat-protocol";
+import type { LucideIcon } from "lucide-react";
+import { PanelRight, X } from "lucide-react";
+import type { HTMLAttributes, ReactNode } from "react";
+import { useCallback, useEffect, useEffectEvent, useId, useLayoutEffect, useMemo, useRef, useState } from "react";
+import type { RightPanel } from "../../../../lib/canvas-utils";
+import { CHAT_PANEL_BREAKPOINT_PX, DESKTOP_PANEL_ONLY } from "../../../../lib/layout-constants";
+import { Button } from "../../../ui/button";
+import { Select, type SelectOption } from "../../../ui/select";
+import { TabsSubtle, TabsSubtleItem } from "../../tabs-subtle";
+import { useChatPanelDataContext, useWorkspaceTreeContext } from "../layout/right-panel-context";
+import { RIGHT_PANEL_LAUNCHER_DEFINITIONS } from "../layout/right-panel-registry";
+import { ChromePillButton } from "../primitives/chrome-pill";
+import { HIT_AREA_EXPAND_CLASS, PANEL_OVERLAY_CLASS } from "../styles/tokens";
+import { collectSessionOpenUIBlocks } from "./artifacts-utils";
+import { getResourceGroups } from "./resource-helpers";
 
-const COMPACT_TABS_CLASS = "[&_[data-proximity-index]]:!h-7 [&_[data-proximity-index]]:!px-2 [&_[data-proximity-index]]:!text-[0.6875rem]"
+const COMPACT_TABS_CLASS =
+	"[&_[data-proximity-index]]:!h-7 [&_[data-proximity-index]]:!px-2 [&_[data-proximity-index]]:!text-[0.6875rem]";
 /**
  * Renders responsive controls for opening or navigating the right panel based on context state.
  *
  * @param compact - Whether to use compact control styling
  */
 export function RightPanelLauncherFromContext({ compact = false }: { compact?: boolean } = {}) {
-  const { reopenRightPanel, rightPanel } = useChatPanelDataContext()
+	const { reopenRightPanel, rightPanel } = useChatPanelDataContext();
 
-  return (
-    <>
-      <div className="min-[960px]:hidden">
-        <RightPanelTabsFromContext compact={compact} idPrefix="right-panel-mobile" />
-      </div>
-      <div className="hidden min-[960px]:block">
-        {rightPanel === null ? (
-          <RightPanelTrigger compact={compact} onOpen={reopenRightPanel} />
-        ) : null}
-      </div>
-    </>
-  )
+	return (
+		<>
+			<div className="min-[960px]:hidden">
+				<RightPanelTabsFromContext compact={compact} idPrefix="right-panel-mobile" />
+			</div>
+			<div className="hidden min-[960px]:block">
+				{rightPanel === null ? <RightPanelTrigger compact={compact} onOpen={reopenRightPanel} /> : null}
+			</div>
+		</>
+	);
 }
 
 /**
@@ -55,39 +45,32 @@ export function RightPanelLauncherFromContext({ compact = false }: { compact?: b
  * @returns The right-panel launcher
  */
 export function RightPanelTabsFromContext({
-  compact = false,
-  idPrefix = "right-panel",
+	compact = false,
+	idPrefix = "right-panel",
 }: {
-  compact?: boolean
-  idPrefix?: string
+	compact?: boolean;
+	idPrefix?: string;
 }) {
-  const {
-    artifactRuns,
-    messages,
-    rightPanel,
-    setRightPanel,
-    resources,
-  } =
-    useChatPanelDataContext()
-  const { workspaceTree } = useWorkspaceTreeContext()
+	const { artifactRuns, messages, rightPanel, setRightPanel, resources } = useChatPanelDataContext();
+	const { workspaceTree } = useWorkspaceTreeContext();
 
-  return (
-    <RightPanelLauncher
-      activePanel={rightPanel}
-      onPanelChange={setRightPanel}
-      resources={resources}
-      replRuns={artifactRuns
-        .flatMap((run) => run.artifacts)
-        .filter((artifact) => artifact.kind === "ipython").length}
-      sessionBlocks={collectSessionOpenUIBlocks(messages).length}
-      openUIArtifacts={artifactRuns
-        .flatMap((run) => run.artifacts)
-        .filter((artifact) => artifact.kind === "openui-html").length}
-      workspace={workspaceTree}
-      idPrefix={idPrefix}
-      compact={compact}
-    />
-  )
+	return (
+		<RightPanelLauncher
+			activePanel={rightPanel}
+			onPanelChange={setRightPanel}
+			resources={resources}
+			replRuns={
+				artifactRuns.flatMap((run) => run.artifacts).filter((artifact) => artifact.kind === "ipython").length
+			}
+			sessionBlocks={collectSessionOpenUIBlocks(messages).length}
+			openUIArtifacts={
+				artifactRuns.flatMap((run) => run.artifacts).filter((artifact) => artifact.kind === "openui-html").length
+			}
+			workspace={workspaceTree}
+			idPrefix={idPrefix}
+			compact={compact}
+		/>
+	);
 }
 
 /**
@@ -97,15 +80,15 @@ export function RightPanelTabsFromContext({
  * @param onOpen - Called when the button is clicked
  */
 export function RightPanelTrigger({ compact = false, onOpen }: { compact?: boolean; onOpen: () => void }) {
-  return (
-    <ChromePillButton
-      ariaLabel="Open side panel"
-      className={compact ? "!size-7 !rounded-[7px] !px-0" : "size-9 justify-center px-0"}
-      onClick={onOpen}
-    >
-      <PanelRight className="size-4" />
-    </ChromePillButton>
-  )
+	return (
+		<ChromePillButton
+			ariaLabel="Open side panel"
+			className={compact ? "!size-7 !rounded-[7px] !px-0" : "size-9 justify-center px-0"}
+			onClick={onOpen}
+		>
+			<PanelRight className="size-4" />
+		</ChromePillButton>
+	);
 }
 
 /**
@@ -122,96 +105,96 @@ export function RightPanelTrigger({ compact = false, onOpen }: { compact?: boole
  * @param compact - Whether to use compact launcher styling
  */
 export function RightPanelLauncher({
-  activePanel,
-  onPanelChange,
-  resources,
-  replRuns = 0,
-  sessionBlocks = 0,
-  openUIArtifacts = 0,
-  workspace,
-  idPrefix = "right-panel",
-  compact = false,
+	activePanel,
+	onPanelChange,
+	resources,
+	replRuns = 0,
+	sessionBlocks = 0,
+	openUIArtifacts = 0,
+	workspace,
+	idPrefix = "right-panel",
+	compact = false,
 }: {
-  activePanel: RightPanel
-  compact?: boolean
-  idPrefix?: string
-  onPanelChange: (panel: RightPanel) => void
-  resources: ChatResourcesResponse | null
-  replRuns?: number
-  /** Generative-UI blocks in the current session. */
-  sessionBlocks?: number
-  openUIArtifacts?: number
-  workspace: WorkspaceTreeResponse | null
+	activePanel: RightPanel;
+	compact?: boolean;
+	idPrefix?: string;
+	onPanelChange: (panel: RightPanel) => void;
+	resources: ChatResourcesResponse | null;
+	replRuns?: number;
+	/** Generative-UI blocks in the current session. */
+	sessionBlocks?: number;
+	openUIArtifacts?: number;
+	workspace: WorkspaceTreeResponse | null;
 }) {
-  const totalResources = getResourceGroups(resources, workspace).reduce(
-    (count, group) => count + group.items.length,
-    0
-  )
-  const totalArtifacts = useMemo(() => {
-    const total = sessionBlocks + openUIArtifacts
-    return total > 0 ? total : undefined
-  }, [openUIArtifacts, sessionBlocks])
+	const totalResources = getResourceGroups(resources, workspace).reduce(
+		(count, group) => count + group.items.length,
+		0,
+	);
+	const totalArtifacts = useMemo(() => {
+		const total = sessionBlocks + openUIArtifacts;
+		return total > 0 ? total : undefined;
+	}, [openUIArtifacts, sessionBlocks]);
 
-  const tabs = useMemo(
-    () =>
-      RIGHT_PANEL_LAUNCHER_DEFINITIONS.map((definition) => ({
-        ...definition,
-        badge:
-          definition.badgeSource === "resources"
-            ? totalResources || undefined
-            : definition.badgeSource === "artifacts"
-              ? totalArtifacts
-              : definition.badgeSource === "repl"
-                ? replRuns || undefined
-              : undefined,
-      })),
-    [replRuns, totalArtifacts, totalResources]
-  )
+	const tabs = useMemo(
+		() =>
+			RIGHT_PANEL_LAUNCHER_DEFINITIONS.map((definition) => ({
+				...definition,
+				badge:
+					definition.badgeSource === "resources"
+						? totalResources || undefined
+						: definition.badgeSource === "artifacts"
+							? totalArtifacts
+							: definition.badgeSource === "repl"
+								? replRuns || undefined
+								: undefined,
+			})),
+		[replRuns, totalArtifacts, totalResources],
+	);
 
-  const selectedIndex = tabs.findIndex((tab) => tab.id === activePanel)
-  const panelOptions = useMemo<Array<SelectOption>>(
-    () =>
-      tabs.map((tab) => ({
-        value: tab.id,
-        label: tab.title,
-        icon: tab.icon as LucideIcon,
-      })),
-    [tabs],
-  )
+	const selectedIndex = tabs.findIndex((tab) => tab.id === activePanel);
+	const panelOptions = useMemo<Array<SelectOption>>(
+		() =>
+			tabs.map((tab) => ({
+				value: tab.id,
+				label: tab.title,
+				icon: tab.icon as LucideIcon,
+			})),
+		[tabs],
+	);
 
-  return (
-    <ResponsivePanelLauncher
-      data-testid="right-panel-inline-launcher"
-      data-active-panel={activePanel ?? "closed"}
-      activePanel={activePanel}
-      options={panelOptions}
-      panelOptions={tabs}
-      idPrefix={idPrefix}
-      selectedIndex={selectedIndex}
-      onSelect={(index) => {
-        const next = tabs.at(index)?.id
-        if (!next) return
-        onPanelChange(next === activePanel ? null : next)
-      }}
-      compact={compact}
-    />
-  )
+	return (
+		<ResponsivePanelLauncher
+			data-testid="right-panel-inline-launcher"
+			data-active-panel={activePanel ?? "closed"}
+			activePanel={activePanel}
+			options={panelOptions}
+			panelOptions={tabs}
+			idPrefix={idPrefix}
+			selectedIndex={selectedIndex}
+			onSelect={(index) => {
+				const next = tabs.at(index)?.id;
+				if (!next) return;
+				onPanelChange(next === activePanel ? null : next);
+			}}
+			compact={compact}
+		/>
+	);
 }
 
 type PanelLauncherTab = (typeof RIGHT_PANEL_LAUNCHER_DEFINITIONS)[number] & {
-  badge?: number
-}
+	badge?: number;
+};
 
 type ResponsivePanelLauncherProps = Omit<HTMLAttributes<HTMLDivElement>, "className" | "onSelect"> & {
-  activePanel: RightPanel
-  className?: string
-  compact?: boolean
-  idPrefix: string
-  onSelect: (index: number) => void
-  options: Array<SelectOption>
-  panelOptions: Array<PanelLauncherTab>
-  selectedIndex: number
-}
+	activePanel: RightPanel;
+	className?: string;
+	compact?: boolean;
+	idPrefix: string;
+	onSelect: (index: number) => void;
+	options: Array<SelectOption>;
+	panelOptions: Array<PanelLauncherTab>;
+	selectedIndex: number;
+};
 
 /**
  * Renders panel navigation as tabs or a dropdown based on the available width.
@@ -219,256 +202,265 @@ type ResponsivePanelLauncherProps = Omit<HTMLAttributes<HTMLDivElement>, "classN
  * @returns The responsive panel launcher.
  */
 function ResponsivePanelLauncher({
-  activePanel,
-  className,
-  compact = false,
-  idPrefix,
-  onSelect,
-  options,
-  panelOptions,
-  selectedIndex,
-  ...props
+	activePanel,
+	className,
+	compact = false,
+	idPrefix,
+	onSelect,
+	options,
+	panelOptions,
+	selectedIndex,
+	...props
 }: ResponsivePanelLauncherProps) {
-  const containerRef = useRef<HTMLDivElement>(null)
-  const measurementRef = useRef<HTMLDivElement>(null)
-  const [isDropdown, setIsDropdown] = useState(false)
+	const containerRef = useRef<HTMLDivElement>(null);
+	const measurementRef = useRef<HTMLDivElement>(null);
+	const [isDropdown, setIsDropdown] = useState(false);
 
-  const measure = useCallback(() => {
-    const container = containerRef.current
-    const measurement = measurementRef.current
-    if (!container || !measurement) return
+	const measure = useCallback(() => {
+		const container = containerRef.current;
+		const measurement = measurementRef.current;
+		if (!container || !measurement) return;
 
-    const availableWidth = container.parentElement?.clientWidth ?? container.clientWidth
-    const requiredWidth = measurement.getBoundingClientRect().width
-    setIsDropdown(requiredWidth > availableWidth + 1)
-  }, [])
+		const parentWidth = container.parentElement?.clientWidth ?? 0;
+		const availableWidth = parentWidth > 0 ? parentWidth : container.clientWidth;
+		if (availableWidth <= 0) return;
 
-  useLayoutEffect(() => {
-    measure()
-    const container = containerRef.current
-    const measurement = measurementRef.current
-    if (!container || !measurement || typeof ResizeObserver === "undefined") return
+		const inner = measurement.firstElementChild;
+		const requiredWidth = Math.max(
+			measurement.scrollWidth,
+			inner instanceof HTMLElement ? inner.scrollWidth : 0,
+			measurement.getBoundingClientRect().width,
+			inner instanceof HTMLElement ? inner.getBoundingClientRect().width : 0,
+		);
+		if (requiredWidth <= 0) return;
 
-    const observer = new ResizeObserver(measure)
-    if (container.parentElement) observer.observe(container.parentElement)
-    observer.observe(container)
-    observer.observe(measurement)
-    return () => observer.disconnect()
-  }, [measure, panelOptions, selectedIndex])
+		setIsDropdown(requiredWidth > availableWidth + 1);
+	}, []);
 
-  const selectPanel = useCallback(
-    (nextPanel: string) => {
-      const nextIndex = panelOptions.findIndex((panel) => panel.id === nextPanel)
-      if (nextIndex >= 0) onSelect(nextIndex)
-    },
-    [onSelect, panelOptions],
-  )
+	useLayoutEffect(() => {
+		measure();
+		const container = containerRef.current;
+		const measurement = measurementRef.current;
+		if (!container || !measurement || typeof ResizeObserver === "undefined") return;
 
-  return (
-    <div
-      ref={containerRef}
-      className={`relative ${isDropdown ? "w-full" : "w-fit"} min-w-0 max-w-full overflow-hidden ${className ?? ""}`}
-      data-panel-launcher-mode={isDropdown ? "dropdown" : "tabs"}
-      {...props}
-    >
-      {isDropdown ? (
-        <Select
-          aria-label="Select panel"
-          className={`w-full min-w-0 max-w-full rounded-full border-border/70 bg-sidebar ${compact ? "h-7" : ""}`}
-          onValueChange={selectPanel}
-          options={options}
-          placeholder="Open panel"
-          value={activePanel}
-        />
-      ) : (
-        <TabsSubtle
-          activeLabel
-          className={`w-fit max-w-full ${compact ? COMPACT_TABS_CLASS : ""}`}
-          idPrefix={idPrefix}
-          selectedIndex={selectedIndex}
-          onSelect={onSelect}
-        >
-          {panelOptions.map((panel, index) => (
-            <TabsSubtleItem
-              key={panel.id}
-              index={index}
-              icon={panel.icon}
-              label={panel.title}
-              badge={panel.badge}
-              aria-label={panel.ariaLabel}
-            />
-          ))}
-        </TabsSubtle>
-      )}
-      <div
-        ref={measurementRef}
-        aria-hidden="true"
-        className="pointer-events-none invisible absolute top-0 left-0 -z-10 h-0 w-max max-w-none overflow-hidden"
-        data-panel-launcher-measurement
-        inert
-      >
-        <TabsSubtle
-          activeLabel
-          className={`w-max max-w-none ${compact ? COMPACT_TABS_CLASS : ""}`}
-          idPrefix={`${idPrefix}-measurement`}
-          selectedIndex={selectedIndex}
-          onSelect={() => undefined}
-        >
-          {panelOptions.map((panel, index) => (
-            <TabsSubtleItem
-              key={panel.id}
-              index={index}
-              icon={panel.icon}
-              label={panel.title}
-              badge={panel.badge}
-              aria-label={panel.ariaLabel}
-            />
-          ))}
-        </TabsSubtle>
-      </div>
-    </div>
-  )
+		const observer = new ResizeObserver(measure);
+		if (container.parentElement) observer.observe(container.parentElement);
+		observer.observe(container);
+		observer.observe(measurement);
+		return () => observer.disconnect();
+	}, [measure, panelOptions, selectedIndex]);
+
+	const selectPanel = useCallback(
+		(nextPanel: string) => {
+			const nextIndex = panelOptions.findIndex((panel) => panel.id === nextPanel);
+			if (nextIndex >= 0) onSelect(nextIndex);
+		},
+		[onSelect, panelOptions],
+	);
+
+	return (
+		<div
+			ref={containerRef}
+			className={`relative ${isDropdown ? "w-full" : "w-fit"} min-w-0 max-w-full overflow-hidden ${className ?? ""}`}
+			data-panel-launcher-mode={isDropdown ? "dropdown" : "tabs"}
+			{...props}
+		>
+			{isDropdown ? (
+				<Select
+					aria-label="Select panel"
+					className={`w-full min-w-0 max-w-full rounded-full border-border/70 bg-sidebar ${compact ? "h-7" : ""}`}
+					onValueChange={selectPanel}
+					options={options}
+					placeholder="Open panel"
+					value={activePanel}
+				/>
+			) : (
+				<TabsSubtle
+					activeLabel
+					className={`w-fit max-w-full ${compact ? COMPACT_TABS_CLASS : ""}`}
+					idPrefix={idPrefix}
+					selectedIndex={selectedIndex}
+					onSelect={onSelect}
+				>
+					{panelOptions.map((panel, index) => (
+						<TabsSubtleItem
+							key={panel.id}
+							index={index}
+							icon={panel.icon}
+							label={panel.title}
+							badge={panel.badge}
+							aria-label={panel.ariaLabel}
+						/>
+					))}
+				</TabsSubtle>
+			)}
+			<div
+				ref={measurementRef}
+				aria-hidden="true"
+				className="pointer-events-none invisible absolute top-0 left-0 -z-10 w-max max-w-none"
+				data-panel-launcher-measurement
+				inert
+			>
+				<TabsSubtle
+					activeLabel
+					className={`w-max max-w-none ${compact ? COMPACT_TABS_CLASS : ""}`}
+					idPrefix={`${idPrefix}-measurement`}
+					selectedIndex={selectedIndex}
+					onSelect={() => undefined}
+				>
+					{panelOptions.map((panel, index) => (
+						<TabsSubtleItem
+							key={panel.id}
+							index={index}
+							icon={panel.icon}
+							label={panel.title}
+							badge={panel.badge}
+							aria-label={panel.ariaLabel}
+						/>
+					))}
+				</TabsSubtle>
+			</div>
+		</div>
+	);
 }
 
 export function MobilePanel({
-  children,
-  dataTestid,
-  headerActions,
-  icon: Icon,
-  onClose,
-  open,
-  title,
+	children,
+	dataTestid,
+	headerActions,
+	icon: Icon,
+	onClose,
+	open,
+	title,
 }: {
-  children: ReactNode
-  dataTestid?: string
-  headerActions?: ReactNode
-  icon?: React.ElementType
-  onClose?: () => void
-  open: boolean
-  title?: string
+	children: ReactNode;
+	dataTestid?: string;
+	headerActions?: ReactNode;
+	icon?: React.ElementType;
+	onClose?: () => void;
+	open: boolean;
+	title?: string;
 }) {
-  const panelRef = useRef<HTMLDialogElement>(null)
-  const panelTitleId = useId()
-  // When the desktop ResizableCanvas owns the panel, we must keep this dialog
-  // out of the browser top layer. Closing it for that reason must not bubble
-  // into the shared `onClose` (which would also dismiss the desktop panel).
-  const suppressCloseRef = useRef(false)
+	const panelRef = useRef<HTMLDialogElement>(null);
+	const panelTitleId = useId();
+	// When the desktop ResizableCanvas owns the panel, we must keep this dialog
+	// out of the browser top layer. Closing it for that reason must not bubble
+	// into the shared `onClose` (which would also dismiss the desktop panel).
+	const suppressCloseRef = useRef(false);
 
-  // Light dismiss — the full-viewport ::backdrop region maps clicks onto the
-  // dialog element, matching the previous bottom sheet-style backdrop button.
-  // Close the native dialog (instead of notifying directly) so the browser
-  // runs modal focus restoration; the dialog onClose handler notifies.
-  const onLightDismiss = useEffectEvent((event: MouseEvent) => {
-    if (panelRef.current && event.target === panelRef.current) panelRef.current.close()
-  })
+	// Light dismiss — the full-viewport ::backdrop region maps clicks onto the
+	// dialog element, matching the previous bottom sheet-style backdrop button.
+	// Close the native dialog (instead of notifying directly) so the browser
+	// runs modal focus restoration; the dialog onClose handler notifies.
+	const onLightDismiss = useEffectEvent((event: MouseEvent) => {
+		if (panelRef.current && event.target === panelRef.current) panelRef.current.close();
+	});
 
-  // Header X-close must close the native dialog first so the browser restores
-  // focus to the previously focused element (the Esc path already closes
-  // natively); the dialog onClose handler then notifies the parent. When the
-  // native dialog is already closed (desktop mode), notify directly.
-  const handleHeaderClose = () => {
-    const dialog = panelRef.current
-    if (dialog && dialog.open) dialog.close()
-    else onClose?.()
-  }
+	// Header X-close must close the native dialog first so the browser restores
+	// focus to the previously focused element (the Esc path already closes
+	// natively); the dialog onClose handler then notifies the parent. When the
+	// native dialog is already closed (desktop mode), notify directly.
+	const handleHeaderClose = () => {
+		const dialog = panelRef.current;
+		if (dialog && dialog.open) dialog.close();
+		else onClose?.();
+	};
 
-  useEffect(() => {
-    if (!open) return
-    const dialog = panelRef.current
-    if (!dialog) return
-    const handler = (event: MouseEvent) => onLightDismiss(event)
-    dialog.addEventListener("click", handler)
-    return () => dialog.removeEventListener("click", handler)
-  }, [open])
+	useEffect(() => {
+		if (!open) return;
+		const dialog = panelRef.current;
+		if (!dialog) return;
+		const handler = (event: MouseEvent) => onLightDismiss(event);
+		dialog.addEventListener("click", handler);
+		return () => dialog.removeEventListener("click", handler);
+	}, [open]);
 
-  useEffect(() => {
-    const dialog = panelRef.current
-    if (!dialog) return
+	useEffect(() => {
+		const dialog = panelRef.current;
+		if (!dialog) return;
 
-    if (!open) {
-      if (dialog.open) {
-        suppressCloseRef.current = true
-        dialog.close()
-        suppressCloseRef.current = false
-      }
-      return
-    }
+		if (!open) {
+			if (dialog.open) {
+				suppressCloseRef.current = true;
+				dialog.close();
+				suppressCloseRef.current = false;
+			}
+			return;
+		}
 
-    const media = window.matchMedia(`(min-width: ${CHAT_PANEL_BREAKPOINT_PX}px)`)
+		const media = window.matchMedia(`(min-width: ${CHAT_PANEL_BREAKPOINT_PX}px)`);
 
-    const syncMode = () => {
-      // Desktop (>=960px): ResizableCanvas renders the panel. A CSS-hidden
-      // showModal() dialog still occupies the top layer and intercepts clicks
-      // on the header tabs / chat chrome — so close it without notifying.
-      if (media.matches) {
-        if (dialog.open) {
-          suppressCloseRef.current = true
-          dialog.close()
-          // HTMLDialogElement.close() fires the `close` event asynchronously
-          // (queued task per the WHATWG spec), so leave the flag set — the
-          // onClose handler consumes it to avoid dismissing the desktop panel.
-        }
-        return
-      }
-      if (!dialog.open) {
-        dialog.showModal()
-        dialog.focus()
-      }
-    }
+		const syncMode = () => {
+			// Desktop (>=960px): ResizableCanvas renders the panel. A CSS-hidden
+			// showModal() dialog still occupies the top layer and intercepts clicks
+			// on the header tabs / chat chrome — so close it without notifying.
+			if (media.matches) {
+				if (dialog.open) {
+					suppressCloseRef.current = true;
+					dialog.close();
+					// HTMLDialogElement.close() fires the `close` event asynchronously
+					// (queued task per the WHATWG spec), so leave the flag set — the
+					// onClose handler consumes it to avoid dismissing the desktop panel.
+				}
+				return;
+			}
+			if (!dialog.open) {
+				dialog.showModal();
+				dialog.focus();
+			}
+		};
 
-    syncMode()
-    media.addEventListener("change", syncMode)
-    return () => media.removeEventListener("change", syncMode)
-  }, [open])
+		syncMode();
+		media.addEventListener("change", syncMode);
+		return () => media.removeEventListener("change", syncMode);
+	}, [open]);
 
-  if (!open) return null
+	if (!open) return null;
 
-  return (
-    <dialog
-      ref={panelRef}
-      data-testid={dataTestid}
-      className={`fixed top-[var(--chat-chrome-top)] right-3 bottom-3 m-0 ${PANEL_OVERLAY_CLASS} backdrop:bg-black/20 ${DESKTOP_PANEL_ONLY}`}
-      aria-labelledby={panelTitleId}
-      onClose={() => {
-        if (suppressCloseRef.current) {
-          suppressCloseRef.current = false
-          return
-        }
-        onClose?.()
-      }}
-    >
-      <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
-        <span id={panelTitleId} className="sr-only">
-          {title ?? "Panel"}
-        </span>
-        {title && (
-          <div className="flex h-10 shrink-0 items-center justify-between gap-2 border-b border-border/60 px-3">
-            <div className="flex min-w-0 items-center gap-2 text-[0.8125rem] font-medium text-foreground/80">
-              {Icon && <Icon className="size-3.5 shrink-0" />}
-              <span className="truncate">{title}</span>
-            </div>
-            <div className="flex shrink-0 items-center gap-1">
-              {headerActions}
-              {onClose && (
-                <Button
-                  type="button"
-                  onClick={handleHeaderClose}
-                  variant="ghost"
-                  size="icon-sm"
-                  className={`${HIT_AREA_EXPAND_CLASS} text-foreground/40 hover:text-foreground/70`}
-                  aria-label="Close panel"
-                  title="Close panel"
-                >
-                  <X data-icon="inline-start" className="size-3.5" />
-                </Button>
-              )}
-            </div>
-          </div>
-        )}
-        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 py-2">
-          {children}
-        </div>
-      </div>
-    </dialog>
-  )
+	return (
+		<dialog
+			ref={panelRef}
+			data-testid={dataTestid}
+			className={`fixed top-[var(--chat-chrome-top)] right-3 bottom-3 m-0 ${PANEL_OVERLAY_CLASS} backdrop:bg-black/20 ${DESKTOP_PANEL_ONLY}`}
+			aria-labelledby={panelTitleId}
+			onClose={() => {
+				if (suppressCloseRef.current) {
+					suppressCloseRef.current = false;
+					return;
+				}
+				onClose?.();
+			}}
+		>
+			<div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
+				<span id={panelTitleId} className="sr-only">
+					{title ?? "Panel"}
+				</span>
+				{title && (
+					<div className="flex h-10 shrink-0 items-center justify-between gap-2 border-b border-border/60 px-3">
+						<div className="flex min-w-0 items-center gap-2 text-[0.8125rem] font-medium text-foreground/80">
+							{Icon && <Icon className="size-3.5 shrink-0" />}
+							<span className="truncate">{title}</span>
+						</div>
+						<div className="flex shrink-0 items-center gap-1">
+							{headerActions}
+							{onClose && (
+								<Button
+									type="button"
+									onClick={handleHeaderClose}
+									variant="ghost"
+									size="icon-sm"
+									className={`${HIT_AREA_EXPAND_CLASS} text-foreground/40 hover:text-foreground/70`}
+									aria-label="Close panel"
+									title="Close panel"
+								>
+									<X data-icon="inline-start" className="size-3.5" />
+								</Button>
+							)}
+						</div>
+					</div>
+				)}
+				<div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 py-2">{children}</div>
+			</div>
+		</dialog>
+	);
 }

--- a/web/design/src/components/product/fleet-pi/pi/workspace-panel.tsx
+++ b/web/design/src/components/product/fleet-pi/pi/workspace-panel.tsx
@@ -182,7 +182,7 @@ export function WorkspacePanelContent({
 			window.clearTimeout(timeoutId);
 			controller.abort();
 		};
-	}, [loadWorkspaceFile, selectedPath]);
+	}, [loadWorkspaceFile, selectedPath, workspace]);
 
 	useEffect(() => {
 		if (!selectedPath || typeof window === "undefined") return;

--- a/web/design/src/components/product/fleet-pi/pi/workspace-panel.tsx
+++ b/web/design/src/components/product/fleet-pi/pi/workspace-panel.tsx
@@ -1,392 +1,362 @@
-import {
-  CircleAlert,
-  FileText,
-  HardDrive,
-} from "lucide-react"
-import { useEffect, useMemo, useRef, useState } from "react"
-import { Markdown } from "../../../registry/beui/agents/markdown"
-import {
-  FileTree,
-  FileTreeFile,
-  FileTreeFolder,
-} from "../../../registry/beui/motion/file-tree"
-import {
-  CHAT_PANEL_BREAKPOINT_PX,
-  WORKSPACE_SPLIT_GAP_RESET,
-  WORKSPACE_SPLIT_HIDDEN_BLOCK,
-} from "../../../../lib/layout-constants"
-import { isPathWithinScope } from "../../../../lib/workspace-path-nav"
-import { isDaytonaNotConnectedError } from "../../../../lib/pi/chat-helpers"
-import { useWorkspaceSplitLayout } from "./hooks/use-workspace-split-layout"
-import { ResourceChipSection, ResourceNotice } from "./shared"
-import { findWorkspaceNode } from "./resource-helpers"
-import { WorkspacePreviewSkeleton, WorkspaceSkeleton } from "./skeleton-loaders"
-import type { ReactNode, RefObject } from "react"
 import type {
-  WorkspaceFileResponse,
-  WorkspaceTreeNode,
-  WorkspaceTreeResponse,
-} from "@prime-agent/web-protocol/chat-protocol"
+	WorkspaceFileResponse,
+	WorkspaceTreeNode,
+	WorkspaceTreeResponse,
+} from "@prime-agent/web-protocol/chat-protocol";
+import { CircleAlert, FileText, HardDrive } from "lucide-react";
+import type { ReactNode, RefObject } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+	CHAT_PANEL_BREAKPOINT_PX,
+	WORKSPACE_SPLIT_GAP_RESET,
+	WORKSPACE_SPLIT_HIDDEN_BLOCK,
+} from "../../../../lib/layout-constants";
+import { isDaytonaNotConnectedError } from "../../../../lib/pi/chat-helpers";
+import { isPathWithinScope } from "../../../../lib/workspace-path-nav";
+import { Markdown } from "../../../registry/beui/agents/markdown";
+import { FileTree, FileTreeFile, FileTreeFolder } from "../../../registry/beui/motion/file-tree";
+import { useWorkspaceSplitLayout } from "./hooks/use-workspace-split-layout";
+import { findWorkspaceNode } from "./resource-helpers";
+import { ResourceChipSection, ResourceNotice } from "./shared";
+import { WorkspacePreviewSkeleton, WorkspaceSkeleton } from "./skeleton-loaders";
 
-export type WorkspacePanelContentProps = {
-  error?: Error | null
-  emptyDescription?: string
-  emptyTitle?: string
-  loadWorkspaceFile: (path: string) => Promise<WorkspaceFileResponse>
-  loading: boolean
-  onSelectedPathChange?: (path: string | null) => void
-  previewEmptyDescription?: string
-  previewEmptyTitle?: string
-  scopePath?: string
-  scopeLabel?: string
-  selectedPath?: string | null
-  treeTestId?: string
-  workspace: WorkspaceTreeResponse | null
+export const WORKSPACE_PREVIEW_TIMEOUT_MS = 15_000;
+
+function previewLoadError(err: unknown): Error {
+	if (err instanceof DOMException && err.name === "AbortError") {
+		return new Error("Preview timed out");
+	}
+	if (err instanceof Error) {
+		if (err.name === "AbortError" || /aborted|timed out/i.test(err.message)) {
+			return new Error("Preview timed out");
+		}
+		return err;
+	}
+	return new Error(String(err));
 }
 
+export type WorkspacePanelContentProps = {
+	error?: Error | null;
+	emptyDescription?: string;
+	emptyTitle?: string;
+	loadWorkspaceFile: (path: string) => Promise<WorkspaceFileResponse>;
+	loading: boolean;
+	onSelectedPathChange?: (path: string | null) => void;
+	previewEmptyDescription?: string;
+	previewEmptyTitle?: string;
+	scopePath?: string;
+	scopeLabel?: string;
+	selectedPath?: string | null;
+	treeTestId?: string;
+	workspace: WorkspaceTreeResponse | null;
+};
+
 export function WorkspacePanelContent({
-  error,
-  emptyDescription = "agent-workspace has not been loaded yet.",
-  emptyTitle = "Workspace unavailable",
-  loadWorkspaceFile,
-  loading,
-  onSelectedPathChange,
-  previewEmptyDescription = "Choose a workspace file to preview its Markdown.",
-  previewEmptyTitle = "Select a file",
-  scopePath,
-  scopeLabel,
-  selectedPath: selectedPathProp,
-  treeTestId = "workspace-tree",
-  workspace,
+	error,
+	emptyDescription = "agent-workspace has not been loaded yet.",
+	emptyTitle = "Workspace unavailable",
+	loadWorkspaceFile,
+	loading,
+	onSelectedPathChange,
+	previewEmptyDescription = "Choose a workspace file to preview its Markdown.",
+	previewEmptyTitle = "Select a file",
+	scopePath,
+	scopeLabel,
+	selectedPath: selectedPathProp,
+	treeTestId = "workspace-tree",
+	workspace,
 }: WorkspacePanelContentProps) {
-  const [internalSelectedPath, setInternalSelectedPath] = useState<
-    string | null
-  >(null)
-  const isControlled = onSelectedPathChange !== undefined
-  const selectedPath = isControlled
-    ? (selectedPathProp ?? null)
-    : internalSelectedPath
-  const setSelectedPath = (path: string | null) => {
-    if (isControlled) {
-      onSelectedPathChange(path)
-      return
-    }
-    setInternalSelectedPath(path)
-  }
-  const [preview, setPreview] = useState<WorkspaceFileResponse | null>(null)
-  const [previewError, setPreviewError] = useState<Error | null>(null)
-  const [previewLoading, setPreviewLoading] = useState(false)
-  const previewRef = useRef<HTMLDivElement | null>(null)
-  const { handleTreeResizeStart, splitRef, splitStyle } =
-    useWorkspaceSplitLayout(workspace)
+	const [internalSelectedPath, setInternalSelectedPath] = useState<string | null>(null);
+	const isControlled = onSelectedPathChange !== undefined;
+	const selectedPath = isControlled ? (selectedPathProp ?? null) : internalSelectedPath;
+	const setSelectedPath = (path: string | null) => {
+		if (isControlled) {
+			onSelectedPathChange(path);
+			return;
+		}
+		setInternalSelectedPath(path);
+	};
+	const [preview, setPreview] = useState<WorkspaceFileResponse | null>(null);
+	const [previewError, setPreviewError] = useState<Error | null>(null);
+	const [previewLoading, setPreviewLoading] = useState(false);
+	const previewRef = useRef<HTMLDivElement | null>(null);
+	const { handleTreeResizeStart, splitRef, splitStyle } = useWorkspaceSplitLayout(workspace);
 
-  const scopedView = useMemo(() => {
-    if (!workspace) {
-      return {
-        headerLabel: scopeLabel ?? "agent-workspace",
-        nodes: [] as Array<WorkspaceTreeNode>,
-      }
-    }
+	const scopedView = useMemo(() => {
+		if (!workspace) {
+			return {
+				headerLabel: scopeLabel ?? "agent-workspace",
+				nodes: [] as Array<WorkspaceTreeNode>,
+			};
+		}
 
-    if (!scopePath) {
-      return {
-        headerLabel: workspace.root,
-        nodes: workspace.nodes,
-      }
-    }
+		if (!scopePath) {
+			return {
+				headerLabel: workspace.root,
+				nodes: workspace.nodes,
+			};
+		}
 
-    const scopedNode = findWorkspaceNode(workspace.nodes, scopePath)
-    if (!scopedNode) {
-      return {
-        headerLabel: scopeLabel ?? scopePath.split("/").pop() ?? scopePath,
-        nodes: [] as Array<WorkspaceTreeNode>,
-      }
-    }
+		const scopedNode = findWorkspaceNode(workspace.nodes, scopePath);
+		if (!scopedNode) {
+			return {
+				headerLabel: scopeLabel ?? scopePath.split("/").pop() ?? scopePath,
+				nodes: [] as Array<WorkspaceTreeNode>,
+			};
+		}
 
-    if (scopedNode.type === "directory") {
-      return {
-        headerLabel: scopeLabel ?? scopedNode.name,
-        nodes: scopedNode.children ?? [],
-      }
-    }
+		if (scopedNode.type === "directory") {
+			return {
+				headerLabel: scopeLabel ?? scopedNode.name,
+				nodes: scopedNode.children ?? [],
+			};
+		}
 
-    return {
-      headerLabel: scopeLabel ?? scopedNode.name,
-      nodes: [scopedNode],
-    }
-  }, [scopeLabel, scopePath, workspace])
+		return {
+			headerLabel: scopeLabel ?? scopedNode.name,
+			nodes: [scopedNode],
+		};
+	}, [scopeLabel, scopePath, workspace]);
 
-  useEffect(() => {
-    if (!workspace || !selectedPath) return
+	useEffect(() => {
+		if (!workspace || !selectedPath) return;
 
-    if (scopePath && !isPathWithinScope(selectedPath, scopePath)) {
-      setSelectedPath(null)
-      setPreview(null)
-      setPreviewError(null)
-      return
-    }
+		if (scopePath && !isPathWithinScope(selectedPath, scopePath)) {
+			setSelectedPath(null);
+			setPreview(null);
+			setPreviewError(null);
+			return;
+		}
 
-    if (findWorkspaceNode(workspace.nodes, selectedPath)?.type === "file") {
-      return
-    }
+		if (findWorkspaceNode(workspace.nodes, selectedPath)?.type === "file") {
+			return;
+		}
 
-    setSelectedPath(null)
-    setPreview(null)
-    setPreviewError(null)
-  }, [onSelectedPathChange, scopePath, selectedPath, workspace])
+		setSelectedPath(null);
+		setPreview(null);
+		setPreviewError(null);
+	}, [onSelectedPathChange, scopePath, selectedPath, workspace]);
 
-  useEffect(() => {
-    if (!selectedPath) return
+	useEffect(() => {
+		if (!selectedPath) {
+			setPreviewLoading(false);
+			return;
+		}
 
-    let cancelled = false
-    async function loadPreview() {
-      setPreviewLoading(true)
-      setPreviewError(null)
-      try {
-        const body = await loadWorkspaceFile(selectedPath ?? "")
-        if (!cancelled) setPreview(body)
-      } catch (err) {
-        if (!cancelled) {
-          setPreview(null)
-          setPreviewError(err instanceof Error ? err : new Error(String(err)))
-        }
-      } finally {
-        if (!cancelled) setPreviewLoading(false)
-      }
-    }
+		const selected = selectedPath;
+		const controller = new AbortController();
+		const timeoutId = window.setTimeout(() => controller.abort(), WORKSPACE_PREVIEW_TIMEOUT_MS);
+		let cancelled = false;
 
-    void loadPreview()
-    return () => {
-      cancelled = true
-    }
-  }, [loadWorkspaceFile, selectedPath, workspace])
+		setPreview((current) => (current?.path === selected ? current : null));
+		setPreviewLoading(true);
+		setPreviewError(null);
 
-  useEffect(() => {
-    if (!selectedPath || typeof window === "undefined") return
-    if (
-      window.matchMedia(`(min-width: ${CHAT_PANEL_BREAKPOINT_PX}px)`).matches
-    ) {
-      return
-    }
+		void (async () => {
+			try {
+				const body = await Promise.race([
+					loadWorkspaceFile(selected),
+					new Promise<never>((_, reject) => {
+						const onAbort = () => reject(new DOMException("Preview timed out", "AbortError"));
+						if (controller.signal.aborted) {
+							onAbort();
+							return;
+						}
+						controller.signal.addEventListener("abort", onAbort, { once: true });
+					}),
+				]);
+				if (cancelled) return;
+				setPreview(body);
+				setPreviewError(null);
+			} catch (err) {
+				if (cancelled) return;
+				setPreview(null);
+				setPreviewError(previewLoadError(err));
+			} finally {
+				if (!cancelled) setPreviewLoading(false);
+			}
+		})();
 
-    const frame = window.requestAnimationFrame(() => {
-      previewRef.current?.scrollIntoView({
-        block: "start",
-        inline: "nearest",
-        behavior: "auto",
-      })
-    })
+		return () => {
+			cancelled = true;
+			window.clearTimeout(timeoutId);
+			controller.abort();
+		};
+	}, [loadWorkspaceFile, selectedPath]);
 
-    return () => window.cancelAnimationFrame(frame)
-  }, [selectedPath])
+	useEffect(() => {
+		if (!selectedPath || typeof window === "undefined") return;
+		if (window.matchMedia(`(min-width: ${CHAT_PANEL_BREAKPOINT_PX}px)`).matches) {
+			return;
+		}
 
-  if (error) {
-    if (isDaytonaNotConnectedError(error)) {
-      return (
-        <ResourceNotice
-          icon={CircleAlert}
-          title="Daytona not connected"
-          description="Connect a Daytona API key for your account to browse and preview your agent workspace."
-        />
-      )
-    }
-    return (
-      <ResourceNotice
-        icon={CircleAlert}
-        title="Unable to load workspace"
-        description={error.message}
-      />
-    )
-  }
+		const frame = window.requestAnimationFrame(() => {
+			previewRef.current?.scrollIntoView({
+				block: "start",
+				inline: "nearest",
+				behavior: "auto",
+			});
+		});
 
-  if (loading && !workspace) {
-    return <WorkspaceSkeleton />
-  }
+		return () => window.cancelAnimationFrame(frame);
+	}, [selectedPath]);
 
-  if (!workspace) {
-    return (
-      <ResourceNotice
-        icon={HardDrive}
-        title={emptyTitle}
-        description={emptyDescription}
-      />
-    )
-  }
+	if (error) {
+		if (isDaytonaNotConnectedError(error)) {
+			return (
+				<ResourceNotice
+					icon={CircleAlert}
+					title="Daytona not connected"
+					description="Connect a Daytona API key for your account to browse and preview your agent workspace."
+				/>
+			);
+		}
+		return <ResourceNotice icon={CircleAlert} title="Unable to load workspace" description={error.message} />;
+	}
 
-  if (scopePath && scopedView.nodes.length === 0) {
-    return (
-      <ResourceNotice
-        icon={HardDrive}
-        title={emptyTitle}
-        description={emptyDescription}
-      />
-    )
-  }
+	if (loading && !workspace) {
+		return <WorkspaceSkeleton />;
+	}
 
-  return (
-    <div
-      ref={splitRef}
-      className={`relative grid h-full min-h-0 grid-cols-1 gap-2 overflow-hidden ${WORKSPACE_SPLIT_GAP_RESET}`}
-      style={splitStyle}
-    >
-      <div className="flex min-h-0 min-w-0 flex-col overflow-hidden">
-        <div
-          data-testid={treeTestId}
-          className="min-h-0 min-w-0 flex-1 overflow-y-auto"
-        >
-          <div className="mb-2 flex min-w-0 items-center gap-2 rounded-sm bg-foreground/5 px-2 py-1.5">
-            <HardDrive className="size-3.5 shrink-0 text-foreground/45" />
-            <span className="min-w-0 flex-1 truncate text-label font-medium text-foreground/70">
-              {scopedView.headerLabel}
-            </span>
-          </div>
-          <FileTree
-            ariaLabel={
-              scopePath
-                ? `Files in ${scopedView.headerLabel}`
-                : "Workspace files"
-            }
-            className="gap-0.5"
-            classNames={{
-              item:
-                "h-8 gap-1.5 rounded-sm text-label font-normal text-foreground/65 hover:bg-foreground/5 hover:text-foreground/80 aria-selected:bg-foreground/8 aria-selected:text-foreground/80",
-              icon: "size-3.5 text-foreground/35",
-              label: "text-label",
-            }}
-            value={selectedPath}
-            onValueChange={(path) => {
-              if (findWorkspaceNode(workspace.nodes, path)?.type === "file") {
-                setSelectedPath(path)
-              }
-            }}
-          >
-            {scopedView.nodes.map((node) => renderWorkspaceNode(node))}
-          </FileTree>
-          {workspace.diagnostics.length > 0 && !scopePath && (
-            <div className="mt-2 border-t border-border/60 pt-2">
-              <ResourceChipSection
-                id="workspace-diagnostics"
-                label="Diagnostics"
-                icon={CircleAlert}
-                items={workspace.diagnostics.map((diagnostic, index) => ({
-                  name: `Diagnostic ${index + 1}`,
-                  description: diagnostic,
-                }))}
-              />
-            </div>
-          )}
-        </div>
-      </div>
-      <button
-        type="button"
-        aria-label="Resize workspace tree"
-        className={`min-h-0 cursor-col-resize touch-none bg-transparent transition-colors outline-none hover:bg-foreground/10 focus-visible:bg-foreground/10 ${WORKSPACE_SPLIT_HIDDEN_BLOCK}`}
-        data-testid="workspace-tree-resize-handle"
-        onPointerDown={handleTreeResizeStart}
-      />
-      <WorkspacePreview
-        emptyDescription={previewEmptyDescription}
-        emptyTitle={previewEmptyTitle}
-        error={previewError}
-        loading={previewLoading}
-        preview={preview}
-        previewRef={previewRef}
-        selectedPath={selectedPath}
-      />
-    </div>
-  )
+	if (!workspace) {
+		return <ResourceNotice icon={HardDrive} title={emptyTitle} description={emptyDescription} />;
+	}
+
+	if (scopePath && scopedView.nodes.length === 0) {
+		return <ResourceNotice icon={HardDrive} title={emptyTitle} description={emptyDescription} />;
+	}
+
+	return (
+		<div
+			ref={splitRef}
+			className={`relative grid h-full min-h-0 grid-cols-1 gap-2 overflow-hidden ${WORKSPACE_SPLIT_GAP_RESET}`}
+			style={splitStyle}
+		>
+			<div className="flex min-h-0 min-w-0 flex-col overflow-hidden">
+				<div data-testid={treeTestId} className="min-h-0 min-w-0 flex-1 overflow-y-auto">
+					<div className="mb-2 flex min-w-0 items-center gap-2 rounded-sm bg-foreground/5 px-2 py-1.5">
+						<HardDrive className="size-3.5 shrink-0 text-foreground/45" />
+						<span className="min-w-0 flex-1 truncate text-label font-medium text-foreground/70">
+							{scopedView.headerLabel}
+						</span>
+					</div>
+					<FileTree
+						ariaLabel={scopePath ? `Files in ${scopedView.headerLabel}` : "Workspace files"}
+						className="gap-0.5"
+						classNames={{
+							item: "h-8 gap-1.5 rounded-sm text-label font-normal text-foreground/65 hover:bg-foreground/5 hover:text-foreground/80 aria-selected:bg-foreground/8 aria-selected:text-foreground/80",
+							icon: "size-3.5 text-foreground/35",
+							label: "text-label",
+						}}
+						value={selectedPath}
+						onValueChange={(path) => {
+							if (findWorkspaceNode(workspace.nodes, path)?.type === "file") {
+								setSelectedPath(path);
+							}
+						}}
+					>
+						{scopedView.nodes.map((node) => renderWorkspaceNode(node))}
+					</FileTree>
+					{workspace.diagnostics.length > 0 && !scopePath && (
+						<div className="mt-2 border-t border-border/60 pt-2">
+							<ResourceChipSection
+								id="workspace-diagnostics"
+								label="Diagnostics"
+								icon={CircleAlert}
+								items={workspace.diagnostics.map((diagnostic, index) => ({
+									name: `Diagnostic ${index + 1}`,
+									description: diagnostic,
+								}))}
+							/>
+						</div>
+					)}
+				</div>
+			</div>
+			<button
+				type="button"
+				aria-label="Resize workspace tree"
+				className={`min-h-0 cursor-col-resize touch-none bg-transparent transition-colors outline-none hover:bg-foreground/10 focus-visible:bg-foreground/10 ${WORKSPACE_SPLIT_HIDDEN_BLOCK}`}
+				data-testid="workspace-tree-resize-handle"
+				onPointerDown={handleTreeResizeStart}
+			/>
+			<WorkspacePreview
+				emptyDescription={previewEmptyDescription}
+				emptyTitle={previewEmptyTitle}
+				error={previewError}
+				loading={previewLoading}
+				preview={preview}
+				previewRef={previewRef}
+				selectedPath={selectedPath}
+			/>
+		</div>
+	);
 }
 
 function renderWorkspaceNode(node: WorkspaceTreeNode): ReactNode {
-  if (node.type === "directory") {
-    return (
-      <FileTreeFolder key={node.path} value={node.path} name={node.name}>
-        {node.children?.map((child) => renderWorkspaceNode(child))}
-      </FileTreeFolder>
-    )
-  }
+	if (node.type === "directory") {
+		return (
+			<FileTreeFolder key={node.path} value={node.path} name={node.name}>
+				{node.children?.map((child) => renderWorkspaceNode(child))}
+			</FileTreeFolder>
+		);
+	}
 
-  return (
-    <FileTreeFile key={node.path} value={node.path} name={node.name} />
-  )
+	return <FileTreeFile key={node.path} value={node.path} name={node.name} />;
 }
 
 function WorkspacePreview({
-  emptyDescription,
-  emptyTitle,
-  error,
-  loading,
-  preview,
-  previewRef,
-  selectedPath,
+	emptyDescription,
+	emptyTitle,
+	error,
+	loading,
+	preview,
+	previewRef,
+	selectedPath,
 }: {
-  emptyDescription: string
-  emptyTitle: string
-  error: Error | null
-  loading: boolean
-  preview: WorkspaceFileResponse | null
-  previewRef: RefObject<HTMLDivElement | null>
-  selectedPath: string | null
+	emptyDescription: string;
+	emptyTitle: string;
+	error: Error | null;
+	loading: boolean;
+	preview: WorkspaceFileResponse | null;
+	previewRef: RefObject<HTMLDivElement | null>;
+	selectedPath: string | null;
 }) {
-  return (
-    <div
-      className="flex min-h-0 min-w-0 flex-col overflow-hidden rounded-md border border-border/60 bg-background"
-      data-testid="workspace-preview"
-      ref={previewRef}
-    >
-      <div className="flex min-h-9 min-w-0 shrink-0 items-center gap-2 border-b border-border/60 px-2.5">
-        <FileText className="size-3.5 shrink-0 text-foreground/35" />
-        <span className="min-w-0 flex-1 truncate text-label font-medium text-foreground/70">
-          {preview?.name ?? selectedPath ?? "Preview"}
-        </span>
-      </div>
-      <div className="flex-1 overflow-y-auto px-3 py-2">
-        {!selectedPath && (
-          <ResourceNotice
-            icon={FileText}
-            title={emptyTitle}
-            description={emptyDescription}
-          />
-        )}
-        {selectedPath && loading && <WorkspacePreviewSkeleton />}
-        {selectedPath && error && (
-          <ResourceNotice
-            icon={CircleAlert}
-            title="Unable to load preview"
-            description={error.message}
-          />
-        )}
-        {selectedPath &&
-          !loading &&
-          !error &&
-          preview?.status === "too-large" && (
-            <ResourceNotice
-              icon={CircleAlert}
-              title="Preview too large"
-              description={`${preview.name} is too large to preview safely.`}
-            />
-          )}
-        {selectedPath &&
-          !loading &&
-          !error &&
-          preview?.status === "unsupported" && (
-            <ResourceNotice
-              icon={CircleAlert}
-              title="Unsupported preview"
-              description={`${preview.name} is not a supported text file.`}
-            />
-          )}
-        {selectedPath &&
-          !loading &&
-          !error &&
-          preview &&
-          (preview.status === undefined || preview.status === "ok") && (
-            <Markdown
-              className="text-label leading-relaxed"
-              content={preview.content}
-            />
-          )}
-      </div>
-    </div>
-  )
+	return (
+		<div
+			className="flex min-h-0 min-w-0 flex-col overflow-hidden rounded-md border border-border/60 bg-background"
+			data-testid="workspace-preview"
+			ref={previewRef}
+		>
+			<div className="flex min-h-9 min-w-0 shrink-0 items-center gap-2 border-b border-border/60 px-2.5">
+				<FileText className="size-3.5 shrink-0 text-foreground/35" />
+				<span className="min-w-0 flex-1 truncate text-label font-medium text-foreground/70">
+					{preview?.name ?? selectedPath ?? "Preview"}
+				</span>
+			</div>
+			<div className="flex-1 overflow-y-auto px-3 py-2">
+				{!selectedPath && <ResourceNotice icon={FileText} title={emptyTitle} description={emptyDescription} />}
+				{selectedPath && loading && !preview && <WorkspacePreviewSkeleton />}
+				{selectedPath && error && (
+					<ResourceNotice icon={CircleAlert} title="Unable to load preview" description={error.message} />
+				)}
+				{selectedPath && !error && preview?.status === "too-large" && (
+					<ResourceNotice
+						icon={CircleAlert}
+						title="Preview too large"
+						description={`${preview.name} is too large to preview safely.`}
+					/>
+				)}
+				{selectedPath && !error && preview?.status === "unsupported" && (
+					<ResourceNotice
+						icon={CircleAlert}
+						title="Unsupported preview"
+						description={`${preview.name} is not a supported text file.`}
+					/>
+				)}
+				{selectedPath && !error && preview && (preview.status === undefined || preview.status === "ok") && (
+					<Markdown className="text-label leading-relaxed" content={preview.content} />
+				)}
+			</div>
+		</div>
+	);
 }

--- a/web/design/src/components/product/fleet-pi/pi/workspace-panel.tsx
+++ b/web/design/src/components/product/fleet-pi/pi/workspace-panel.tsx
@@ -39,7 +39,7 @@ export type WorkspacePanelContentProps = {
 	error?: Error | null;
 	emptyDescription?: string;
 	emptyTitle?: string;
-	loadWorkspaceFile: (path: string) => Promise<WorkspaceFileResponse>;
+	loadWorkspaceFile: (path: string, signal?: AbortSignal) => Promise<WorkspaceFileResponse>;
 	loading: boolean;
 	onSelectedPathChange?: (path: string | null) => void;
 	previewEmptyDescription?: string;
@@ -155,7 +155,7 @@ export function WorkspacePanelContent({
 		void (async () => {
 			try {
 				const body = await Promise.race([
-					loadWorkspaceFile(selected),
+					loadWorkspaceFile(selected, controller.signal),
 					new Promise<never>((_, reject) => {
 						const onAbort = () => reject(new DOMException("Preview timed out", "AbortError"));
 						if (controller.signal.aborted) {

--- a/web/design/src/components/product/fleet-pi/session-sidebar/navigation.tsx
+++ b/web/design/src/components/product/fleet-pi/session-sidebar/navigation.tsx
@@ -1,18 +1,23 @@
-import { BookOpenText, ChevronDown, CircleHelp, Folder, FolderPlus, Search, Settings, SquarePen } from "lucide-react";
-import type { LucideIcon } from "lucide-react";
-import { useMemo } from "react";
-import type { ReactNode } from "react";
-import type { ChatSessionInfo } from "@prime-agent/web-protocol/chat-protocol";
 import type { ProjectId, ProjectSummary } from "@prime-agent/web-protocol";
+import type { ChatSessionInfo } from "@prime-agent/web-protocol/chat-protocol";
+import type { LucideIcon } from "lucide-react";
+import { BookOpenText, ChevronDown, CircleHelp, Folder, FolderPlus, Search, Settings, SquarePen } from "lucide-react";
+import type { ReactNode } from "react";
+import { useMemo } from "react";
+import { normalizeSessionLabel } from "../../../../lib/pi/chat-helpers";
+import { SurfaceProvider } from "../../../../lib/surface-context";
+import { type SearchableThread, ThreadSearch } from "../../../registry/assistant-ui/elements/thread-search";
 import type { AISidebarProps, SidebarResource } from "../../../registry/beui/agents/ai-sidebar";
 import { Popover } from "../../../registry/beui/agents/input/input-popover";
+import {
+	AnimatedSidebar,
+	AnimatedSidebarFooter,
+	AnimatedSidebarHeader,
+	AnimatedSidebarRail,
+} from "../../../registry/beui/motion/animated-sidebar";
 import { Button } from "../../../ui/button";
-import { ThreadSearch, type SearchableThread } from "../../../registry/assistant-ui/elements/thread-search";
-import { AnimatedSidebar, AnimatedSidebarFooter, AnimatedSidebarHeader, AnimatedSidebarRail } from "../../../registry/beui/motion/animated-sidebar";
-import { FleetVersionBadge } from "./fleet-version-badge";
-import { SurfaceProvider } from "../../../../lib/surface-context";
-import { normalizeSessionLabel } from "../../../../lib/pi/chat-helpers";
 import { sortSessions } from "../session-sidebar-model";
+import { FleetVersionBadge } from "./fleet-version-badge";
 import { FleetSessionSidebarProjectList } from "./project-list";
 import type { SidebarStateView } from "./state";
 import {
@@ -140,9 +145,7 @@ export function FleetSessionSidebarNavigation({
 	const matchingProjects = useMemo(() => {
 		const needle = query.trim().toLowerCase();
 		if (!needle) return sortedProjects;
-		return sortedProjects.filter((project) =>
-			`${project.name} ${project.pathLabel}`.toLowerCase().includes(needle),
-		);
+		return sortedProjects.filter((project) => `${project.name} ${project.pathLabel}`.toLowerCase().includes(needle));
 	}, [query, sortedProjects]);
 	return (
 		<AnimatedSidebar
@@ -153,161 +156,163 @@ export function FleetSessionSidebarNavigation({
 		>
 			{/* The floating rail is a surface-2 card; menus opened inside lift from it. */}
 			<SurfaceProvider value={2}>
-			<AnimatedSidebarHeader className="gap-2 border-0 px-2.5 pb-2 pt-2.5">
-				<div className="relative flex h-9 min-w-0 items-center justify-between gap-1">
-					<Popover
-						open={brandMenuOpen}
-						onOpenChange={setBrandMenuOpen}
-						side="bottom"
-						align="start"
-						trigger={
-							<button
-								type="button"
-								className="flex h-8 w-fit shrink-0 items-center gap-1 rounded-lg px-2 text-left text-sm font-medium outline-none transition-colors hover:bg-sidebar-accent focus-visible:ring-2 focus-visible:ring-sidebar-ring"
-							>
-								<span className="truncate">Qredence Fleet</span>
-								<ChevronDown className="size-3.5 text-muted-foreground" />
-							</button>
-						}
-						className="w-52 p-1"
-					>
-						{onCreateProject ? (
+				<AnimatedSidebarHeader className="gap-2 border-0 px-2.5 pb-2 pt-2.5">
+					<div className="relative flex h-9 min-w-0 items-center justify-between gap-1">
+						<Popover
+							open={brandMenuOpen}
+							onOpenChange={setBrandMenuOpen}
+							side="bottom"
+							align="start"
+							trigger={
+								<button
+									type="button"
+									className="flex h-8 w-fit shrink-0 items-center gap-1 rounded-lg px-2 text-left text-sm font-medium outline-none transition-colors hover:bg-sidebar-accent focus-visible:ring-2 focus-visible:ring-sidebar-ring"
+								>
+									<span className="truncate">Qredence Fleet</span>
+									<ChevronDown className="size-3.5 text-muted-foreground" />
+								</button>
+							}
+							className="w-52 p-1"
+						>
+							{onCreateProject ? (
+								<SidebarMenuItem
+									icon={FolderPlus}
+									label="Add project"
+									onClick={() => {
+										setBrandMenuOpen(false);
+										setCreateOpen(true);
+									}}
+								/>
+							) : null}
 							<SidebarMenuItem
-								icon={FolderPlus}
-								label="Add project"
+								icon={Settings}
+								label="Settings"
 								onClick={() => {
 									setBrandMenuOpen(false);
-									setCreateOpen(true);
+									onOpenSettings?.();
 								}}
 							/>
-						) : null}
-						<SidebarMenuItem
-							icon={Settings}
-							label="Settings"
-							onClick={() => {
-								setBrandMenuOpen(false);
-								onOpenSettings?.();
-							}}
-						/>
-						<SidebarMenuItem icon={BookOpenText} label="Documentation" href={DOCUMENTATION_URL} />
-					</Popover>
+							<SidebarMenuItem icon={BookOpenText} label="Documentation" href={DOCUMENTATION_URL} />
+						</Popover>
 
-					<Popover
-						open={searchOpen}
-						onOpenChange={setSearchOpen}
-						side="bottom"
-						align="end"
-						className="w-64 p-0"
-						trigger={
-							<Button
-								type="button"
-								variant="ghost"
-								size="icon"
-								aria-label="Search projects and sessions"
-								title="Search projects and sessions"
-								className="shrink-0 text-muted-foreground hover:bg-sidebar-accent"
-							>
-								<Search data-icon="inline-start" className="size-4" />
-							</Button>
-						}
-					>
-						<div className="max-h-[min(32rem,calc(100vh-5rem))] overflow-y-auto">
-							<ThreadSearch
-								threads={searchThreads}
-								query={query}
-								activeId={activeSessionId ?? ""}
-								onQueryChange={setQuery}
-								onSelect={(sessionId) => selectSearchResult(`search-session:${sessionId}`)}
-								className="max-w-none rounded-none border-0 bg-transparent p-2 shadow-none"
-							/>
-							<div className="border-t border-border/60 px-2 pb-2 pt-1.5">
-								<span className="px-2 pb-1 font-mono text-[0.625rem] uppercase tracking-[0.14em] text-muted-foreground/60">
-									Projects
-								</span>
-								<div className="mt-1 flex flex-col gap-0.5">
-									{matchingProjects.map((project) => (
-										<button
-											key={project.projectId}
-											type="button"
-											onClick={() => selectSearchResult(`search-project:${project.projectId}`)}
-											className="flex w-full min-w-0 items-center gap-2 rounded-xl px-2 py-1.5 text-left text-xs outline-none transition-colors hover:bg-foreground/[0.03] focus-visible:ring-2 focus-visible:ring-ring"
-										>
-											<Folder className="size-3.5 shrink-0 text-muted-foreground/60" />
-											<span className="min-w-0 flex-1 truncate">{project.name}</span>
-											<span className="max-w-24 truncate text-[0.625rem] text-muted-foreground/55">{project.pathLabel}</span>
-										</button>
-									))}
-									{matchingProjects.length === 0 ? (
-										<span className="p-2 text-center text-[0.6875rem] text-muted-foreground/60">
-											No project matches “{query}”
-										</span>
-									) : null}
+						<Popover
+							open={searchOpen}
+							onOpenChange={setSearchOpen}
+							side="bottom"
+							align="end"
+							className="w-64 p-0"
+							trigger={
+								<Button
+									type="button"
+									variant="ghost"
+									size="icon"
+									aria-label="Search projects and sessions"
+									title="Search projects and sessions"
+									className="shrink-0 text-muted-foreground hover:bg-sidebar-accent"
+								>
+									<Search data-icon="inline-start" className="size-4" />
+								</Button>
+							}
+						>
+							<div className="max-h-[min(32rem,calc(100vh-5rem))] overflow-y-auto">
+								<ThreadSearch
+									threads={searchThreads}
+									query={query}
+									activeId={activeSessionId ?? ""}
+									onQueryChange={setQuery}
+									onSelect={(sessionId) => selectSearchResult(`search-session:${sessionId}`)}
+									className="max-w-none rounded-none border-0 p-2 shadow-none"
+								/>
+								<div className="border-t border-border/60 px-2 pb-2 pt-1.5">
+									<span className="px-2 pb-1 font-mono text-[0.625rem] uppercase tracking-[0.14em] text-muted-foreground/60">
+										Projects
+									</span>
+									<div className="mt-1 flex flex-col gap-0.5">
+										{matchingProjects.map((project) => (
+											<button
+												key={project.projectId}
+												type="button"
+												onClick={() => selectSearchResult(`search-project:${project.projectId}`)}
+												className="flex w-full min-w-0 items-center gap-2 rounded-xl px-2 py-1.5 text-left text-xs outline-none transition-colors hover:bg-foreground/[0.03] focus-visible:ring-2 focus-visible:ring-ring"
+											>
+												<Folder className="size-3.5 shrink-0 text-muted-foreground/60" />
+												<span className="min-w-0 flex-1 truncate">{project.name}</span>
+												<span className="max-w-24 truncate text-[0.625rem] text-muted-foreground/55">
+													{project.pathLabel}
+												</span>
+											</button>
+										))}
+										{matchingProjects.length === 0 ? (
+											<span className="p-2 text-center text-[0.6875rem] text-muted-foreground/60">
+												No project matches “{query}”
+											</span>
+										) : null}
+									</div>
+								</div>
+								<div className="flex items-center justify-end gap-3 border-t border-border/60 px-3 py-2 text-[0.625rem] text-muted-foreground/70">
+									<span className="flex items-center gap-1">
+										<KbdHint>↑</KbdHint>
+										<KbdHint>↓</KbdHint>
+										navigate
+									</span>
+									<span className="flex items-center gap-1">
+										<KbdHint>↵</KbdHint>
+										open
+									</span>
+									<span className="flex items-center gap-1">
+										<KbdHint>esc</KbdHint>
+										close
+									</span>
 								</div>
 							</div>
-							<div className="flex items-center justify-end gap-3 border-t border-border/60 px-3 py-2 text-[0.625rem] text-muted-foreground/70">
-								<span className="flex items-center gap-1">
-									<KbdHint>↑</KbdHint>
-									<KbdHint>↓</KbdHint>
-									navigate
-								</span>
-								<span className="flex items-center gap-1">
-									<KbdHint>↵</KbdHint>
-									open
-								</span>
-								<span className="flex items-center gap-1">
-									<KbdHint>esc</KbdHint>
-									close
-								</span>
-							</div>
-						</div>
-					</Popover>
-				</div>
-				<button
-					type="button"
-					onClick={onNewSession}
-					className="flex h-8 w-full items-center justify-start gap-2 rounded-lg px-2 text-[0.8125rem] font-normal text-sidebar-foreground outline-none transition-colors hover:bg-sidebar-accent focus-visible:bg-sidebar-accent focus-visible:ring-2 focus-visible:ring-sidebar-ring"
-				>
-					<SquarePen className="size-4 shrink-0 text-muted-foreground" />
-					New chat
-				</button>
-			</AnimatedSidebarHeader>
-			<FleetSessionSidebarProjectList
-				projectActionsOpen={projectActionsOpen}
-				setProjectActionsOpen={setProjectActionsOpen}
-				expandedProjectIds={expandedProjectIds}
-				setExpandedProjectIds={setExpandedProjectIds}
-				setCreateOpen={setCreateOpen}
-				projects={projects}
-				projectSessions={projectSessions}
-				sidebarItems={sidebarItems}
-				activeProjectId={activeProjectId}
-				activeSessionId={activeSessionId}
-				onNewSession={onNewSession}
-				onNewSessionInProject={onNewSessionInProject}
-				onProjectSelect={onProjectSelect}
-				onRenameSession={onRenameSession}
-				onCreateProject={onCreateProject}
-				resumeResource={resumeResource}
-				toggleProjectResource={toggleProjectResource}
-				renderMenu={renderMenu}
-			/>
-			<AnimatedSidebarFooter className="flex-row items-center gap-1 border-sidebar-border px-2.5 py-2 pb-[max(0.5rem,env(safe-area-inset-bottom))]">
-				<div className="min-w-0 flex-1">
-					{accountMenu ?? <span className="flex h-8 items-center px-2 text-[0.8125rem]">Qredence</span>}
-				</div>
-				<FleetVersionBadge />
-				<a
-					href={DOCUMENTATION_URL}
-					target="_blank"
-					rel="noreferrer"
-					aria-label="Open Qredence documentation"
-					title="Help"
-					className="grid size-8 shrink-0 place-items-center rounded-lg text-muted-foreground outline-none transition-colors hover:bg-sidebar-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-sidebar-ring"
-				>
-					<CircleHelp className="size-4" />
-				</a>
-			</AnimatedSidebarFooter>
-			<AnimatedSidebarRail />
+						</Popover>
+					</div>
+					<button
+						type="button"
+						onClick={onNewSession}
+						className="flex h-8 w-full items-center justify-start gap-2 rounded-lg px-2 text-[0.8125rem] font-normal text-sidebar-foreground outline-none transition-colors hover:bg-sidebar-accent focus-visible:bg-sidebar-accent focus-visible:ring-2 focus-visible:ring-sidebar-ring"
+					>
+						<SquarePen className="size-4 shrink-0 text-muted-foreground" />
+						New chat
+					</button>
+				</AnimatedSidebarHeader>
+				<FleetSessionSidebarProjectList
+					projectActionsOpen={projectActionsOpen}
+					setProjectActionsOpen={setProjectActionsOpen}
+					expandedProjectIds={expandedProjectIds}
+					setExpandedProjectIds={setExpandedProjectIds}
+					setCreateOpen={setCreateOpen}
+					projects={projects}
+					projectSessions={projectSessions}
+					sidebarItems={sidebarItems}
+					activeProjectId={activeProjectId}
+					activeSessionId={activeSessionId}
+					onNewSession={onNewSession}
+					onNewSessionInProject={onNewSessionInProject}
+					onProjectSelect={onProjectSelect}
+					onRenameSession={onRenameSession}
+					onCreateProject={onCreateProject}
+					resumeResource={resumeResource}
+					toggleProjectResource={toggleProjectResource}
+					renderMenu={renderMenu}
+				/>
+				<AnimatedSidebarFooter className="flex-row items-center gap-1 border-sidebar-border px-2.5 py-2 pb-[max(0.5rem,env(safe-area-inset-bottom))]">
+					<div className="min-w-0 flex-1">
+						{accountMenu ?? <span className="flex h-8 items-center px-2 text-[0.8125rem]">Qredence</span>}
+					</div>
+					<FleetVersionBadge />
+					<a
+						href={DOCUMENTATION_URL}
+						target="_blank"
+						rel="noreferrer"
+						aria-label="Open Qredence documentation"
+						title="Help"
+						className="grid size-8 shrink-0 place-items-center rounded-lg text-muted-foreground outline-none transition-colors hover:bg-sidebar-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-sidebar-ring"
+					>
+						<CircleHelp className="size-4" />
+					</a>
+				</AnimatedSidebarFooter>
+				<AnimatedSidebarRail />
 			</SurfaceProvider>
 		</AnimatedSidebar>
 	);

--- a/web/design/src/components/registry/beui/motion/popover-morph.tsx
+++ b/web/design/src/components/registry/beui/motion/popover-morph.tsx
@@ -1,57 +1,58 @@
 "use client";
 
-import { AnimatePresence, m, useReducedMotion } from "motion/react";
-import {
-  cloneElement,
-  createContext,
-  isValidElement,
-  type ReactElement,
-  type ReactNode,
-  type Ref,
-  useCallback,
-  useContext,
-  useEffect,
-  useEffectEvent,
-  useId,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
-import { createPortal } from "react-dom";
 import { usePopoverPortalPosition } from "@prime-agent/web-design/components/registry/beui/motion/popover-position";
 import { EASE_OUT, SPRING_PANEL } from "@prime-agent/web-design/lib/ease";
 import { useHydrated } from "@prime-agent/web-design/lib/hooks/use-hydrated";
 import { cn } from "@prime-agent/web-design/lib/utils";
+import { AnimatePresence, m, useReducedMotion } from "motion/react";
+import {
+	cloneElement,
+	createContext,
+	isValidElement,
+	type ReactElement,
+	type ReactNode,
+	type Ref,
+	useCallback,
+	useContext,
+	useEffect,
+	useEffectEvent,
+	useId,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
+import { createPortal } from "react-dom";
+import { elevatedMenu } from "../../../../lib/surfaces";
 
 type Side = "top" | "bottom";
 type Align = "start" | "end";
 
 type MorphContextValue = {
-  open: boolean;
-  setOpen: (open: boolean) => void;
-  toggle: () => void;
-  triggerId: string;
-  contentId: string;
-  triggerRef: React.MutableRefObject<HTMLElement | null>;
-  contentRef: React.MutableRefObject<HTMLDivElement | null>;
+	open: boolean;
+	setOpen: (open: boolean) => void;
+	toggle: () => void;
+	triggerId: string;
+	contentId: string;
+	triggerRef: React.MutableRefObject<HTMLElement | null>;
+	contentRef: React.MutableRefObject<HTMLDivElement | null>;
 };
 
 const MorphContext = createContext<MorphContextValue | null>(null);
 
 function useMorphContext(component: string) {
-  const ctx = useContext(MorphContext);
-  if (!ctx) throw new Error(`${component} must be used within <MorphPopover>`);
-  return ctx;
+	const ctx = useContext(MorphContext);
+	if (!ctx) throw new Error(`${component} must be used within <MorphPopover>`);
+	return ctx;
 }
 
 export interface MorphPopoverProps {
-  children: ReactNode;
-  /** Controlled open state. */
-  open?: boolean;
-  /** Uncontrolled initial open state. */
-  defaultOpen?: boolean;
-  onOpenChange?: (open: boolean) => void;
-  className?: string;
+	children: ReactNode;
+	/** Controlled open state. */
+	open?: boolean;
+	/** Uncontrolled initial open state. */
+	defaultOpen?: boolean;
+	onOpenChange?: (open: boolean) => void;
+	className?: string;
 }
 
 /**
@@ -60,123 +61,116 @@ export interface MorphPopoverProps {
  * piece. Closes on outside pointer / Escape. Controlled or uncontrolled.
  */
 export function MorphPopover({
-  children,
-  open: controlledOpen,
-  defaultOpen = false,
-  onOpenChange,
-  className,
+	children,
+	open: controlledOpen,
+	defaultOpen = false,
+	onOpenChange,
+	className,
 }: MorphPopoverProps) {
-  const baseId = useId();
-  const rootRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLElement | null>(null);
-  const contentRef = useRef<HTMLDivElement | null>(null);
-  const [internalOpen, setInternalOpen] = useState(defaultOpen);
-  const controlled = controlledOpen !== undefined;
-  const open = controlled ? controlledOpen : internalOpen;
+	const baseId = useId();
+	const rootRef = useRef<HTMLDivElement>(null);
+	const triggerRef = useRef<HTMLElement | null>(null);
+	const contentRef = useRef<HTMLDivElement | null>(null);
+	const [internalOpen, setInternalOpen] = useState(defaultOpen);
+	const controlled = controlledOpen !== undefined;
+	const open = controlled ? controlledOpen : internalOpen;
 
-  const setOpen = useCallback(
-    (next: boolean) => {
-      if (!controlled) setInternalOpen(next);
-      onOpenChange?.(next);
-    },
-    [controlled, onOpenChange],
-  );
-  const toggle = useCallback(() => setOpen(!open), [setOpen, open]);
-  const setOpenEvent = useEffectEvent(setOpen);
+	const setOpen = useCallback(
+		(next: boolean) => {
+			if (!controlled) setInternalOpen(next);
+			onOpenChange?.(next);
+		},
+		[controlled, onOpenChange],
+	);
+	const toggle = useCallback(() => setOpen(!open), [setOpen, open]);
+	const setOpenEvent = useEffectEvent(setOpen);
 
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => e.key === "Escape" && setOpenEvent(false);
-    const onPointer = (e: PointerEvent) => {
-      const target = e.target as Node;
-      if (
-        rootRef.current &&
-        !rootRef.current.contains(target) &&
-        !contentRef.current?.contains(target)
-      )
-        setOpenEvent(false);
-    };
-    window.addEventListener("keydown", onKey);
-    window.addEventListener("pointerdown", onPointer);
-    return () => {
-      window.removeEventListener("keydown", onKey);
-      window.removeEventListener("pointerdown", onPointer);
-    };
-  }, [open]);
+	useEffect(() => {
+		if (!open) return;
+		const onKey = (e: KeyboardEvent) => e.key === "Escape" && setOpenEvent(false);
+		const onPointer = (e: PointerEvent) => {
+			const target = e.target as Node;
+			if (rootRef.current && !rootRef.current.contains(target) && !contentRef.current?.contains(target))
+				setOpenEvent(false);
+		};
+		window.addEventListener("keydown", onKey);
+		window.addEventListener("pointerdown", onPointer);
+		return () => {
+			window.removeEventListener("keydown", onKey);
+			window.removeEventListener("pointerdown", onPointer);
+		};
+	}, [open]);
 
-  const ctx = useMemo<MorphContextValue>(
-    () => ({
-      open,
-      setOpen,
-      toggle,
-      triggerId: `${baseId}-trigger`,
-      contentId: `${baseId}-content`,
-      triggerRef,
-      contentRef,
-    }),
-    [open, setOpen, toggle, baseId],
-  );
+	const ctx = useMemo<MorphContextValue>(
+		() => ({
+			open,
+			setOpen,
+			toggle,
+			triggerId: `${baseId}-trigger`,
+			contentId: `${baseId}-content`,
+			triggerRef,
+			contentRef,
+		}),
+		[open, setOpen, toggle, baseId],
+	);
 
-  return (
-    <MorphContext.Provider value={ctx}>
-      <div ref={rootRef} className={cn("relative inline-flex", className)}>
-        {children}
-      </div>
-    </MorphContext.Provider>
-  );
+	return (
+		<MorphContext.Provider value={ctx}>
+			<div ref={rootRef} className={cn("relative inline-flex", className)}>
+				{children}
+			</div>
+		</MorphContext.Provider>
+	);
 }
 
 export interface MorphPopoverTriggerProps {
-  children: ReactElement;
+	children: ReactElement;
 }
 
 function mergeRefs<T>(...refs: Array<Ref<T> | undefined>) {
-  return (node: T | null) => {
-    for (const ref of refs) {
-      if (typeof ref === "function") ref(node);
-      else if (ref && typeof ref === "object")
-        (ref as React.MutableRefObject<T | null>).current = node;
-    }
-  };
+	return (node: T | null) => {
+		for (const ref of refs) {
+			if (typeof ref === "function") ref(node);
+			else if (ref && typeof ref === "object") (ref as React.MutableRefObject<T | null>).current = node;
+		}
+	};
 }
 
 /** Wraps a single element, toggling the popover on click. */
 export function MorphPopoverTrigger({ children }: MorphPopoverTriggerProps) {
-  const ctx = useMorphContext("MorphPopoverTrigger");
-  if (!isValidElement(children)) return children;
+	const ctx = useMorphContext("MorphPopoverTrigger");
+	if (!isValidElement(children)) return children;
 
-  const child = children as ReactElement<Record<string, unknown>>;
-  const childOnClick = child.props.onClick as
-    | ((e: unknown) => void)
-    | undefined;
-  const childRef = (child.props as { ref?: Ref<HTMLElement> }).ref;
+	const child = children as ReactElement<Record<string, unknown>>;
+	const childOnClick = child.props.onClick as ((e: unknown) => void) | undefined;
+	const childRef = (child.props as { ref?: Ref<HTMLElement> }).ref;
 
-  return cloneElement(child, {
-    id: ctx.triggerId,
-    ref: mergeRefs(childRef, (node: HTMLElement | null) => {
-      ctx.triggerRef.current = node;
-    }),
-    onClick: (e: unknown) => {
-      childOnClick?.(e);
-      ctx.toggle();
-    },
-    "aria-haspopup": "dialog",
-    "aria-expanded": ctx.open,
-    "aria-controls": ctx.open ? ctx.contentId : undefined,
-  });
+	return cloneElement(child, {
+		id: ctx.triggerId,
+		ref: mergeRefs(childRef, (node: HTMLElement | null) => {
+			ctx.triggerRef.current = node;
+		}),
+		onClick: (e: unknown) => {
+			childOnClick?.(e);
+			ctx.toggle();
+		},
+		"aria-haspopup": "dialog",
+		"aria-expanded": ctx.open,
+		"aria-controls": ctx.open ? ctx.contentId : undefined,
+	});
 }
 
 const originFor = (side: Side, align: Align) =>
-  `${side === "bottom" ? "top" : "bottom"} ${align === "end" ? "right" : "left"}`;
+	`${side === "bottom" ? "top" : "bottom"} ${align === "end" ? "right" : "left"}`;
 
 // A clip that hides everything but the corner nearest the trigger, so the
 // panel appears to grow out of it. inset(top right bottom left).
 function clipHidden(side: Side, align: Align, radius: number) {
-  const top = side === "bottom" ? "0%" : "92%";
-  const bottom = side === "bottom" ? "92%" : "0%";
-  const right = align === "end" ? "0%" : "92%";
-  const left = align === "end" ? "92%" : "0%";
-  return `inset(${top} ${right} ${bottom} ${left} round ${radius}px)`;
+	const top = side === "bottom" ? "0%" : "92%";
+	const bottom = side === "bottom" ? "92%" : "0%";
+	const right = align === "end" ? "0%" : "92%";
+	const left = align === "end" ? "92%" : "0%";
+	return `inset(${top} ${right} ${bottom} ${left} round ${radius}px)`;
 }
 const clipShown = (radius: number) => `inset(0% 0% 0% 0% round ${radius}px)`;
 
@@ -185,105 +179,98 @@ const clipShown = (radius: number) => `inset(0% 0% 0% 0% round ${radius}px)`;
 const MORPH_CLIP_TRANSITION = { duration: 0.32, ease: EASE_OUT } as const;
 
 export interface MorphPopoverContentProps {
-  children: ReactNode;
-  side?: Side;
-  align?: Align;
-  /** Gap between trigger and panel, in px. Default 8. */
-  sideOffset?: number;
-  /** Panel corner radius, in px. Default 16. */
-  radius?: number;
-  className?: string;
+	children: ReactNode;
+	side?: Side;
+	align?: Align;
+	/** Gap between trigger and panel, in px. Default 8. */
+	sideOffset?: number;
+	/** Panel corner radius, in px. Default 16. */
+	radius?: number;
+	className?: string;
 }
 
 export function MorphPopoverContent({
-  children,
-  side = "bottom",
-  align = "end",
-  sideOffset = 8,
-  radius = 16,
-  className,
+	children,
+	side = "bottom",
+	align = "end",
+	sideOffset = 8,
+	radius = 16,
+	className,
 }: MorphPopoverContentProps) {
-  const ctx = useMorphContext("MorphPopoverContent");
-  const reduce = useReducedMotion() ?? false;
-  const portalReady = useHydrated();
-  const layout = usePopoverPortalPosition(
-    ctx.triggerRef,
-    ctx.contentRef,
-    portalReady && ctx.open,
-  );
+	const ctx = useMorphContext("MorphPopoverContent");
+	const reduce = useReducedMotion() ?? false;
+	const portalReady = useHydrated();
+	const layout = usePopoverPortalPosition(ctx.triggerRef, ctx.contentRef, portalReady && ctx.open);
 
-  const left = layout
-    ? align === "end"
-      ? layout.trigger.left + layout.trigger.width - layout.content.width
-      : layout.trigger.left
-    : 0;
-  const top = layout
-    ? side === "bottom"
-      ? layout.trigger.top + layout.trigger.height + sideOffset
-      : layout.trigger.top - layout.content.height - sideOffset
-    : 0;
+	const left = layout
+		? align === "end"
+			? layout.trigger.left + layout.trigger.width - layout.content.width
+			: layout.trigger.left
+		: 0;
+	const top = layout
+		? side === "bottom"
+			? layout.trigger.top + layout.trigger.height + sideOffset
+			: layout.trigger.top - layout.content.height - sideOffset
+		: 0;
 
-  // Both directions travel between the exact same hidden/show states. Exit
-  // targets "hidden" directly instead of introducing separate choreography.
-  const wrap = reduce
-    ? undefined
-    : {
-        hidden: { opacity: 0, scale: 0.96, transition: SPRING_PANEL },
-        show: { opacity: 1, scale: 1, transition: SPRING_PANEL },
-      };
-  const clip = reduce
-    ? undefined
-    : {
-        hidden: {
-          clipPath: clipHidden(side, align, radius),
-          transition: MORPH_CLIP_TRANSITION,
-        },
-        show: {
-          clipPath: clipShown(radius),
-          transition: MORPH_CLIP_TRANSITION,
-        },
-      };
+	// Both directions travel between the exact same hidden/show states. Exit
+	// targets "hidden" directly instead of introducing separate choreography.
+	const wrap = reduce
+		? undefined
+		: {
+				hidden: { opacity: 0, scale: 0.96, transition: SPRING_PANEL },
+				show: { opacity: 1, scale: 1, transition: SPRING_PANEL },
+			};
+	const clip = reduce
+		? undefined
+		: {
+				hidden: {
+					clipPath: clipHidden(side, align, radius),
+					transition: MORPH_CLIP_TRANSITION,
+				},
+				show: {
+					clipPath: clipShown(radius),
+					transition: MORPH_CLIP_TRANSITION,
+				},
+			};
 
-  // Keep the server and first client render identical, then mount the portal.
-  if (!portalReady) return null;
+	// Keep the server and first client render identical, then mount the portal.
+	if (!portalReady) return null;
 
-  return createPortal(
-    <AnimatePresence>
-      {ctx.open ? (
-        <m.div
-          data-morph-popover-portal=""
-          // Wrapper carries the shadow as a drop-shadow filter, which hugs the
-          // clipped shape below (box-shadow would just get clipped away).
-          variants={wrap}
-          initial={reduce ? { opacity: 0 } : "hidden"}
-          animate={reduce ? { opacity: 1 } : "show"}
-          exit={reduce ? { opacity: 0 } : "hidden"}
-          transition={reduce ? { duration: 0.12 } : undefined}
-          style={{
-            left,
-            top,
-            visibility: layout ? "visible" : "hidden",
-            transformOrigin: originFor(side, align),
-          }}
-          className="fixed z-[9999] [filter:drop-shadow(0_10px_18px_rgba(0,0,0,0.14))]"
-        >
-          <m.div
-            ref={ctx.contentRef}
-            id={ctx.contentId}
-            role="dialog"
-            aria-labelledby={ctx.triggerId}
-            variants={clip}
-            style={{ borderRadius: radius }}
-            className={cn(
-              "overflow-hidden border border-border bg-background",
-              className,
-            )}
-          >
-            {children}
-          </m.div>
-        </m.div>
-      ) : null}
-    </AnimatePresence>,
-    document.body,
-  );
+	return createPortal(
+		<AnimatePresence>
+			{ctx.open ? (
+				<m.div
+					data-morph-popover-portal=""
+					// Wrapper carries the shadow as a drop-shadow filter, which hugs the
+					// clipped shape below (box-shadow would just get clipped away).
+					variants={wrap}
+					initial={reduce ? { opacity: 0 } : "hidden"}
+					animate={reduce ? { opacity: 1 } : "show"}
+					exit={reduce ? { opacity: 0 } : "hidden"}
+					transition={reduce ? { duration: 0.12 } : undefined}
+					style={{
+						left,
+						top,
+						visibility: layout ? "visible" : "hidden",
+						transformOrigin: originFor(side, align),
+					}}
+					className="fixed z-[9999] [filter:drop-shadow(0_10px_18px_rgba(0,0,0,0.14))]"
+				>
+					<m.div
+						ref={ctx.contentRef}
+						id={ctx.contentId}
+						role="dialog"
+						aria-labelledby={ctx.triggerId}
+						variants={clip}
+						style={{ borderRadius: radius }}
+						className={cn("overflow-hidden", elevatedMenu, className)}
+					>
+						{children}
+					</m.div>
+				</m.div>
+			) : null}
+		</AnimatePresence>,
+		document.body,
+	);
 }

--- a/web/design/src/components/ui/popover.tsx
+++ b/web/design/src/components/ui/popover.tsx
@@ -1,99 +1,75 @@
-import * as React from "react"
-import { Popover as PopoverPrimitive } from "@base-ui/react/popover"
-
-import { cn } from "@prime-agent/web-design/lib/utils"
-import { surfaceClasses } from "@prime-agent/web-design/lib/surface-classes"
-import { SurfaceProvider, useSurface } from "@prime-agent/web-design/lib/surface-context"
+import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
+import type * as React from "react";
+import { surfaceClasses } from "../../lib/surface-classes";
+import { SurfaceProvider, useSurface } from "../../lib/surface-context";
+import { elevatedMenu } from "../../lib/surfaces";
+import { cn } from "../../lib/utils";
 
 /** Conventional elevation offset for a popover/dropdown off its substrate (Fluid surfaces). */
-const POPOVER_SURFACE_OFFSET = 2
+const POPOVER_SURFACE_OFFSET = 2;
 
 function Popover({ ...props }: PopoverPrimitive.Root.Props) {
-  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+	return <PopoverPrimitive.Root data-slot="popover" {...props} />;
 }
 
 function PopoverTrigger({ ...props }: PopoverPrimitive.Trigger.Props) {
-  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+	return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
 }
 
 function PopoverContent({
-  className,
-  children,
-  align = "center",
-  alignOffset = 0,
-  side = "bottom",
-  sideOffset = 4,
-  ...props
+	className,
+	children,
+	align = "center",
+	alignOffset = 0,
+	side = "bottom",
+	sideOffset = 4,
+	...props
 }: PopoverPrimitive.Popup.Props &
-  Pick<
-    PopoverPrimitive.Positioner.Props,
-    "align" | "alignOffset" | "side" | "sideOffset"
-  >) {
-  const substrate = useSurface()
-  const level = Math.min(substrate + POPOVER_SURFACE_OFFSET, 8)
-  return (
-    <PopoverPrimitive.Portal>
-      <PopoverPrimitive.Positioner
-        align={align}
-        alignOffset={alignOffset}
-        side={side}
-        sideOffset={sideOffset}
-        className="isolate z-50"
-      >
-        <PopoverPrimitive.Popup
-          data-slot="popover-content"
-          className={cn(
-            "z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-lg p-2.5 text-sm text-popover-foreground outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
-            surfaceClasses(level, 3),
-            className
-          )}
-          {...props}
-        >
-          <SurfaceProvider value={level}>{children}</SurfaceProvider>
-        </PopoverPrimitive.Popup>
-      </PopoverPrimitive.Positioner>
-    </PopoverPrimitive.Portal>
-  )
+	Pick<PopoverPrimitive.Positioner.Props, "align" | "alignOffset" | "side" | "sideOffset">) {
+	const substrate = useSurface();
+	const level = Math.min(substrate + POPOVER_SURFACE_OFFSET, 8);
+	return (
+		<PopoverPrimitive.Portal>
+			<PopoverPrimitive.Positioner
+				align={align}
+				alignOffset={alignOffset}
+				side={side}
+				sideOffset={sideOffset}
+				className="isolate z-50"
+			>
+				<PopoverPrimitive.Popup
+					data-slot="popover-content"
+					className={cn(
+						"z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-lg p-2.5 text-sm outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+						surfaceClasses(level, 3),
+						elevatedMenu,
+						className,
+					)}
+					{...props}
+				>
+					<SurfaceProvider value={level}>{children}</SurfaceProvider>
+				</PopoverPrimitive.Popup>
+			</PopoverPrimitive.Positioner>
+		</PopoverPrimitive.Portal>
+	);
 }
 
 function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="popover-header"
-      className={cn("flex flex-col gap-0.5 text-sm", className)}
-      {...props}
-    />
-  )
+	return <div data-slot="popover-header" className={cn("flex flex-col gap-0.5 text-sm", className)} {...props} />;
 }
 
 function PopoverTitle({ className, ...props }: PopoverPrimitive.Title.Props) {
-  return (
-    <PopoverPrimitive.Title
-      data-slot="popover-title"
-      className={cn("font-medium", className)}
-      {...props}
-    />
-  )
+	return <PopoverPrimitive.Title data-slot="popover-title" className={cn("font-medium", className)} {...props} />;
 }
 
-function PopoverDescription({
-  className,
-  ...props
-}: PopoverPrimitive.Description.Props) {
-  return (
-    <PopoverPrimitive.Description
-      data-slot="popover-description"
-      className={cn("text-muted-foreground", className)}
-      {...props}
-    />
-  )
+function PopoverDescription({ className, ...props }: PopoverPrimitive.Description.Props) {
+	return (
+		<PopoverPrimitive.Description
+			data-slot="popover-description"
+			className={cn("text-muted-foreground", className)}
+			{...props}
+		/>
+	);
 }
 
-export {
-  Popover,
-  PopoverContent,
-  PopoverDescription,
-  PopoverHeader,
-  PopoverTitle,
-  PopoverTrigger,
-}
+export { Popover, PopoverContent, PopoverDescription, PopoverHeader, PopoverTitle, PopoverTrigger };

--- a/web/design/src/lib/surfaces.tsx
+++ b/web/design/src/lib/surfaces.tsx
@@ -1,62 +1,55 @@
 "use client";
 
+import { cn } from "@prime-agent/web-design/lib/utils";
 import type { ComponentProps } from "react";
 import { useLayoutEffect, useRef, useState } from "react";
-import { cn } from "@prime-agent/web-design/lib/utils";
 
 export const paper =
-  "bg-background shadow-[0_1px_2px_rgba(0,0,0,0.04),0_12px_32px_-16px_rgba(0,0,0,0.12)] dark:bg-popover dark:shadow-none";
+	"bg-background shadow-[0_1px_2px_rgba(0,0,0,0.04),0_12px_32px_-16px_rgba(0,0,0,0.12)] dark:bg-popover dark:shadow-none";
+
+/** Opaque elevated menu for chrome popovers (mode, search, attach) on dark surfaces. */
+export const elevatedMenu = "border border-border bg-popover text-popover-foreground shadow-lg";
 
 export const floating =
-  "bg-background shadow-[0_2px_8px_rgba(0,0,0,0.05),0_20px_48px_-16px_rgba(0,0,0,0.18)] dark:bg-popover dark:shadow-[0_20px_48px_-16px_rgba(0,0,0,0.55)]";
+	"bg-background shadow-[0_2px_8px_rgba(0,0,0,0.05),0_20px_48px_-16px_rgba(0,0,0,0.18)] dark:bg-popover dark:shadow-[0_20px_48px_-16px_rgba(0,0,0,0.55)]";
 
 export const field = "bg-foreground/[0.04] dark:bg-foreground/[0.06]";
 
 export const fieldInteractive =
-  "bg-foreground/[0.04] transition-colors hover:bg-foreground/[0.07] dark:bg-foreground/[0.06] dark:hover:bg-foreground/[0.09]";
+	"bg-foreground/[0.04] transition-colors hover:bg-foreground/[0.07] dark:bg-foreground/[0.06] dark:hover:bg-foreground/[0.09]";
 
 export const pressable =
-  "transition-transform duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] active:scale-[0.96] motion-reduce:transition-none";
+	"transition-transform duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] active:scale-[0.96] motion-reduce:transition-none";
 
 export const ghostButton =
-  "flex items-center justify-center rounded-full text-foreground/45 outline-none transition-[background-color,color,scale] duration-150 hover:bg-foreground/[0.06] hover:text-foreground/90 active:scale-[0.96] focus-visible:ring-2 focus-visible:ring-foreground/20 motion-reduce:transition-none dark:hover:bg-foreground/[0.09]";
+	"flex items-center justify-center rounded-full text-foreground/45 outline-none transition-[background-color,color,scale] duration-150 hover:bg-foreground/[0.06] hover:text-foreground/90 active:scale-[0.96] focus-visible:ring-2 focus-visible:ring-foreground/20 motion-reduce:transition-none dark:hover:bg-foreground/[0.09]";
 
 export const inkButton =
-  "bg-foreground text-background transition-[opacity,scale] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:opacity-90 active:scale-[0.96] motion-reduce:transition-none";
+	"bg-foreground text-background transition-[opacity,scale] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:opacity-90 active:scale-[0.96] motion-reduce:transition-none";
 
 export const iconSwap =
-  "[grid-area:1/1] transition-[opacity,scale,filter] duration-200 ease-[cubic-bezier(0.2,0,0,1)] motion-reduce:transition-none";
+	"[grid-area:1/1] transition-[opacity,scale,filter] duration-200 ease-[cubic-bezier(0.2,0,0,1)] motion-reduce:transition-none";
 
 export const iconSwapIn = "scale-100 opacity-100 blur-none";
 
 export const iconSwapOut = "scale-[0.25] opacity-0 blur-[4px]";
 
 export const labelSwap =
-  "col-start-1 row-start-1 flex w-max items-center gap-1.5 leading-none transition-[opacity,filter] duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none";
+	"col-start-1 row-start-1 flex w-max items-center gap-1.5 leading-none transition-[opacity,filter] duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none";
 
 export const labelSwapIn = "opacity-100 blur-none";
 
-export const labelSwapOut =
-  "pointer-events-none select-none opacity-0 blur-[2px]";
+export const labelSwapOut = "pointer-events-none select-none opacity-0 blur-[2px]";
 
 export const collapsePanel =
-  "h-(--collapsible-panel-height) overflow-hidden transition-[height] duration-200 ease-[cubic-bezier(0.32,0.72,0,1)] data-[ending-style]:h-0 data-[starting-style]:h-0 motion-reduce:transition-none";
+	"h-(--collapsible-panel-height) overflow-hidden transition-[height] duration-200 ease-[cubic-bezier(0.32,0.72,0,1)] data-[ending-style]:h-0 data-[starting-style]:h-0 motion-reduce:transition-none";
 
 export const live = "text-blue-500 dark:text-blue-400";
 
 export const mono = "font-mono text-[0.6875rem] tracking-tight";
 
-export function ShimmerLabel({
-  active = true,
-  className,
-  ...props
-}: ComponentProps<"span"> & { active?: boolean }) {
-  return (
-    <span
-      className={cn(active && "shimmer motion-reduce:animate-none", className)}
-      {...props}
-    />
-  );
+export function ShimmerLabel({ active = true, className, ...props }: ComponentProps<"span"> & { active?: boolean }) {
+	return <span className={cn(active && "shimmer motion-reduce:animate-none", className)} {...props} />;
 }
 
 /**
@@ -74,51 +67,50 @@ export const codeScroll = "overflow-x-auto";
 export const codeSurface = "w-max min-w-full";
 
 export function SwapLabel({
-  active,
-  children,
-  className,
+	active,
+	children,
+	className,
 }: {
-  active: 0 | 1;
-  children: [React.ReactNode, React.ReactNode];
-  className?: string;
+	active: 0 | 1;
+	children: [React.ReactNode, React.ReactNode];
+	className?: string;
 }) {
-  const firstLayerRef = useRef<HTMLSpanElement>(null);
-  const secondLayerRef = useRef<HTMLSpanElement>(null);
-  const [width, setWidth] = useState<number | null>(null);
+	const firstLayerRef = useRef<HTMLSpanElement>(null);
+	const secondLayerRef = useRef<HTMLSpanElement>(null);
+	const [width, setWidth] = useState<number | null>(null);
 
-  useLayoutEffect(() => {
-    const target = (active === 0 ? firstLayerRef : secondLayerRef).current;
-    if (!target) return undefined;
-    const measure = () =>
-      setWidth(Math.ceil(target.getBoundingClientRect().width));
-    measure();
-    const observer = new ResizeObserver(measure);
-    observer.observe(target);
-    return () => observer.disconnect();
-  }, [active]);
+	useLayoutEffect(() => {
+		const target = (active === 0 ? firstLayerRef : secondLayerRef).current;
+		if (!target) return undefined;
+		const measure = () => setWidth(Math.ceil(target.getBoundingClientRect().width));
+		measure();
+		const observer = new ResizeObserver(measure);
+		observer.observe(target);
+		return () => observer.disconnect();
+	}, [active]);
 
-  return (
-    <span
-      style={width === null ? undefined : { width }}
-      className={cn(
-        "grid overflow-x-clip transition-[width] duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none",
-        className,
-      )}
-    >
-      <span
-        ref={firstLayerRef}
-        aria-hidden={active !== 0}
-        className={cn(labelSwap, active === 0 ? labelSwapIn : labelSwapOut)}
-      >
-        {children[0]}
-      </span>
-      <span
-        ref={secondLayerRef}
-        aria-hidden={active !== 1}
-        className={cn(labelSwap, active === 1 ? labelSwapIn : labelSwapOut)}
-      >
-        {children[1]}
-      </span>
-    </span>
-  );
+	return (
+		<span
+			style={width === null ? undefined : { width }}
+			className={cn(
+				"grid overflow-x-clip transition-[width] duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none",
+				className,
+			)}
+		>
+			<span
+				ref={firstLayerRef}
+				aria-hidden={active !== 0}
+				className={cn(labelSwap, active === 0 ? labelSwapIn : labelSwapOut)}
+			>
+				{children[0]}
+			</span>
+			<span
+				ref={secondLayerRef}
+				aria-hidden={active !== 1}
+				className={cn(labelSwap, active === 1 ? labelSwapIn : labelSwapOut)}
+			>
+				{children[1]}
+			</span>
+		</span>
+	);
 }


### PR DESCRIPTION
## Summary
- Fix right-panel tab clipping by measuring launcher width reliably and switching to dropdown mode on narrow panels
- Restore opaque elevated surfaces for search, mode, and attach popovers
- Wire header **New chat** through shared workspace action with error handling and improved hit target
- Fix workspace Markdown preview hanging on skeleton (timeout, abort, error states)

## Test plan
- [x] `pnpm --filter @prime-agent/web exec vitest run` on affected test files (57 tests)
- [x] `pnpm run check`
- [x] Manual browser QA on rebuilt `fleet-agent` at loopback